### PR TITLE
Phase 1.1: domain types and repository protocols

### DIFF
--- a/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// The share root. One household per `CKShare`. See `ARCHITECTURE.md` §4.
+///
+/// Children are referenced by id from the child side (`Location.householdID`)
+/// rather than as a `[Location]` inside this struct — value types model the
+/// node, the repository surfaces the relationship.
+public struct Household: Sendable, Hashable, Identifiable {
+    public let id: UUID
+    public var name: String
+    public let createdAt: Date
+
+    public init(id: UUID = UUID(), name: String = "My Pantry", createdAt: Date = Date()) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+    }
+}
+
+/// A physical storage location within a household — pantry, fridge, freezer,
+/// dry goods, or other.
+public struct Location: Sendable, Hashable, Identifiable {
+    public let id: UUID
+    public let householdID: Household.ID
+    public var name: String
+    public var kind: LocationKind
+    public var sortOrder: Int16
+    public let createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        householdID: Household.ID,
+        name: String,
+        kind: LocationKind = .pantry,
+        sortOrder: Int16 = 0,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.householdID = householdID
+        self.name = name
+        self.kind = kind
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+    }
+}
+
+/// An inventory item. `updatedAt` is stamped by the repository on every edit
+/// — callers should not set it directly. See `ItemRepository.update(_:)`.
+public struct Item: Sendable, Hashable, Identifiable {
+    public let id: UUID
+    public let locationID: Location.ID
+    public var name: String
+    public var quantity: Int32
+    public var unit: Unit
+    public var expiresAt: Date?
+    public var notes: String?
+    public let createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        locationID: Location.ID,
+        name: String,
+        quantity: Int32 = 1,
+        unit: Unit = .count,
+        expiresAt: Date? = nil,
+        notes: String? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.locationID = locationID
+        self.name = name
+        self.quantity = quantity
+        self.unit = unit
+        self.expiresAt = expiresAt
+        self.notes = notes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// A photo attached to an item. The lowest `sortOrder` photo is the primary
+/// (the one shown in lists, grids, and the item header); the rest are
+/// secondary reference shots. See `ARCHITECTURE.md` §4.
+public struct ItemPhoto: Sendable, Hashable, Identifiable {
+    public let id: UUID
+    public let itemID: Item.ID
+    public var imageData: Data?
+    public var thumbnailData: Data?
+    public var caption: String?
+    public var sortOrder: Int16
+    public let createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        itemID: Item.ID,
+        imageData: Data? = nil,
+        thumbnailData: Data? = nil,
+        caption: String? = nil,
+        sortOrder: Int16 = 0,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.itemID = itemID
+        self.imageData = imageData
+        self.thumbnailData = thumbnailData
+        self.caption = caption
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+    }
+}

--- a/Packages/Core/Sources/NakedPantreeDomain/Enums.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Enums.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// The kind of physical storage a `Location` represents.
+///
+/// Stored as `String` on `Location.kindRaw` so a forward-incompatible client
+/// adding a new value won't crash older builds — the unknown raw is preserved
+/// via `unknown(String)`. See `ARCHITECTURE.md` §4.
+public enum LocationKind: Sendable, Hashable {
+    case pantry
+    case fridge
+    case freezer
+    case dryGoods
+    case other
+    case unknown(String)
+
+    /// Raw values that are part of the persistence contract. Renaming any of
+    /// these breaks decoding of existing CloudKit records — see the
+    /// stability tests in `LocationKindStabilityTests`.
+    public static let knownRawValues: [String] = [
+        "pantry", "fridge", "freezer", "dryGoods", "other",
+    ]
+
+    public var rawValue: String {
+        switch self {
+        case .pantry: "pantry"
+        case .fridge: "fridge"
+        case .freezer: "freezer"
+        case .dryGoods: "dryGoods"
+        case .other: "other"
+        case .unknown(let raw): raw
+        }
+    }
+
+    /// Maps every known raw to its canonical case; anything else is preserved
+    /// via `.unknown(rawValue)` so older clients don't crash on a value a
+    /// newer client wrote. Construction is total — there is no failure mode.
+    public init(rawValue: String) {
+        switch rawValue {
+        case "pantry": self = .pantry
+        case "fridge": self = .fridge
+        case "freezer": self = .freezer
+        case "dryGoods": self = .dryGoods
+        case "other": self = .other
+        default: self = .unknown(rawValue)
+        }
+    }
+}
+
+/// The unit a `quantity` is expressed in.
+///
+/// Stored as `String` on `Item.unitRaw`. New units are an additive schema
+/// change — see `ARCHITECTURE.md` §10. The `unknown(String)` catch-all
+/// preserves any value a newer client may write.
+public enum Unit: Sendable, Hashable {
+    case count
+    case gram
+    case kilogram
+    case ounce
+    case pound
+    case milliliter
+    case liter
+    case fluidOunce
+    case package
+    case unknown(String)
+
+    public static let knownRawValues: [String] = [
+        "count", "gram", "kilogram", "ounce", "pound",
+        "milliliter", "liter", "fluidOunce", "package",
+    ]
+
+    public var rawValue: String {
+        switch self {
+        case .count: "count"
+        case .gram: "gram"
+        case .kilogram: "kilogram"
+        case .ounce: "ounce"
+        case .pound: "pound"
+        case .milliliter: "milliliter"
+        case .liter: "liter"
+        case .fluidOunce: "fluidOunce"
+        case .package: "package"
+        case .unknown(let raw): raw
+        }
+    }
+
+    public init(rawValue: String) {
+        switch rawValue {
+        case "count": self = .count
+        case "gram": self = .gram
+        case "kilogram": self = .kilogram
+        case "ounce": self = .ounce
+        case "pound": self = .pound
+        case "milliliter": self = .milliliter
+        case "liter": self = .liter
+        case "fluidOunce": self = .fluidOunce
+        case "package": self = .package
+        default: self = .unknown(rawValue)
+        }
+    }
+}

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Read and update the active household.
+///
+/// `currentHousehold()` is fetch-or-create: on first call it bootstraps a
+/// default household named "My Pantry" with one default `Location` named
+/// "Kitchen" (Phase 1 exit criterion in `ROADMAP.md`). Subsequent calls
+/// return the same record. Callers don't need to know about bootstrap.
+public protocol HouseholdRepository: Sendable {
+    func currentHousehold() async throws -> Household
+    func update(_ household: Household) async throws
+}
+
+/// CRUD over `Location`s scoped to a single household.
+public protocol LocationRepository: Sendable {
+    func locations(in householdID: Household.ID) async throws -> [Location]
+    func location(id: Location.ID) async throws -> Location?
+    func create(_ location: Location) async throws
+    func update(_ location: Location) async throws
+    func delete(id: Location.ID) async throws
+}
+
+/// CRUD over `Item`s plus household-scoped search.
+///
+/// `update(_:)` stamps `updatedAt = Date()` on the persisted record before
+/// writing — the value passed in by the caller is overwritten. Tests may
+/// inject a clock indirectly by reading the persisted record back; the
+/// protocol does not expose one.
+public protocol ItemRepository: Sendable {
+    func items(in locationID: Location.ID) async throws -> [Item]
+    func item(id: Item.ID) async throws -> Item?
+    /// Case-insensitive substring match on `Item.name`, scoped to one
+    /// household. Empty / whitespace-only queries return an empty array.
+    func search(_ query: String, in householdID: Household.ID) async throws -> [Item]
+    func create(_ item: Item) async throws
+    func update(_ item: Item) async throws
+    func delete(id: Item.ID) async throws
+}
+
+/// CRUD over an item's photo strip. The lowest-`sortOrder` photo is the
+/// primary; the rest are secondary. See `ARCHITECTURE.md` §4.
+public protocol ItemPhotoRepository: Sendable {
+    func photos(for itemID: Item.ID) async throws -> [ItemPhoto]
+    func create(_ photo: ItemPhoto) async throws
+    func update(_ photo: ItemPhoto) async throws
+    func delete(id: ItemPhoto.ID) async throws
+}

--- a/Packages/Core/Tests/NakedPantreeDomainTests/EntityTests.swift
+++ b/Packages/Core/Tests/NakedPantreeDomainTests/EntityTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import NakedPantreeDomain
+
+@Suite("Entity defaults")
+struct EntityDefaultsTests {
+    @Test("Household defaults match the bootstrap contract")
+    func householdDefaults() {
+        let household = Household()
+        #expect(household.name == "My Pantry")
+    }
+
+    @Test("Location defaults to .pantry kind and sortOrder 0")
+    func locationDefaults() {
+        let household = Household()
+        let location = Location(householdID: household.id, name: "Kitchen")
+        #expect(location.kind == .pantry)
+        #expect(location.sortOrder == 0)
+        #expect(location.householdID == household.id)
+    }
+
+    @Test("Item defaults to quantity 1, unit .count, and no expiry")
+    func itemDefaults() {
+        let location = Location(householdID: UUID(), name: "Kitchen")
+        let item = Item(locationID: location.id, name: "Tomatoes")
+        #expect(item.quantity == 1)
+        #expect(item.unit == .count)
+        #expect(item.expiresAt == nil)
+        #expect(item.notes == nil)
+        #expect(item.locationID == location.id)
+    }
+
+    @Test("ItemPhoto defaults to sortOrder 0 and no payload")
+    func itemPhotoDefaults() {
+        let item = Item(locationID: UUID(), name: "Tomatoes")
+        let photo = ItemPhoto(itemID: item.id)
+        #expect(photo.sortOrder == 0)
+        #expect(photo.imageData == nil)
+        #expect(photo.thumbnailData == nil)
+        #expect(photo.caption == nil)
+        #expect(photo.itemID == item.id)
+    }
+}

--- a/Packages/Core/Tests/NakedPantreeDomainTests/EnumStabilityTests.swift
+++ b/Packages/Core/Tests/NakedPantreeDomainTests/EnumStabilityTests.swift
@@ -1,0 +1,89 @@
+import Testing
+@testable import NakedPantreeDomain
+
+/// Raw values are part of the persistence contract: renaming any of them
+/// silently breaks decoding of older CloudKit records. These tests pin the
+/// raw strings down — round-trip alone wouldn't catch a `pantry → pantries`
+/// rename, hence the hardcoded expectations. See `AGENTS.md` §2.
+@Suite("LocationKind raw-value stability")
+struct LocationKindStabilityTests {
+    @Test("Known cases use the contract raw values")
+    func knownCasesHaveExpectedRawValues() {
+        #expect(LocationKind.pantry.rawValue == "pantry")
+        #expect(LocationKind.fridge.rawValue == "fridge")
+        #expect(LocationKind.freezer.rawValue == "freezer")
+        #expect(LocationKind.dryGoods.rawValue == "dryGoods")
+        #expect(LocationKind.other.rawValue == "other")
+    }
+
+    @Test("init(rawValue:) maps known raws to their canonical case")
+    func initFromKnownRawValues() {
+        #expect(LocationKind(rawValue: "pantry") == .pantry)
+        #expect(LocationKind(rawValue: "fridge") == .fridge)
+        #expect(LocationKind(rawValue: "freezer") == .freezer)
+        #expect(LocationKind(rawValue: "dryGoods") == .dryGoods)
+        #expect(LocationKind(rawValue: "other") == .other)
+    }
+
+    @Test("init(rawValue:) preserves unknown values via the catch-all")
+    func unknownRawValueRoundTrips() {
+        let future = LocationKind(rawValue: "freezerOutside")
+        #expect(future == .unknown("freezerOutside"))
+        #expect(future.rawValue == "freezerOutside")
+    }
+
+    @Test("knownRawValues exposes exactly the contract raws")
+    func knownRawValuesIsAuthoritative() {
+        #expect(
+            LocationKind.knownRawValues
+                == ["pantry", "fridge", "freezer", "dryGoods", "other"]
+        )
+    }
+}
+
+@Suite("Unit raw-value stability")
+struct UnitStabilityTests {
+    @Test("Known cases use the contract raw values")
+    func knownCasesHaveExpectedRawValues() {
+        #expect(Unit.count.rawValue == "count")
+        #expect(Unit.gram.rawValue == "gram")
+        #expect(Unit.kilogram.rawValue == "kilogram")
+        #expect(Unit.ounce.rawValue == "ounce")
+        #expect(Unit.pound.rawValue == "pound")
+        #expect(Unit.milliliter.rawValue == "milliliter")
+        #expect(Unit.liter.rawValue == "liter")
+        #expect(Unit.fluidOunce.rawValue == "fluidOunce")
+        #expect(Unit.package.rawValue == "package")
+    }
+
+    @Test("init(rawValue:) maps known raws to their canonical case")
+    func initFromKnownRawValues() {
+        #expect(Unit(rawValue: "count") == .count)
+        #expect(Unit(rawValue: "gram") == .gram)
+        #expect(Unit(rawValue: "kilogram") == .kilogram)
+        #expect(Unit(rawValue: "ounce") == .ounce)
+        #expect(Unit(rawValue: "pound") == .pound)
+        #expect(Unit(rawValue: "milliliter") == .milliliter)
+        #expect(Unit(rawValue: "liter") == .liter)
+        #expect(Unit(rawValue: "fluidOunce") == .fluidOunce)
+        #expect(Unit(rawValue: "package") == .package)
+    }
+
+    @Test("init(rawValue:) preserves unknown values via the catch-all")
+    func unknownRawValueRoundTrips() {
+        let future = Unit(rawValue: "tablespoon")
+        #expect(future == .unknown("tablespoon"))
+        #expect(future.rawValue == "tablespoon")
+    }
+
+    @Test("knownRawValues exposes exactly the contract raws")
+    func knownRawValuesIsAuthoritative() {
+        #expect(
+            Unit.knownRawValues
+                == [
+                    "count", "gram", "kilogram", "ounce", "pound",
+                    "milliliter", "liter", "fluidOunce", "package",
+                ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary

First slice of Phase 1 ([ROADMAP.md](https://github.com/ellisandy/NakedPantree/blob/main/ROADMAP.md)). Defines the `NakedPantreeDomain` surface that the persistence layer and feature code will share — pure value types and protocols, no Core Data or UIKit dependencies.

- **Entities** (`Household`, `Location`, `Item`, `ItemPhoto`) per [ARCHITECTURE.md §4](https://github.com/ellisandy/NakedPantree/blob/main/ARCHITECTURE.md). Children carry their parent ID rather than holding a `[Child]` array — the repository surfaces relationships. Defaults match the bootstrap contract: `Household.name = "My Pantry"`, `Location.kind = .pantry`, `Item.quantity = 1`, `Item.unit = .count`, `ItemPhoto.sortOrder = 0` (primary).
- **Enums** (`LocationKind`, `Unit`) each with the `unknown(String)` catch-all required by [AGENTS.md §2](https://github.com/ellisandy/NakedPantree/blob/main/AGENTS.md) so a forward-incompatible client adding a value can't crash older builds. `init(rawValue:)` is total and routes known raws to canonical cases (never `.unknown(known-raw)`).
- **Repository protocols** (`HouseholdRepository`, `LocationRepository`, `ItemRepository`, `ItemPhotoRepository`). Two contracts called out on the protocols themselves:
  - `HouseholdRepository.currentHousehold()` is fetch-or-create — bootstrap (`"My Pantry"` + a `"Kitchen"` location) is the repo's responsibility, not the caller's.
  - `ItemRepository.update(_:)` stamps `updatedAt`; the value the caller passes in is overwritten.

The existing `moduleVersion` placeholder is kept so the persistence stub link survives — it goes away when the Core Data implementation lands in Phase 1.2.

## Test plan

- [x] `swift test --package-path Packages/Core` — 14 tests pass locally (entity defaults + enum stability with hardcoded expected raws + unknown round-trip).
- [x] `swift-format lint --strict` (in `swift:6.0` container, matches CI) clean.
- [x] `swiftlint --strict` clean.
- [x] `xcodebuild build` on iPhone 17 simulator succeeds (no new app-target code, but verifies the package still links into the app).
- [ ] CI (`Lint` + `Build & Test`) green on PR.

## Out of scope (next PRs in Phase 1)

- Phase 1.2: Core Data model + repository implementations.
- Phase 1.3: NavigationSplitView shell.
- Phase 1.4: CRUD wired up.
- Phase 1.5: Search + first-launch bootstrap.