### PR TITLE
Add initial design guidelines and brand assets

### DIFF
--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -130,6 +130,9 @@ Lowercase `naked pantree` works really well. Alternative weighted lockup:
 
 ## 6. Color Palette
 
+> Machine-readable source of truth: [`assets/brand/colors.json`](assets/brand/colors.json).
+> If you change a value here, change it there in the same commit.
+
 ### 🌿 Primary Theme (Farm + Modern)
 
 | Name | Hex | Usage |

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -1,0 +1,243 @@
+# Naked Pantree — Design Guidelines
+
+> Know what you have—no pants required.
+
+This document is the source of truth for Naked Pantree's product voice, visual
+identity, and UX personality. It is intentionally opinionated. Restraint is the
+point: the humor gets users in, the utility keeps them.
+
+---
+
+## 1. App Overview
+
+**Naked Pantree** helps people track everything in their pantry, fridge,
+freezer, and beyond—whether it's in the kitchen, barn, or that extra freezer
+outside.
+
+Built for real-life setups (not just perfect kitchens), Naked Pantree lets users:
+
+- 🧊 Track multiple storage locations (indoor + outdoor)
+- 🥫 Organize pantry, fridge, freezer, and dry goods in one place
+- ⏰ Get alerts before food expires
+- 📦 Quickly log and update inventory as they use or restock
+- 🔍 Search across all their food instantly
+- 🧠 Reduce waste and stop buying duplicates
+
+**Promise:** Simple. Fast. Pants optional.
+
+---
+
+## 2. Brand Positioning
+
+**Core Idea:** *"Serious inventory tracking… that doesn't take itself too
+seriously."*
+
+Naked Pantree is a useful system with personality—not a novelty app. Every
+design decision should reinforce that hierarchy: **utility first, humor
+second.**
+
+### Pillars
+
+| Pillar | What it means |
+| --- | --- |
+| Practical | Solves a real daily problem (waste, duplicates, expiry). |
+| Playful | Light personality in copy, never in core flows. |
+| Real-life | Built for messy, multi-location homes—not magazine kitchens. |
+| Trustworthy | Data is accurate, alerts are timely, sync is reliable. |
+
+---
+
+## 3. Tone & Voice
+
+- **Playful, but not childish.**
+- **Confident, slightly witty.**
+- **Never crude or explicit.**
+- **Practical-first, humor-second.**
+
+### Voice in practice
+
+✅ Do:
+
+- "You're out of eggs. Again."
+- "Milk expires tomorrow. You've been warned."
+- "Inventory updated. Productivity achieved (pants optional)."
+
+❌ Don't:
+
+- Crude jokes, innuendo, or anything that earns the name a second time.
+- Long-winded copy. If a sentence isn't doing work, cut it.
+- Humor inside critical flows (errors, data loss warnings, billing).
+
+### Rule of thumb
+
+If a user is frustrated, hungry, or in a hurry—**be useful, not funny.**
+Reserve personality for moments of low stakes (empty states, success toasts,
+onboarding).
+
+---
+
+## 4. Logo
+
+Three approved directions, in priority order:
+
+### Concept A — Minimal Icon (Recommended)
+
+- Simple pantry box / crate icon.
+- Slight "open door" or "peek inside" visual.
+- Clean, modern lines (Apple-style).
+- Hidden humor: nothing explicit—the name carries the joke.
+
+### Concept B — Barn + Crate Hybrid
+
+- Small barn silhouette.
+- Crate or shelves visible inside.
+- Subtle nod to farm / outdoor-storage use case.
+
+### Concept C — The Clever One
+
+- Pantry box with a tiny "missing" lower panel.
+- Implies the "no pants" idea without being obvious.
+- Use only if a stronger personality cue is wanted.
+
+**Never:** add text inside the logo, use a literal pair of pants, or lean
+cartoonish.
+
+---
+
+## 5. Typography
+
+Keep it clean and modern.
+
+| Use | Font |
+| --- | --- |
+| Primary | San Francisco (iOS default) or **Inter** |
+| Alt (more personality) | SF Rounded |
+
+### Wordmark style
+
+Lowercase `naked pantree` works really well. Alternative weighted lockup:
+
+- **Naked** — light weight
+- **Pantree** — bold weight
+
+### Hierarchy
+
+- Headings: semibold/bold, tight tracking.
+- Body: regular, comfortable line-height (~1.4).
+- Numerals (quantities, dates): tabular figures wherever counts or expiry
+  dates are listed.
+
+---
+
+## 6. Color Palette
+
+### 🌿 Primary Theme (Farm + Modern)
+
+| Name | Hex | Usage |
+| --- | --- | --- |
+| Forest Green | `#2F5D50` | Primary brand, headers, key CTAs |
+| Warm Cream | `#F4F1EC` | App background, cards |
+| Soft Brown | `#8B6F47` | Secondary accents, dividers, pantry category |
+
+### 🧊 Accent Colors
+
+| Name | Hex | Usage |
+| --- | --- | --- |
+| Cool Blue | `#4A90E2` | Fridge / freezer UI |
+| Muted Orange | `#E9A857` | Expiring soon warnings |
+| Soft Red | `#D64545` | Expired items, destructive actions |
+
+### Usage rules
+
+- Forest Green is the hero. Don't substitute another green.
+- Warm Cream is the canvas. Pure white is reserved for elevated surfaces (e.g.
+  modals over cream).
+- Status colors (Orange, Red) are reserved for **expiry & destructive
+  states**—never decorative.
+- Cool Blue is reserved for **cold storage** (fridge, freezer). Don't use it
+  for generic links or buttons.
+
+### Accessibility
+
+- Every color pairing in production must meet **WCAG AA** for text contrast.
+- Do not communicate state with color alone—pair with an icon or label
+  (e.g. expiring items get the orange chip *and* a clock icon).
+
+---
+
+## 7. App Icon
+
+The icon must:
+
+- Look clean on the iOS home screen.
+- Not scream "joke app."
+- Still feel unique.
+
+### Spec
+
+- Rounded square.
+- Deep green (`#2F5D50`) background.
+- Minimal white line icon of a crate / pantry box.
+- Slight "open" or "peek" visual.
+- **No text. No jokes.** Let the name do the work.
+
+---
+
+## 8. Taglines
+
+Use sparingly. One per surface, max.
+
+- "Pants optional inventory."
+- "Know what you have."
+- "From barn to kitchen."
+- "Track everything. Waste less."
+- "Check your pantry. Wherever you are."
+
+---
+
+## 9. UX Personality Touches
+
+This is where the brand earns its name. Personality lives in **low-stakes
+moments**, not core flows.
+
+| Moment | Copy |
+| --- | --- |
+| First launch | "Welcome to Naked Pantree. We won't ask what you're wearing." |
+| Empty pantry | "Your pantry is empty. This feels like a bigger problem." |
+| Expiry warning | "This expires soon. Time to act." |
+| Sync success | "All stocked up." |
+
+### Where personality is **off-limits**
+
+- Errors that block the user (auth failure, sync failure, data loss).
+- Permission requests (camera, notifications).
+- Billing, subscription, and account deletion flows.
+- Anything legal, privacy-related, or safety-related.
+
+In those moments: be plain, calm, and direct.
+
+---
+
+## 10. Writing Checklist
+
+Before shipping any user-facing string, ask:
+
+1. Is it **useful** before it's clever?
+2. Is it **short**? (Cut a word. Cut another.)
+3. Would a frustrated user roll their eyes at it?
+4. Does it use color/icon **plus** text for state?
+5. Does it reinforce the brand without explaining the joke?
+
+If the answer to any of these is "no," rewrite or remove.
+
+---
+
+## 11. Final Thought
+
+Naked Pantree should be:
+
+- **Useful** — solves a real, daily problem.
+- **Sticky** — earns daily check-ins.
+- **Memorable** — the name and tone stay with people.
+
+The key is **restraint**. The humor gets them in. The utility keeps them.

--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -78,29 +78,28 @@ onboarding).
 
 ## 4. Logo
 
-Three approved directions, in priority order:
+The Naked Pantree mark has two parts:
 
-### Concept A — Minimal Icon (Recommended)
+1. **Wordmark** — the lowercase `naked pantree` lockup. See §5 (Typography).
+2. **Icon mark** — an illustrated open pantry cabinet revealing stocked
+   shelves. The full app-icon spec lives in §7.
 
-- Simple pantry box / crate icon.
-- Slight "open door" or "peek inside" visual.
-- Clean, modern lines (Apple-style).
-- Hidden humor: nothing explicit—the name carries the joke.
+### Direction
 
-### Concept B — Barn + Crate Hybrid
+- **Pantry, not crate.** A two-shelf cream cabinet with the door swung
+  open—warm, lived-in, unmistakably a pantry.
+- **Peek inside.** The open door is the entire idea: the contents are the
+  payoff, the name is the punchline.
+- **Illustrated, not line-art.** Soft fills, gentle shading, brand-palette
+  contents on the shelves.
+- **Hidden humor.** Nothing explicit on the mark—the name carries the joke.
 
-- Small barn silhouette.
-- Crate or shelves visible inside.
-- Subtle nod to farm / outdoor-storage use case.
+### Never
 
-### Concept C — The Clever One
-
-- Pantry box with a tiny "missing" lower panel.
-- Implies the "no pants" idea without being obvious.
-- Use only if a stronger personality cue is wanted.
-
-**Never:** add text inside the logo, use a literal pair of pants, or lean
-cartoonish.
+- Add text inside the mark.
+- Use a literal pair of pants.
+- Lean cartoonish, sticker-y, or emoji-styled.
+- Close the cabinet door (we always show what's inside).
 
 ---
 
@@ -171,15 +170,61 @@ The icon must:
 
 - Look clean on the iOS home screen.
 - Not scream "joke app."
-- Still feel unique.
+- Still feel unique at every size.
+- Read as a **pantry being opened**—before any other detail.
 
-### Spec
+### Composition
 
-- Rounded square.
-- Deep green (`#2F5D50`) background.
-- Minimal white line icon of a crate / pantry box.
-- Slight "open" or "peek" visual.
+- **Background:** solid Forest Green `#2F5D50`, full bleed.
+- **Cabinet:** Warm Cream `#F4F1EC`, two shelves, centered.
+- **Door:** swung open to the right, small green knob, casts no hard shadow.
+- **Contents (brand-palette only):**
+  - Top shelf — a glass jar of grains, a jar of red sauce, a milk bottle.
+  - Bottom shelf — a tomato can, a clamp-lid jar of beans, an olive-oil bottle
+    with an herb label.
+- **Style:** illustrated, soft fills, subtle shading. No outlines-only line
+  art. No photoreal textures.
 - **No text. No jokes.** Let the name do the work.
+
+### Construction
+
+- Designed on a full square **1024×1024** canvas.
+- iOS applies the rounded-corner mask automatically—**do not pre-round** the
+  artwork.
+- Keep all critical content inside a centered safe area (~80% of the canvas);
+  corners may be clipped on some platforms.
+- Use simple shapes and strong contrast so the silhouette of the open cabinet
+  reads first, contents second.
+
+### Required sizes
+
+Export from the same 1024×1024 master:
+
+| Size | Use |
+| --- | --- |
+| 1024×1024 | App Store, marketing |
+| 512×512 | macOS / web |
+| 180×180 | iPhone @3x |
+| 120×120 | iPhone @2x |
+| 87×87 | iPhone Settings @3x |
+| 60×60 | iPhone Spotlight / Notifications |
+
+### Small-size rules
+
+At 87×87 and 60×60 the individual jars will compress. That's expected—the
+cabinet shape, open door, and palette must still read. Verify legibility by:
+
+1. Exporting all sizes and viewing on a real device home screen.
+2. Checking Settings, Spotlight, and Notifications surfaces.
+3. Squinting at the 60×60 export—if the open-door silhouette is unclear,
+   simplify the contents (fewer items, larger shapes) before shipping.
+
+### Light / dark mode
+
+The deep green background works in both modes. Verify the cream cabinet has
+sufficient contrast against the system wallpaper in dark mode and against
+light wallpapers; do not ship a separate dark-mode variant unless a real
+contrast problem is found.
 
 ---
 

--- a/assets/brand/README.md
+++ b/assets/brand/README.md
@@ -1,0 +1,32 @@
+# Brand Assets
+
+Source-of-truth assets for the Naked Pantree brand. See
+[`DESIGN_GUIDELINES.md`](../../DESIGN_GUIDELINES.md) for the full spec.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `colors.json` | Machine-readable brand palette. Import into design tools, codegen, or theme files. |
+
+## Pending (designer to add)
+
+These are placeholders — drop the files in when ready, then update this table:
+
+| File | Purpose |
+| --- | --- |
+| `brand-sheet.png` | Single-page brand reference (icon at all sizes + palette + usage notes). |
+| `app-icon-1024.png` | Master 1024×1024 app icon export. |
+| `app-icon-512.png` | macOS / web export. |
+| `app-icon-180.png` | iPhone @3x. |
+| `app-icon-120.png` | iPhone @2x. |
+| `app-icon-87.png` | iPhone Settings @3x. |
+| `app-icon-60.png` | iPhone Spotlight / Notifications. |
+| `wordmark.svg` | Lowercase `naked pantree` lockup. |
+
+## Rules
+
+- All exports come from a single 1024×1024 master. Do **not** pre-round
+  corners — iOS applies the rounded mask automatically.
+- If you change a color in `colors.json`, update §6 of `DESIGN_GUIDELINES.md`
+  in the same commit. They must stay in sync.

--- a/assets/brand/colors.json
+++ b/assets/brand/colors.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format/",
+  "name": "Naked Pantree Brand Palette",
+  "version": "1.0.0",
+  "description": "Source of truth for Naked Pantree brand colors. See DESIGN_GUIDELINES.md §6 for usage rules.",
+  "primary": {
+    "forestGreen": {
+      "hex": "#2F5D50",
+      "rgb": [47, 93, 80],
+      "role": "Primary brand. App icon background, headers, key CTAs.",
+      "notes": "Hero color. Do not substitute another green."
+    },
+    "warmCream": {
+      "hex": "#F4F1EC",
+      "rgb": [244, 241, 236],
+      "role": "App background, cards, the pantry cabinet in the icon.",
+      "notes": "Pure white is reserved for elevated surfaces (modals over cream)."
+    },
+    "softBrown": {
+      "hex": "#8B6F47",
+      "rgb": [139, 111, 71],
+      "role": "Secondary accents, dividers, pantry/dry-goods category."
+    }
+  },
+  "accent": {
+    "coolBlue": {
+      "hex": "#4A90E2",
+      "rgb": [74, 144, 226],
+      "role": "Fridge / freezer UI only.",
+      "notes": "Reserved for cold storage. Not a generic link or button color."
+    },
+    "mutedOrange": {
+      "hex": "#E9A857",
+      "rgb": [233, 168, 87],
+      "role": "Expiring-soon warnings.",
+      "notes": "Status color. Never decorative."
+    },
+    "softRed": {
+      "hex": "#D64545",
+      "rgb": [214, 69, 69],
+      "role": "Expired items, destructive actions.",
+      "notes": "Status color. Never decorative."
+    }
+  },
+  "rules": {
+    "accessibility": "All production text/background pairings must meet WCAG AA.",
+    "stateCommunication": "Never communicate state with color alone. Always pair with an icon or label.",
+    "iconPalette": [
+      "#2F5D50",
+      "#F4F1EC",
+      "#E9A857",
+      "#D64545",
+      "#8B6F47"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Establish a starting point for the Naked Pantree brand and design system.

- **`DESIGN_GUIDELINES.md`** — 11-section brand guide: positioning, voice, logo, typography, color palette (with usage rules + WCAG AA), app icon, taglines, UX personality (with explicit "off-limits" moments for errors/billing/legal), writing checklist.
- **App icon direction locked in** — illustrated open pantry cabinet with brand-palette contents (replaces the earlier minimal-line concept). Includes composition spec, 1024×1024 master construction notes, required export size table (1024 / 512 / 180 / 120 / 87 / 60), small-size legibility checks, and light/dark guidance.
- **`assets/brand/colors.json`** — machine-readable design tokens (hex, rgb, role, usage) so codegen and design tools can consume the palette directly.
- **`assets/brand/README.md`** — folder index + TODO table for designer-produced exports (brand sheet PNG, app-icon size set, wordmark SVG).

## Pending (designer to add)

- `assets/brand/brand-sheet.png`
- `assets/brand/app-icon-{1024,512,180,120,87,60}.png`
- `assets/brand/wordmark.svg`

## Test plan

- [ ] Skim `DESIGN_GUIDELINES.md` end-to-end for tone and accuracy.
- [ ] Confirm color values in `assets/brand/colors.json` match §6.
- [ ] Confirm app icon spec in §7 matches the chosen illustrated direction.
- [ ] Decide whether the placeholder filenames in `assets/brand/README.md` are the ones the designer should use.


---
_Generated by [Claude Code](https://claude.ai/code/session_015XphFJzojDkZAbCt4ZVHQT)_