### PR TITLE
Update AGENTS.md worktree guidance; populate README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,32 +47,27 @@ and ask the user first.
   re-read §3 and §9 of `DESIGN_GUIDELINES.md`.
 - **Don't add a backend.** v1.0 is iCloud-only. If you find yourself
   reaching for a server, you're solving the wrong problem.
-- **Use a git worktree for every task** — see §3 below. Do not switch
-  branches in the main checkout while another task is in flight.
+- **Don't have two tasks in flight in the same checkout.** Use a worktree
+  if the environment supports it; otherwise commit / push / open a PR
+  before switching branches. See §3.
 
 ---
 
-## 3. Use a git worktree for every task
+## 3. Branch isolation: worktrees when supported, serial branches otherwise
 
-This repo expects parallel work. Multiple agents (or one agent across
-multiple sessions) regularly have independent branches in flight.
-Switching branches in the main checkout corrupts in-progress work and
-makes review history confusing. Worktrees fix this.
+This repo expects multiple branches in flight at once. Switching branches
+in a single checkout while another task is mid-edit corrupts in-progress
+work and confuses review history. There are two ways to avoid that — pick
+the one your environment supports.
 
-### The rule
+### Preferred: git worktrees
 
-- **Every new task starts with `git worktree add`.** Never `git checkout`
-  another branch in the main checkout to do new work.
-- **One worktree per branch.** Don't share worktrees across tasks.
-- **Clean up when done.** After the PR merges, remove the worktree.
-
-### How
+When the environment supports it, each new task gets its own worktree:
 
 ```bash
 # From the main checkout. Branch name follows DEVELOPMENT.md §4 conventions.
 git worktree add ../NakedPantree-<short-name> -b claude/<short-name>
 
-# Work inside it.
 cd ../NakedPantree-<short-name>
 # ... make commits, push, open PR ...
 
@@ -82,20 +77,37 @@ git worktree remove ../NakedPantree-<short-name>
 git branch -d claude/<short-name>
 ```
 
+### Known limitation: hosted commit-signing services
+
+Some Claude Code hosted environments use a managed commit-signing service
+that rejects signing requests issued from a worktree (HTTP 400
+`"missing source"`) but signs cleanly from the main checkout. Confirmed
+with an empty-commit test from each location. If you hit it:
+
+- **Don't reach for `--no-verify` or `-c commit.gpgsign=false`.** That
+  produces unsigned commits and a downstream policy headache.
+- **Fall back to serial branches in the main checkout.** Only one task
+  in flight at a time. Commit, push, and open the PR before starting the
+  next one.
+- **Don't keep uncommitted changes when you switch branches.** Stash or
+  commit first.
+
+A quick way to check the current environment: from a worktree, run
+`git commit --allow-empty -m "signing test"`. If it fails, you're in a
+fall-back environment.
+
 ### When using the Claude Code `Agent` tool
 
-The `Agent` tool accepts an `isolation: "worktree"` parameter that
-creates and cleans up a worktree automatically. Prefer that to manual
-`git worktree add` when delegating a self-contained task to a sub-agent.
-The agent's branch and final path come back in the result if any commits
-were made; the worktree is auto-removed if no changes were made.
+`Agent` accepts an `isolation: "worktree"` parameter that creates and
+cleans up a worktree automatically. The same signing limitation applies —
+if the sub-agent's commits fail to sign in its worktree, prefer running
+the work directly in the main checkout instead.
 
-### When *not* to use a worktree
+### When *not* to isolate at all
 
 - One-line edits the user is watching live (e.g. fixing a typo they just
-  pointed out). Switching to a worktree adds friction with no benefit.
-- Pure read-only investigation. Read what you need from the main
-  checkout — no branch involved.
+  pointed out). Branch switching adds friction with no benefit.
+- Pure read-only investigation. Read what you need; no branch involved.
 
 ---
 
@@ -149,10 +161,12 @@ A short list of traps that have already cost time:
   the navigation; see `ARCHITECTURE.md` §7.
 - **Putting humor in error messages, permission requests, billing, or
   legal text.** See `DESIGN_GUIDELINES.md` §9 — those are off-limits.
-- **`git checkout`-ing a different branch in the main checkout.** Use a
-  worktree. See §3.
-- **Skipping `--no-verify` discussions.** Don't use it without explicit
-  user permission, even if a hook is annoying. Fix the hook or the code.
+- **Switching branches in the main checkout while another task is mid-edit.**
+  See §3 for the worktree workflow and the signing-service caveat.
+- **Reaching for `--no-verify` to bypass a failing hook.** Don't, without
+  explicit user permission. Fix the hook or the code.
+- **Assuming worktrees just work.** They don't, in every environment —
+  re-read §3.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# NakedPantree
-Serious inventory tracking… that doesn’t take itself too seriously.
+# Naked Pantree
+
+> Know what you have—no pants required.
+
+Naked Pantree is an iOS app for tracking everything in your pantry, fridge,
+freezer, and beyond — across the kitchen, garage, barn, and that extra
+freezer outside. Multi-location, shared between household members, and it
+reminds you before things expire.
+
+**Status:** in planning. No app code yet — design, architecture, and the
+phased roadmap are committed; implementation begins with Phase 0 (Xcode
+project scaffolding) per [`ROADMAP.md`](ROADMAP.md).
+
+## What's here
+
+| Document | What's in it |
+| --- | --- |
+| [`DESIGN_GUIDELINES.md`](DESIGN_GUIDELINES.md) | Voice, color palette, typography, app icon, copy rules. |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | Stack choices, domain model, sync + sharing topology, testing strategy. |
+| [`ROADMAP.md`](ROADMAP.md) | Eight phases between empty repo and TestFlight, each with exit criteria. |
+| [`DEVELOPMENT.md`](DEVELOPMENT.md) | Local setup, branch policy, pre-merge checklist. |
+| [`AGENTS.md`](AGENTS.md) | Operating manual for AI coding agents working on this repo. |
+| [`assets/brand/`](assets/brand) | Brand color tokens (machine-readable). |
+
+## Stack
+
+- iOS 26+; iPad-compatible; runs on Apple Silicon Macs via "Designed for
+  iPad on Mac."
+- SwiftUI with `NavigationSplitView` from day one.
+- Core Data via `NSPersistentCloudKitContainer` (private + shared stores)
+  for sync + sharing.
+- Local SwiftPM `Packages/Core/` for domain + persistence reuse (paves
+  the way for a future personal CLI / AI helper).
+- Swift Testing.
+- Xcode Cloud → TestFlight.
+
+See `ARCHITECTURE.md` for the why behind each.
+
+## Project conventions
+
+- Voice and copy rules in `DESIGN_GUIDELINES.md` apply to every
+  user-facing string the project ships.
+- Every PR follows the pre-merge checklist in `DEVELOPMENT.md` §4.
+- AI-authored work follows `AGENTS.md` — including its branch-isolation
+  workflow and the known signing-service caveat in §3.
+
+## Contributing
+
+This is a personal project; outside contributions aren't being solicited
+for v1.0. The docs are public so future-me, collaborators, and AI agents
+share the same source of truth.


### PR DESCRIPTION
## Summary

Two small doc changes informed by what we learned during PR #7.

### `AGENTS.md` — relax the worktree rule, document the signing limitation
- Demoted "use a worktree for every task" hard rule to "don't have two tasks in flight in the same checkout" — worktrees don't work in every environment.
- Rewrote §3 around branch isolation generally, with worktrees as the preferred path and serial branches in the main checkout as the supported fallback.
- Documented the hosted commit-signing service constraint: HTTP 400 `"missing source"` from a worktree, signs cleanly from the main checkout (confirmed with an empty-commit test from each location during the ROADMAP work). `--no-verify` and disabling signing are explicitly called out as wrong-answers.
- Added a one-line detection step (empty signing-test commit) so follow-on agents can identify the constraint without re-deriving it.

### `README.md` — actual entry point
- Was a one-line tagline. Now: project status, doc map table linking to all five docs (`DESIGN_GUIDELINES`, `ARCHITECTURE`, `ROADMAP`, `DEVELOPMENT`, `AGENTS`) and the brand assets, stack summary, conventions pointer.
- Voice rules from `DESIGN_GUIDELINES.md` applied.

## Sequencing note

This PR's `README.md` references [`ROADMAP.md`](ROADMAP.md), which lands in PR #7. **Merge #7 first** to avoid a broken link in `README.md`. If you merge this one first, the link will 404 until #7 lands.

## Test plan

- [x] Read `AGENTS.md` §2–§3 — confirm the relaxed rule is what you want enforced.
- [x] Read `README.md` — confirm the doc map is complete and the framing matches the project's voice.
- [x] Confirm the merge ordering with PR #7.

https://claude.ai/code/session_015XphFJzojDkZAbCt4ZVHQT

---
_Generated by [Claude Code](https://claude.ai/code/session_015XphFJzojDkZAbCt4ZVHQT)_