### PR TITLE
Flesh out DEVELOPMENT.md and AGENTS.md; require worktrees for new tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ Cursor, Copilot Workspace, etc.) working on Naked Pantree. Humans, see
 `DEVELOPMENT.md`. Architecture, see `ARCHITECTURE.md`. Brand voice and
 copy rules, see `DESIGN_GUIDELINES.md`.
 
-> **Status:** stub. Expanded as conventions get exercised on real PRs.
-> Sections marked **TBD** will fill in alongside the first code that needs
-> them.
+> **Status:** the rules and conventions that don't depend on real code are
+> filled in. Sections that wait for the project to exist carry explicit
+> `TODO` markers.
 
 ---
 
@@ -20,7 +20,8 @@ copy rules, see `DESIGN_GUIDELINES.md`.
    that contradict it without flagging them as a deviation.
 2. `DESIGN_GUIDELINES.md` — voice, copy, color, logo. Every user-facing
    string passes the §10 checklist.
-3. This file — local conventions and traps.
+3. `DEVELOPMENT.md` — local setup, branch policy, pre-merge checklist.
+4. This file — local conventions and traps.
 
 ---
 
@@ -46,10 +47,59 @@ and ask the user first.
   re-read §3 and §9 of `DESIGN_GUIDELINES.md`.
 - **Don't add a backend.** v1.0 is iCloud-only. If you find yourself
   reaching for a server, you're solving the wrong problem.
+- **Use a git worktree for every task** — see §3 below. Do not switch
+  branches in the main checkout while another task is in flight.
 
 ---
 
-## 3. Conventions
+## 3. Use a git worktree for every task
+
+This repo expects parallel work. Multiple agents (or one agent across
+multiple sessions) regularly have independent branches in flight.
+Switching branches in the main checkout corrupts in-progress work and
+makes review history confusing. Worktrees fix this.
+
+### The rule
+
+- **Every new task starts with `git worktree add`.** Never `git checkout`
+  another branch in the main checkout to do new work.
+- **One worktree per branch.** Don't share worktrees across tasks.
+- **Clean up when done.** After the PR merges, remove the worktree.
+
+### How
+
+```bash
+# From the main checkout. Branch name follows DEVELOPMENT.md §4 conventions.
+git worktree add ../NakedPantree-<short-name> -b claude/<short-name>
+
+# Work inside it.
+cd ../NakedPantree-<short-name>
+# ... make commits, push, open PR ...
+
+# After the PR merges:
+cd /home/user/NakedPantree   # or wherever the main checkout lives
+git worktree remove ../NakedPantree-<short-name>
+git branch -d claude/<short-name>
+```
+
+### When using the Claude Code `Agent` tool
+
+The `Agent` tool accepts an `isolation: "worktree"` parameter that
+creates and cleans up a worktree automatically. Prefer that to manual
+`git worktree add` when delegating a self-contained task to a sub-agent.
+The agent's branch and final path come back in the result if any commits
+were made; the worktree is auto-removed if no changes were made.
+
+### When *not* to use a worktree
+
+- One-line edits the user is watching live (e.g. fixing a typo they just
+  pointed out). Switching to a worktree adds friction with no benefit.
+- Pure read-only investigation. Read what you need from the main
+  checkout — no branch involved.
+
+---
+
+## 4. Conventions
 
 ### File layout
 
@@ -59,8 +109,12 @@ under `Packages/Core/Sources/NakedPantreeDomain/Repositories/`.
 
 ### Naming
 
-**TBD** — concrete naming conventions (view suffix, view-model suffix,
-repository naming) will be locked in alongside the first feature PR.
+> **TODO (first feature PR):** lock in the suffix conventions
+> (`*View`, `*ViewModel`, `*Repository`, `*Service`) once the first real
+> feature lands and we can point at concrete examples.
+
+Until then: prefer Apple's own SwiftUI sample-app conventions and match
+whatever neighbors in the file use.
 
 ### Tests
 
@@ -70,15 +124,16 @@ repository naming) will be locked in alongside the first feature PR.
   tests.
 - UI tests are smoke-only; they exercise navigation, not business logic.
 
-### Commits
+### Commits and PRs
 
-- Commit messages explain *why*, not *what*. Imperative mood. One change
-  per commit when practical.
-- Never push to `main` directly. Open a PR; wait for Xcode Cloud green.
+Follow `DEVELOPMENT.md` §4. The pre-merge checklist there applies to
+agent-authored PRs too. In particular: update `ARCHITECTURE.md` in the
+same PR if the change touches the schema, an enum, or a repository
+protocol.
 
 ---
 
-## 4. Things that look fine but aren't
+## 5. Things that look fine but aren't
 
 A short list of traps that have already cost time:
 
@@ -90,14 +145,18 @@ A short list of traps that have already cost time:
   will reject it.
 - **Using SwiftData.** It still doesn't expose the CloudKit shared
   database on iOS 26. Sharing is the product. Don't.
-- **Reaching for `TabView` at the root.** Locations + Smart Lists *are*
+- **Reaching for `TabView` at the root.** Smart Lists + Locations *are*
   the navigation; see `ARCHITECTURE.md` §7.
 - **Putting humor in error messages, permission requests, billing, or
   legal text.** See `DESIGN_GUIDELINES.md` §9 — those are off-limits.
+- **`git checkout`-ing a different branch in the main checkout.** Use a
+  worktree. See §3.
+- **Skipping `--no-verify` discussions.** Don't use it without explicit
+  user permission, even if a hook is annoying. Fix the hook or the code.
 
 ---
 
-## 5. When you're stuck
+## 6. When you're stuck
 
 - If a change requires deviating from `ARCHITECTURE.md`, propose the
   deviation in the PR description and wait for sign-off rather than
@@ -107,3 +166,5 @@ A short list of traps that have already cost time:
   writing code.
 - If `DESIGN_GUIDELINES.md` and a UX choice seem to conflict, the
   guidelines win.
+- If `DEVELOPMENT.md` has a `TODO` blocking your task, fill it in as
+  part of your PR — don't work around it silently.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,36 +4,48 @@
 
 This doc is for humans setting the project up locally. For the architectural
 shape of the code, see `ARCHITECTURE.md`. For guidance aimed at AI coding
-agents, see `AGENTS.md`.
+agents, see `AGENTS.md`. For voice and copy rules, see
+`DESIGN_GUIDELINES.md`.
 
-> **Status:** stub. Filled out as the actual project structure lands. Sections
-> marked **TBD** will be completed before the first code PR.
+> **Status:** the things that are project-independent are filled in. Sections
+> that depend on the not-yet-existing Xcode project carry explicit `TODO`
+> markers with the PR or event that should resolve them.
 
 ---
 
 ## 1. Prerequisites
 
-- macOS (latest), Xcode 26 or newer.
-- An Apple Developer account enrolled in CloudKit (free tier is fine for
-  local dev; paid is required for TestFlight).
-- Two test devices (or one device + the simulator) for sharing flows.
-- Optional: `swift-format` and `swiftlint` installed via Homebrew for the
-  pre-commit hook.
+| Requirement | Why |
+| --- | --- |
+| **macOS 15 or newer** on **Apple Silicon** | "Designed for iPad on Mac" requires Apple Silicon (`ARCHITECTURE.md` §10). |
+| **Xcode 26 or newer** | iOS 26 SDK, Swift Testing default, current SwiftUI surface. |
+| **Swift 6 toolchain** (bundled with Xcode 26) | Strict concurrency, `Sendable` repository protocols. |
+| **Apple Developer account** with CloudKit enabled | Free tier is fine for local dev; paid is required to push a TestFlight build. |
+| **Two devices** (or one device + the simulator) | Sharing flows can't be exercised on a single CloudKit account from one process. See `ARCHITECTURE.md` §11. |
+| `swift-format` and `swiftlint` (Homebrew) | Pre-commit hook + CI lint. Configs live at the repo root once added (see TODO below). |
+
+Optional but useful: a second iCloud account for the "different accounts,
+share accepted" manual check.
 
 ---
 
 ## 2. First-time setup
 
-**TBD** — to be filled in once the Xcode project is created. Will cover:
-
-1. Clone the repo.
-2. Open `NakedPantree.xcworkspace` (not the `.xcodeproj` — the workspace
-   includes the local SwiftPM `Packages/Core/`).
-3. Configure your Team in Signing & Capabilities for both the app and the
-   tests targets.
-4. Set the CloudKit container identifier to your developer-account
-   container.
-5. Run the `Bootstrap` scheme once to generate any required local files.
+> **TODO (scaffolding PR):** rewrite this section with concrete steps once
+> the Xcode project exists. The shape will be:
+>
+> 1. Clone the repo.
+> 2. Open `NakedPantree.xcworkspace` (the workspace pulls in the local
+>    `Packages/Core/` SwiftPM package — opening the bare `.xcodeproj`
+>    misses it).
+> 3. In Signing & Capabilities, set your Team for the app target, the
+>    `NakedPantreeTests` target, and the `NakedPantreeUITests` target.
+> 4. Set the CloudKit container identifier to `iCloud.<your-id>.NakedPantree`
+>    (the default container created with the app target).
+> 5. Run the **Bootstrap** scheme once to provision any required local
+>    files (CloudKit schema deploy, default `Household` and `Location`).
+> 6. Build & run on a real device — the Simulator can't reach the iCloud
+>    accounts you'll want to test against.
 
 ---
 
@@ -41,39 +53,116 @@ agents, see `AGENTS.md`.
 
 ### Build
 
-**TBD** — Xcode Build / Cmd+B. CLI invocation via `xcodebuild` to be
-documented.
+> **TODO (scaffolding PR):** lock in the exact `xcodebuild` invocation and
+> scheme names. Cmd+B in Xcode works without any of that.
 
 ### Test
 
-- **Unit tests:** Cmd+U in Xcode, or `xcodebuild test ...` (exact incantation
-  TBD). Includes `NakedPantreeDomain` and `NakedPantreePersistence` package
-  tests plus app-target Swift Testing suites.
-- **UI tests:** the `NakedPantreeUITests` scheme. These are smoke flows
-  only — see §11 of `ARCHITECTURE.md` for what's automated vs manual.
+The intent (per `ARCHITECTURE.md` §11):
 
-### Lint / format
+- **Package tests** (`NakedPantreeDomain`, `NakedPantreePersistence`) — fast,
+  no I/O, run on every save.
+- **App-target Swift Testing suites** — view models, scheduler, photo
+  pipeline against in-memory repository mocks.
+- **XCUITest smoke flows** — sidebar nav, item create, share sheet open.
 
-**TBD** — `swift-format` config and `swiftlint` rules to be added.
+Cmd+U in Xcode runs everything.
+
+> **TODO (scaffolding PR):** document the headless invocations:
+> `xcodebuild test -scheme <name> -destination 'platform=iOS Simulator,...'`
+> for each suite, and the equivalent for the SwiftPM package
+> (`swift test --package-path Packages/Core`).
+
+### Lint and format
+
+We will commit configs for both tools at the repo root:
+
+- `.swift-format` — code-formatting rules.
+- `.swiftlint.yml` — lint rules.
+
+A pre-commit hook should run both on staged Swift files. CI runs them on
+every PR.
+
+> **TODO (lint PR):** add the actual `.swift-format` and `.swiftlint.yml`
+> files, the pre-commit hook script under `scripts/`, and the GitHub
+> Actions workflow that runs them.
 
 ---
 
-## 4. Manual QA checklist
+## 4. Branch and commit policy
 
-The full per-release checklist lives in §11 of `ARCHITECTURE.md`. The short
+This is project-independent and locked in now.
+
+- **Never push to `main` directly.** All changes land via PR.
+- **Branch naming:** `<author-or-agent>/<short-kebab-summary>`. Examples:
+  `ellisandy/share-sheet-bridge`, `claude/notification-scheduler`.
+- **Commit messages:** imperative mood, explain *why* not *what*. One
+  logical change per commit when practical. Match the existing style in
+  `git log`.
+- **Signing:** commits do not need to be GPG-signed for v1.0; revisit if
+  the team grows.
+- **PR size:** prefer small, reviewable PRs. If a PR touches more than
+  ~400 lines of non-trivial code, split it.
+
+### Pre-merge checklist
+
+Before requesting review:
+
+- [ ] `ARCHITECTURE.md` updated if the change adds/removes an entity, an
+      enum, a repository protocol, or a CloudKit schema field.
+- [ ] `DESIGN_GUIDELINES.md` voice rules applied to every user-facing
+      string the PR adds or edits.
+- [ ] Unit tests added or updated for any new logic in
+      `NakedPantreeDomain`, `NakedPantreePersistence`, or app view models.
+- [ ] `swift-format` and `swiftlint` clean.
+- [ ] Manual checklist (`ARCHITECTURE.md` §11) re-run if the PR touches
+      sync, sharing, notifications, or photos.
+- [ ] Screenshot (or short video) attached for any UI-visible change.
+
+---
+
+## 5. Manual QA
+
+The full per-release checklist lives in `ARCHITECTURE.md` §11. The short
 version: two devices, sharing accepted, airplane-mode write, photo, Mac
-build.
+build, notification tap.
+
+If anything on that list becomes flaky, the answer is to push it down into
+the automated layer by improving the protocol abstraction, not to add
+another manual step.
 
 ---
 
-## 5. Release
+## 6. Release
 
-**TBD** — Xcode Cloud workflow names, TestFlight group, App Store Connect
-setup. Will be filled in once the workflows exist.
+> **TODO (Xcode Cloud setup PR):** document the Xcode Cloud workflow names
+> (PR check, TestFlight beta), the TestFlight internal group, and the App
+> Store Connect bundle ID once they exist.
+
+The shape, per `ARCHITECTURE.md` §10:
+
+- Every PR: Xcode Cloud builds and runs the test suites.
+- Merges to `main`: Xcode Cloud builds, tests, archives, uploads to
+  TestFlight (internal group).
+- App Store releases are manual until we have a reason to automate.
+
+CloudKit schema changes require a deliberate "Deploy to Production" step
+in the CloudKit Console **after** a TestFlight build has exercised every
+new field against the development schema. Skipping that step is how you
+ship a build that can't sync.
 
 ---
 
-## 6. Troubleshooting
+## 7. Troubleshooting
 
-**TBD** — common CloudKit "no account" / "schema not deployed" / "share
-not accepted" pitfalls and how to recover. Filled in as we hit them.
+> **TODO (filled in opportunistically):** add entries here as we hit and
+> resolve issues. Expected starting set:
+>
+> - "iCloud account required" at launch despite being signed in.
+> - CloudKit "schema not deployed" after adding a field.
+> - Share invitation never arrives (Messages vs. Mail vs. AirDrop).
+> - `NSPersistentStoreRemoteChange` not firing on the second device.
+> - Mac build (Designed for iPad) crashes at launch.
+
+Each entry should follow the format: **Symptom → Root cause → Fix.** No
+folklore.


### PR DESCRIPTION
## Summary

Fleshes out the two stub docs that landed with the architecture PR. Everything project-independent is locked in; everything that depends on the not-yet-existing Xcode project is marked with an explicit `TODO` and the PR/event that should fill it in.

### DEVELOPMENT.md
- Concrete prerequisites table (macOS 15 on Apple Silicon, Xcode 26, Swift 6, CloudKit account, two devices).
- New §4 branch + commit policy with a pre-merge checklist that ties back to `ARCHITECTURE.md` and `DESIGN_GUIDELINES.md`.
- Release shape: Xcode Cloud + TestFlight + the CloudKit schema "Deploy to Production" gate (skipping that gate is how you ship a build that can't sync).
- Explicit `TODO` markers for: first-time setup, headless `xcodebuild` invocations, lint configs, Xcode Cloud workflow names, troubleshooting entries — each tagged with the PR that should resolve them.

### AGENTS.md
- New hard rule + dedicated §3 requiring `git worktree add` for every new task, with the exact commands. Calls out the Claude Code `Agent` tool's `isolation: "worktree"` option for delegated sub-tasks.
- Naming conventions deferred to the first feature PR (with explicit `TODO`) since they need real code to point at.
- "Things that look fine but aren't" gained two entries: switching branches in the main checkout (use a worktree) and `--no-verify` (don't, without explicit permission).

## Test plan

- [ ] Read `DEVELOPMENT.md` end-to-end — confirm the prerequisites match your dev box.
- [ ] Read `AGENTS.md` §3 — confirm the worktree workflow is what you want enforced.
- [ ] Confirm every `TODO` is tagged with the right resolving event (scaffolding PR, lint PR, Xcode Cloud PR, first feature PR).
- [ ] Flag anything that should be a hard rule but currently isn't.

https://claude.ai/code/session_015XphFJzojDkZAbCt4ZVHQT

---
_Generated by [Claude Code](https://claude.ai/code/session_015XphFJzojDkZAbCt4ZVHQT)_