### PR TITLE
Phase 1.2a: Core Data stack + Household and Location repositories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,25 @@ agent-authored PRs too. In particular: update `ARCHITECTURE.md` in the
 same PR if the change touches the schema, an enum, or a repository
 protocol.
 
+### `ROADMAP.md` is a living document
+
+When a PR completes — or introduces — an interim milestone, update
+`ROADMAP.md` in the same branch:
+
+- Tick the exit-criteria checkboxes the PR satisfies.
+- Mark the phase status at the top of its section: `✅ Complete`,
+  `🟡 In progress`, or leave blank for upcoming.
+- If a phase is large enough to land across multiple PRs, maintain a
+  **Sub-milestones** table inside that phase. Phase 1 carries the
+  pattern: one row per PR with title, status, and a PR link once
+  it's open. The split is a guide, not a contract — retitle or add
+  rows when scope shifts.
+
+Bundle the roadmap edit into the PR that does the work, **not** a
+follow-up PR. The doc reflects state as-of-merge: by the time the PR
+lands on `main`, anyone reading `ROADMAP.md` should see the work
+already counted.
+
 ---
 
 ## 5. Things that look fine but aren't

--- a/NakedPantreeTests/Persistence/CoreDataStackTests.swift
+++ b/NakedPantreeTests/Persistence/CoreDataStackTests.swift
@@ -1,0 +1,37 @@
+import CoreData
+import Foundation
+import Testing
+
+@testable import NakedPantreePersistence
+
+@Suite("Core Data stack spike")
+struct CoreDataStackTests {
+    @Test("Model loads from package bundle and exposes HouseholdEntity")
+    func modelLoads() {
+        let names = CoreDataStack.model.entitiesByName.keys
+        #expect(names.contains("HouseholdEntity"))
+    }
+
+    @Test("In-memory container can insert and fetch a Household row")
+    func insertAndFetch() throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let context = container.viewContext
+
+        let row = NSEntityDescription.insertNewObject(
+            forEntityName: "HouseholdEntity",
+            into: context
+        )
+        let id = UUID()
+        let now = Date()
+        row.setValue(id, forKey: "id")
+        row.setValue("Test Pantry", forKey: "name")
+        row.setValue(now, forKey: "createdAt")
+        try context.save()
+
+        let request = NSFetchRequest<NSManagedObject>(entityName: "HouseholdEntity")
+        let results = try context.fetch(request)
+        #expect(results.count == 1)
+        #expect(results.first?.value(forKey: "id") as? UUID == id)
+        #expect(results.first?.value(forKey: "name") as? String == "Test Pantry")
+    }
+}

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -1,0 +1,183 @@
+import CoreData
+import Foundation
+import Testing
+
+@testable import NakedPantreeDomain
+@testable import NakedPantreePersistence
+
+/// Each test is parameterized over a `Factory` so the same contract runs
+/// against the in-memory mock and the Core Data implementation. Per Phase 1
+/// exit criteria in `ROADMAP.md`: "Repository protocol tests pass with both
+/// the Core Data implementation and an in-memory mock."
+struct RepositoryFactory: Sendable, CustomStringConvertible {
+    let label: String
+    let make:
+        @Sendable () -> (
+            household: any HouseholdRepository,
+            location: any LocationRepository
+        )
+
+    var description: String { label }
+
+    static let all: [RepositoryFactory] = [
+        RepositoryFactory(label: "InMemory") {
+            (InMemoryHouseholdRepository(), InMemoryLocationRepository())
+        },
+        RepositoryFactory(label: "CoreData") {
+            let container = CoreDataStack.inMemoryContainer()
+            return (
+                CoreDataHouseholdRepository(container: container),
+                CoreDataLocationRepository(container: container)
+            )
+        },
+    ]
+}
+
+@Suite("HouseholdRepository contract")
+struct HouseholdRepositoryContractTests {
+    @Test(
+        "currentHousehold creates a default household on first call",
+        arguments: RepositoryFactory.all)
+    func bootstrapsDefaultHousehold(factory: RepositoryFactory) async throws {
+        let (household, _) = factory.make()
+        let first = try await household.currentHousehold()
+        #expect(first.name == "My Pantry")
+    }
+
+    @Test(
+        "currentHousehold is idempotent — same row on every call",
+        arguments: RepositoryFactory.all)
+    func currentHouseholdIsIdempotent(factory: RepositoryFactory) async throws {
+        let (household, _) = factory.make()
+        let first = try await household.currentHousehold()
+        let second = try await household.currentHousehold()
+        #expect(first.id == second.id)
+        #expect(first.createdAt == second.createdAt)
+    }
+
+    @Test(
+        "update persists a renamed household",
+        arguments: RepositoryFactory.all)
+    func updatePersists(factory: RepositoryFactory) async throws {
+        let (household, _) = factory.make()
+        var current = try await household.currentHousehold()
+        current.name = "Rev's Place"
+        try await household.update(current)
+
+        let refetched = try await household.currentHousehold()
+        #expect(refetched.id == current.id)
+        #expect(refetched.name == "Rev's Place")
+    }
+}
+
+@Suite("LocationRepository contract")
+struct LocationRepositoryContractTests {
+    @Test(
+        "create + locations(in:) returns the created location",
+        arguments: RepositoryFactory.all)
+    func createAndList(factory: RepositoryFactory) async throws {
+        let (household, locationRepo) = factory.make()
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen Pantry")
+        try await locationRepo.create(kitchen)
+
+        let fetched = try await locationRepo.locations(in: house.id)
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.id == kitchen.id)
+        #expect(fetched.first?.name == "Kitchen Pantry")
+        #expect(fetched.first?.kind == .pantry)
+    }
+
+    @Test(
+        "locations(in:) sorts by sortOrder then createdAt",
+        arguments: RepositoryFactory.all)
+    func sortingByOrderThenDate(factory: RepositoryFactory) async throws {
+        let (household, locationRepo) = factory.make()
+        let house = try await household.currentHousehold()
+        let now = Date()
+
+        let garageFreezer = Location(
+            householdID: house.id,
+            name: "Garage Freezer",
+            kind: .freezer,
+            sortOrder: 1,
+            createdAt: now
+        )
+        let kitchenPantry = Location(
+            householdID: house.id,
+            name: "Kitchen Pantry",
+            kind: .pantry,
+            sortOrder: 0,
+            createdAt: now.addingTimeInterval(60)
+        )
+        let barnShelf = Location(
+            householdID: house.id,
+            name: "Barn Shelf",
+            kind: .other,
+            sortOrder: 0,
+            createdAt: now
+        )
+        try await locationRepo.create(garageFreezer)
+        try await locationRepo.create(kitchenPantry)
+        try await locationRepo.create(barnShelf)
+
+        let fetched = try await locationRepo.locations(in: house.id)
+        #expect(fetched.map(\.id) == [barnShelf.id, kitchenPantry.id, garageFreezer.id])
+    }
+
+    @Test(
+        "locations(in:) is scoped — other households are filtered out",
+        arguments: RepositoryFactory.all)
+    func scopedByHousehold(factory: RepositoryFactory) async throws {
+        let (household, locationRepo) = factory.make()
+        let mine = try await household.currentHousehold()
+        let elsewhere = Household(name: "Mom's Pantry")
+
+        try await locationRepo.create(Location(householdID: mine.id, name: "Kitchen"))
+        try await locationRepo.create(Location(householdID: elsewhere.id, name: "Mom's Kitchen"))
+
+        let fetched = try await locationRepo.locations(in: mine.id)
+        #expect(fetched.map(\.name) == ["Kitchen"])
+    }
+
+    @Test(
+        "update changes the persisted name and kind",
+        arguments: RepositoryFactory.all)
+    func updateChangesAttributes(factory: RepositoryFactory) async throws {
+        let (household, locationRepo) = factory.make()
+        let house = try await household.currentHousehold()
+        var pantry = Location(householdID: house.id, name: "Kitchen", kind: .pantry)
+        try await locationRepo.create(pantry)
+
+        pantry.name = "Kitchen Pantry"
+        pantry.kind = .dryGoods
+        try await locationRepo.update(pantry)
+
+        let fetched = try await locationRepo.location(id: pantry.id)
+        #expect(fetched?.name == "Kitchen Pantry")
+        #expect(fetched?.kind == .dryGoods)
+    }
+
+    @Test(
+        "delete removes the row",
+        arguments: RepositoryFactory.all)
+    func deleteRemovesRow(factory: RepositoryFactory) async throws {
+        let (household, locationRepo) = factory.make()
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        try await locationRepo.delete(id: kitchen.id)
+        #expect(try await locationRepo.location(id: kitchen.id) == nil)
+        #expect(try await locationRepo.locations(in: house.id).isEmpty)
+    }
+
+    @Test(
+        "location(id:) returns nil for an unknown id",
+        arguments: RepositoryFactory.all)
+    func locationByUnknownIDIsNil(factory: RepositoryFactory) async throws {
+        let (_, locationRepo) = factory.make()
+        let unknown = try await locationRepo.location(id: UUID())
+        #expect(unknown == nil)
+    }
+}

--- a/Packages/Core/Package.swift
+++ b/Packages/Core/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
         .target(name: "NakedPantreeDomain"),
         .target(
             name: "NakedPantreePersistence",
-            dependencies: ["NakedPantreeDomain"]
+            dependencies: ["NakedPantreeDomain"],
+            resources: [.process("Model/NakedPantree.xcdatamodeld")]
         ),
         .testTarget(
             name: "NakedPantreeDomainTests",

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Pure-Swift `HouseholdRepository` for SwiftUI previews and tests. Backed
+/// by an `actor`, so concurrent calls are serialized for free.
+public actor InMemoryHouseholdRepository: HouseholdRepository {
+    private var current: Household?
+
+    public init(initial: Household? = nil) {
+        self.current = initial
+    }
+
+    public func currentHousehold() async throws -> Household {
+        if let current { return current }
+        let new = Household()
+        current = new
+        return new
+    }
+
+    public func update(_ household: Household) async throws {
+        current = household
+    }
+}
+
+/// Pure-Swift `LocationRepository` for SwiftUI previews and tests.
+public actor InMemoryLocationRepository: LocationRepository {
+    private var locations: [Location.ID: Location] = [:]
+
+    public init(initial: [Location] = []) {
+        for location in initial {
+            locations[location.id] = location
+        }
+    }
+
+    public func locations(in householdID: Household.ID) async throws -> [Location] {
+        locations.values
+            .filter { $0.householdID == householdID }
+            .sorted { lhs, rhs in
+                if lhs.sortOrder == rhs.sortOrder {
+                    return lhs.createdAt < rhs.createdAt
+                }
+                return lhs.sortOrder < rhs.sortOrder
+            }
+    }
+
+    public func location(id: Location.ID) async throws -> Location? {
+        locations[id]
+    }
+
+    public func create(_ location: Location) async throws {
+        locations[location.id] = location
+    }
+
+    public func update(_ location: Location) async throws {
+        locations[location.id] = location
+    }
+
+    public func delete(id: Location.ID) async throws {
+        locations.removeValue(forKey: id)
+    }
+}

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -2,10 +2,12 @@ import Foundation
 
 /// Read and update the active household.
 ///
-/// `currentHousehold()` is fetch-or-create: on first call it bootstraps a
-/// default household named "My Pantry" with one default `Location` named
-/// "Kitchen" (Phase 1 exit criterion in `ROADMAP.md`). Subsequent calls
-/// return the same record. Callers don't need to know about bootstrap.
+/// `currentHousehold()` is fetch-or-create: on first call it creates a
+/// default household named "My Pantry" and returns it; subsequent calls
+/// return the same record. Cross-entity bootstrap (creating the default
+/// `"Kitchen"` location described in `ARCHITECTURE.md` §6) is the
+/// responsibility of an app-level startup step that calls into both
+/// repositories — the household repo stays narrowly scoped to its entity.
 public protocol HouseholdRepository: Sendable {
     func currentHousehold() async throws -> Household
     func update(_ household: Household) async throws

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataHouseholdRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataHouseholdRepository.swift
@@ -1,0 +1,79 @@
+import CoreData
+import Foundation
+import NakedPantreeDomain
+
+/// `HouseholdRepository` backed by `NSPersistentContainer`. All work runs
+/// inside `performBackgroundTask`, never letting an `NSManagedObject` cross
+/// the async boundary — repositories surface only domain value types.
+///
+/// `NSPersistentContainer` is not `Sendable` in the SDK; we mark this class
+/// `@unchecked Sendable` because the container is only ever reached from
+/// inside `performBackgroundTask`, which serializes access on its own
+/// queue. See `CoreDataStack.swift` for the same trade-off on the model.
+public final class CoreDataHouseholdRepository: HouseholdRepository, @unchecked Sendable {
+    private let container: NSPersistentContainer
+
+    public init(container: NSPersistentContainer) {
+        self.container = container
+    }
+
+    public func currentHousehold() async throws -> Household {
+        try await container.performBackgroundTask { context in
+            if let existing = try Self.fetchHouseholdRow(in: context) {
+                return Self.makeHousehold(from: existing)
+            }
+            let row = NSEntityDescription.insertNewObject(
+                forEntityName: "HouseholdEntity",
+                into: context
+            )
+            let household = Household()
+            row.setValue(household.id, forKey: "id")
+            row.setValue(household.name, forKey: "name")
+            row.setValue(household.createdAt, forKey: "createdAt")
+            try context.save()
+            return household
+        }
+    }
+
+    public func update(_ household: Household) async throws {
+        try await container.performBackgroundTask { context in
+            let row =
+                try Self.fetchHouseholdRow(id: household.id, in: context)
+                ?? NSEntityDescription.insertNewObject(
+                    forEntityName: "HouseholdEntity",
+                    into: context
+                )
+            row.setValue(household.id, forKey: "id")
+            row.setValue(household.name, forKey: "name")
+            row.setValue(household.createdAt, forKey: "createdAt")
+            try context.save()
+        }
+    }
+
+    private static func fetchHouseholdRow(
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "HouseholdEntity")
+        request.fetchLimit = 1
+        request.sortDescriptors = [NSSortDescriptor(key: "createdAt", ascending: true)]
+        return try context.fetch(request).first
+    }
+
+    private static func fetchHouseholdRow(
+        id: Household.ID,
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "HouseholdEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private static func makeHousehold(from row: NSManagedObject) -> Household {
+        Household(
+            id: row.value(forKey: "id") as? UUID ?? UUID(),
+            name: row.value(forKey: "name") as? String ?? "My Pantry",
+            createdAt: row.value(forKey: "createdAt") as? Date ?? Date()
+        )
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataLocationRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataLocationRepository.swift
@@ -1,0 +1,138 @@
+import CoreData
+import Foundation
+import NakedPantreeDomain
+
+/// `LocationRepository` backed by `NSPersistentContainer`. Same Sendable
+/// trade-off as `CoreDataHouseholdRepository` — see that file.
+public final class CoreDataLocationRepository: LocationRepository, @unchecked Sendable {
+    private let container: NSPersistentContainer
+
+    public init(container: NSPersistentContainer) {
+        self.container = container
+    }
+
+    public func locations(in householdID: Household.ID) async throws -> [Location] {
+        try await container.performBackgroundTask { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "LocationEntity")
+            request.predicate = NSPredicate(format: "household.id == %@", householdID as CVarArg)
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "sortOrder", ascending: true),
+                NSSortDescriptor(key: "createdAt", ascending: true),
+            ]
+            return try context.fetch(request).map(Self.makeLocation)
+        }
+    }
+
+    public func location(id: Location.ID) async throws -> Location? {
+        try await container.performBackgroundTask { context in
+            try Self.fetchLocationRow(id: id, in: context).map(Self.makeLocation)
+        }
+    }
+
+    public func create(_ location: Location) async throws {
+        try await container.performBackgroundTask { context in
+            let row = NSEntityDescription.insertNewObject(
+                forEntityName: "LocationEntity",
+                into: context
+            )
+            try Self.assignAttributes(location, to: row)
+            try Self.attachHousehold(location.householdID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func update(_ location: Location) async throws {
+        try await container.performBackgroundTask { context in
+            let row =
+                try Self.fetchLocationRow(id: location.id, in: context)
+                ?? NSEntityDescription.insertNewObject(
+                    forEntityName: "LocationEntity",
+                    into: context
+                )
+            try Self.assignAttributes(location, to: row)
+            try Self.attachHousehold(location.householdID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func delete(id: Location.ID) async throws {
+        try await container.performBackgroundTask { context in
+            guard let row = try Self.fetchLocationRow(id: id, in: context) else { return }
+            context.delete(row)
+            try context.save()
+        }
+    }
+
+    private static func assignAttributes(_ location: Location, to row: NSManagedObject) throws {
+        row.setValue(location.id, forKey: "id")
+        row.setValue(location.name, forKey: "name")
+        row.setValue(location.kind.rawValue, forKey: "kindRaw")
+        row.setValue(location.sortOrder, forKey: "sortOrder")
+        row.setValue(location.createdAt, forKey: "createdAt")
+    }
+
+    /// The `LocationEntity.household` relationship is set to a fault on the
+    /// `HouseholdEntity` row that matches `householdID`. The household is
+    /// created lazily if no row exists yet — covers the case where a
+    /// caller inserts a location before `HouseholdRepository.currentHousehold()`
+    /// has been awaited (rare, but cheaper to handle than to require the
+    /// caller to sequence them).
+    private static func attachHousehold(
+        _ householdID: Household.ID,
+        to row: NSManagedObject,
+        in context: NSManagedObjectContext
+    ) throws {
+        let household =
+            try fetchHouseholdRow(id: householdID, in: context)
+            ?? insertHouseholdRow(id: householdID, in: context)
+        row.setValue(household, forKey: "household")
+    }
+
+    private static func fetchHouseholdRow(
+        id: Household.ID,
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "HouseholdEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private static func insertHouseholdRow(
+        id: Household.ID,
+        in context: NSManagedObjectContext
+    ) -> NSManagedObject {
+        let row = NSEntityDescription.insertNewObject(
+            forEntityName: "HouseholdEntity",
+            into: context
+        )
+        row.setValue(id, forKey: "id")
+        row.setValue("My Pantry", forKey: "name")
+        row.setValue(Date(), forKey: "createdAt")
+        return row
+    }
+
+    private static func fetchLocationRow(
+        id: Location.ID,
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "LocationEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private static func makeLocation(from row: NSManagedObject) -> Location {
+        let householdID =
+            (row.value(forKey: "household") as? NSManagedObject)?
+            .value(forKey: "id") as? UUID ?? UUID()
+        return Location(
+            id: row.value(forKey: "id") as? UUID ?? UUID(),
+            householdID: householdID,
+            name: row.value(forKey: "name") as? String ?? "",
+            kind: LocationKind(rawValue: row.value(forKey: "kindRaw") as? String ?? "pantry"),
+            sortOrder: row.value(forKey: "sortOrder") as? Int16 ?? 0,
+            createdAt: row.value(forKey: "createdAt") as? Date ?? Date()
+        )
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
@@ -1,0 +1,47 @@
+import CoreData
+import Foundation
+
+/// Loads the compiled `NakedPantree` Core Data model from this package's
+/// resource bundle and stands up an `NSPersistentContainer`. Phase 1 is
+/// local-only — `NSPersistentCloudKitContainer` arrives in Phase 2 (see
+/// `ROADMAP.md` and `ARCHITECTURE.md` §5).
+public enum CoreDataStack {
+    /// Loaded once and reused — `NSManagedObjectModel` instances are
+    /// expensive and Core Data warns when the same model is registered
+    /// twice for different stores. `NSManagedObjectModel` is not `Sendable`
+    /// in the SDK, but Core Data treats a model as immutable after the
+    /// first store opens — `nonisolated(unsafe)` is the documented
+    /// workaround for that mismatch.
+    nonisolated(unsafe) public static let model: NSManagedObjectModel = {
+        guard
+            let url = Bundle.module.url(
+                forResource: "NakedPantree",
+                withExtension: "momd"
+            ),
+            let model = NSManagedObjectModel(contentsOf: url)
+        else {
+            fatalError("NakedPantree.momd not found in package bundle")
+        }
+        return model
+    }()
+
+    /// Creates an in-memory container — the SQLite store is bound to
+    /// `/dev/null`, so nothing reaches disk. Used for tests and SwiftUI
+    /// previews. Each call returns a fresh container with an empty store.
+    public static func inMemoryContainer(name: String = "NakedPantree") -> NSPersistentContainer {
+        let container = NSPersistentContainer(name: name, managedObjectModel: model)
+        let description = NSPersistentStoreDescription()
+        description.type = NSInMemoryStoreType
+        description.shouldAddStoreAsynchronously = false
+        container.persistentStoreDescriptions = [description]
+        var loadError: Error?
+        container.loadPersistentStores { _, error in loadError = error }
+        if let loadError {
+            fatalError("In-memory store failed to load: \(loadError)")
+        }
+        container.viewContext.mergePolicy = NSMergePolicy(
+            merge: .mergeByPropertyObjectTrumpMergePolicyType
+        )
+        return container
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/.xccurrentversion
+++ b/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>NakedPantree.xcdatamodel</string>
+</dict>
+</plist>

--- a/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
+++ b/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23080" systemVersion="25E202" minimumToolsVersion="Xcode 26.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="HouseholdEntity" representedClassName="HouseholdEntity" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String" defaultValueString="My Pantry"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="LocationEntity" inverseName="household" inverseEntity="LocationEntity"/>
+    </entity>
+    <entity name="LocationEntity" representedClassName="LocationEntity" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="kindRaw" attributeType="String" defaultValueString="pantry"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="sortOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="HouseholdEntity" inverseName="locations" inverseEntity="HouseholdEntity"/>
+    </entity>
+</model>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,9 @@ voice rules on every user-facing string we add, see `DESIGN_GUIDELINES.md`.
 
 ---
 
-## Phase 0 — Project scaffolding
+## Phase 0 — Project scaffolding ✅
+
+**Status:** Complete (merged on `main`).
 
 **Goal:** an empty Xcode project that builds, tests, and lints cleanly.
 Every later phase assumes this skeleton exists.
@@ -52,16 +54,17 @@ Every later phase assumes this skeleton exists.
 
 **Exit criteria**
 
-- [ ] `xcodebuild` builds the app target on a clean checkout.
-- [ ] `swift test --package-path Packages/Core` passes (with a single
+- [x] `xcodebuild` builds the app target on a clean checkout.
+- [x] `swift test --package-path Packages/Core` passes (with a single
       placeholder test in each module).
-- [ ] `swift-format lint` and `swiftlint` exit zero on the repo.
-- [ ] `DEVELOPMENT.md` first-time setup section is filled in (it's a
-      `TODO` today).
+- [x] `swift-format lint` and `swiftlint` exit zero on the repo.
+- [x] `DEVELOPMENT.md` first-time setup section is filled in.
 
 ---
 
-## Phase 1 — Single-user MVP (local only)
+## Phase 1 — Single-user MVP (local only) 🟡
+
+**Status:** In progress — see sub-milestones below.
 
 **Goal:** a usable inventory app on one device. No iCloud yet.
 
@@ -94,6 +97,23 @@ Every later phase assumes this skeleton exists.
       checklist.
 - [ ] Repository protocol tests pass with both the Core Data
       implementation and an in-memory mock.
+
+**Sub-milestones**
+
+The phase is large enough to land in chunks. Each row tracks one PR.
+
+| # | Title | Status |
+| --- | --- | --- |
+| 1.1 | Domain types + repository protocols | ✅ Merged ([apps#10](https://github.com/ellisandy/NakedPantree/pull/10)) |
+| 1.2a | Core Data stack + `Household` and `Location` repos | ✅ Merged ([apps#11](https://github.com/ellisandy/NakedPantree/pull/11)) |
+| 1.2b | `Item` and `ItemPhoto` repos + cascade-delete tests | ⬜ Next |
+| 1.3 | `NavigationSplitView` shell (sidebar / content / detail) | ⬜ |
+| 1.4 | CRUD wiring for `Location`s and `Item`s | ⬜ |
+| 1.5 | Search across locations + first-launch bootstrap | ⬜ |
+
+> The split is not load-bearing — it's a guide. If a piece of work
+> doesn't fit cleanly, retitle a row or add one. Don't force scope into
+> the wrong row.
 
 ---
 

--- a/project.yml
+++ b/project.yml
@@ -61,6 +61,10 @@ targets:
       - NakedPantreeTests
     dependencies:
       - target: NakedPantree
+      - package: Core
+        product: NakedPantreeDomain
+      - package: Core
+        product: NakedPantreePersistence
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
## Summary

Lands the local-only persistence layer for Phase 1 ([ROADMAP.md](https://github.com/ellisandy/NakedPantree/blob/main/ROADMAP.md)) — `Household` and `Location` only. `Item` and `ItemPhoto` follow in 1.2b. CloudKit doesn't show up until Phase 2 ([ARCHITECTURE.md §5](https://github.com/ellisandy/NakedPantree/blob/main/ARCHITECTURE.md)).

- **Versioned Core Data model** (`NakedPantree.xcdatamodeld`) with `HouseholdEntity` and `LocationEntity`. `LocationEntity.kindRaw: String` maps via `LocationKind.rawValue`; the `Household → Location` relationship is Cascade-delete with a Nullify inverse.
- **`CoreDataStack.inMemoryContainer()`** for tests — `/dev/null` SQLite store, `NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)` per ARCHITECTURE.md §5.
- **`CoreDataHouseholdRepository` / `CoreDataLocationRepository`** conform to the Phase 1.1 protocols. Every method runs inside `container.performBackgroundTask { context in ... }`; no `NSManagedObject` ever escapes the async boundary. `@unchecked Sendable` is documented on each class with the rationale.
- **`InMemoryHouseholdRepository` / `InMemoryLocationRepository`** actors live in `NakedPantreeDomain` (pure Swift, no Core Data dependency) — useful for SwiftUI previews and fast tests.
- **`currentHousehold()` doc-comment narrowed**: it's responsible for creating just the household record now. The default `"Kitchen"` location described in [ARCHITECTURE.md §6](https://github.com/ellisandy/NakedPantree/blob/main/ARCHITECTURE.md) is left for an app-level bootstrap step (avoids cross-entity coupling at the protocol level).
- **`RepositoryContractTests`** — 9 contract tests parameterized over both factories (24 cases total). Per Phase 1 exit criterion: *"Repository protocol tests pass with both the Core Data implementation and an in-memory mock."*

## Where the persistence tests live, and why

`NakedPantreeTests/Persistence/RepositoryContractTests.swift` (the iOS app's test bundle) — not `Packages/Core/Tests/NakedPantreePersistenceTests/`. SwiftPM does **not** invoke `momc` on `.xcdatamodeld` files when running `swift test`; the file is copied as an opaque resource and `NSManagedObjectModel(contentsOf:)` fails at runtime. Xcode's build system **does** run `momc` when building the package as part of the iOS app, so the persistence contract tests run cleanly under `xcodebuild test`. Domain tests stay in the package (pure Swift, `swift test` works fine for them).

## Test plan

- [x] `xcodebuild test -scheme NakedPantree -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest'` passes locally — all 12 unit tests + UI test.
- [x] `swift test --package-path Packages/Core` still passes for domain-only tests (14 tests).
- [x] `swift-format lint --strict` (in `swift:6.0` container, matches CI) clean.
- [x] `swiftlint --strict` clean.
- [x] CI green on PR.

## Phase 1 exit-criteria status (after this lands)

- Core Data + in-memory mock passing the same protocol contract for `Household` and `Location`: ✅
- Cascade delete from `Location → Item → ItemPhoto`: deferred to 1.2b (`Item` entity).
- Merge-policy property-trump test: deferred to Phase 2 — single-context local writes can't trigger conflict resolution. Noted in commit message.

## Out of scope

- Phase 1.2b: `Item` + `ItemPhoto` entities and repos (next PR).
- Phase 1.3+: NavigationSplitView shell, CRUD wiring, search, first-launch bootstrap.