### PR TITLE
Phase 1.2b: Item and ItemPhoto repositories with cascade-delete tests

### DIFF
--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -9,25 +9,41 @@ import Testing
 /// against the in-memory mock and the Core Data implementation. Per Phase 1
 /// exit criteria in `ROADMAP.md`: "Repository protocol tests pass with both
 /// the Core Data implementation and an in-memory mock."
+struct RepositoryBundle: Sendable {
+    let household: any HouseholdRepository
+    let location: any LocationRepository
+    let item: any ItemRepository
+    let photo: any ItemPhotoRepository
+}
+
 struct RepositoryFactory: Sendable, CustomStringConvertible {
     let label: String
-    let make:
-        @Sendable () -> (
-            household: any HouseholdRepository,
-            location: any LocationRepository
-        )
+    let make: @Sendable () -> RepositoryBundle
 
     var description: String { label }
 
     static let all: [RepositoryFactory] = [
         RepositoryFactory(label: "InMemory") {
-            (InMemoryHouseholdRepository(), InMemoryLocationRepository())
+            let location = InMemoryLocationRepository()
+            let item = InMemoryItemRepository(
+                locationLookup: { [weak location] id in
+                    try await location?.location(id: id)
+                }
+            )
+            return RepositoryBundle(
+                household: InMemoryHouseholdRepository(),
+                location: location,
+                item: item,
+                photo: InMemoryItemPhotoRepository()
+            )
         },
         RepositoryFactory(label: "CoreData") {
             let container = CoreDataStack.inMemoryContainer()
-            return (
-                CoreDataHouseholdRepository(container: container),
-                CoreDataLocationRepository(container: container)
+            return RepositoryBundle(
+                household: CoreDataHouseholdRepository(container: container),
+                location: CoreDataLocationRepository(container: container),
+                item: CoreDataItemRepository(container: container),
+                photo: CoreDataItemPhotoRepository(container: container)
             )
         },
     ]
@@ -39,7 +55,8 @@ struct HouseholdRepositoryContractTests {
         "currentHousehold creates a default household on first call",
         arguments: RepositoryFactory.all)
     func bootstrapsDefaultHousehold(factory: RepositoryFactory) async throws {
-        let (household, _) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
         let first = try await household.currentHousehold()
         #expect(first.name == "My Pantry")
     }
@@ -48,7 +65,8 @@ struct HouseholdRepositoryContractTests {
         "currentHousehold is idempotent — same row on every call",
         arguments: RepositoryFactory.all)
     func currentHouseholdIsIdempotent(factory: RepositoryFactory) async throws {
-        let (household, _) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
         let first = try await household.currentHousehold()
         let second = try await household.currentHousehold()
         #expect(first.id == second.id)
@@ -59,7 +77,8 @@ struct HouseholdRepositoryContractTests {
         "update persists a renamed household",
         arguments: RepositoryFactory.all)
     func updatePersists(factory: RepositoryFactory) async throws {
-        let (household, _) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
         var current = try await household.currentHousehold()
         current.name = "Rev's Place"
         try await household.update(current)
@@ -76,7 +95,9 @@ struct LocationRepositoryContractTests {
         "create + locations(in:) returns the created location",
         arguments: RepositoryFactory.all)
     func createAndList(factory: RepositoryFactory) async throws {
-        let (household, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
         let house = try await household.currentHousehold()
         let kitchen = Location(householdID: house.id, name: "Kitchen Pantry")
         try await locationRepo.create(kitchen)
@@ -92,7 +113,9 @@ struct LocationRepositoryContractTests {
         "locations(in:) sorts by sortOrder then createdAt",
         arguments: RepositoryFactory.all)
     func sortingByOrderThenDate(factory: RepositoryFactory) async throws {
-        let (household, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
         let house = try await household.currentHousehold()
         let now = Date()
 
@@ -129,7 +152,9 @@ struct LocationRepositoryContractTests {
         "locations(in:) is scoped — other households are filtered out",
         arguments: RepositoryFactory.all)
     func scopedByHousehold(factory: RepositoryFactory) async throws {
-        let (household, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
         let mine = try await household.currentHousehold()
         let elsewhere = Household(name: "Mom's Pantry")
 
@@ -144,7 +169,9 @@ struct LocationRepositoryContractTests {
         "update changes the persisted name and kind",
         arguments: RepositoryFactory.all)
     func updateChangesAttributes(factory: RepositoryFactory) async throws {
-        let (household, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
         let house = try await household.currentHousehold()
         var pantry = Location(householdID: house.id, name: "Kitchen", kind: .pantry)
         try await locationRepo.create(pantry)
@@ -162,7 +189,9 @@ struct LocationRepositoryContractTests {
         "delete removes the row",
         arguments: RepositoryFactory.all)
     func deleteRemovesRow(factory: RepositoryFactory) async throws {
-        let (household, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
         let house = try await household.currentHousehold()
         let kitchen = Location(householdID: house.id, name: "Kitchen")
         try await locationRepo.create(kitchen)
@@ -176,8 +205,326 @@ struct LocationRepositoryContractTests {
         "location(id:) returns nil for an unknown id",
         arguments: RepositoryFactory.all)
     func locationByUnknownIDIsNil(factory: RepositoryFactory) async throws {
-        let (_, locationRepo) = factory.make()
+        let bundle = factory.make()
+        let locationRepo = bundle.location
         let unknown = try await locationRepo.location(id: UUID())
         #expect(unknown == nil)
+    }
+}
+
+@Suite("ItemRepository contract")
+struct ItemRepositoryContractTests {
+    @Test(
+        "create + items(in:) returns the created item",
+        arguments: RepositoryFactory.all)
+    func createAndList(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let tomatoes = Item(
+            locationID: kitchen.id, name: "Tomatoes", quantity: 3, unit: .count
+        )
+        try await itemRepo.create(tomatoes)
+
+        let fetched = try await itemRepo.items(in: kitchen.id)
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.id == tomatoes.id)
+        #expect(fetched.first?.name == "Tomatoes")
+        #expect(fetched.first?.quantity == 3)
+        #expect(fetched.first?.unit == .count)
+    }
+
+    @Test(
+        "items(in:) is scoped — items in other locations are filtered out",
+        arguments: RepositoryFactory.all)
+    func scopedByLocation(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Kitchen")
+        let freezer = Location(householdID: house.id, name: "Garage Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Rice"))
+        try await itemRepo.create(Item(locationID: freezer.id, name: "Ice Cream"))
+
+        let pantryItems = try await itemRepo.items(in: pantry.id)
+        #expect(pantryItems.map(\.name) == ["Rice"])
+    }
+
+    @Test(
+        "update stamps updatedAt and overwrites the caller's value",
+        arguments: RepositoryFactory.all)
+    func updateStampsTimestamp(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let originalDate = Date(timeIntervalSince1970: 1)
+        var item = Item(
+            locationID: kitchen.id,
+            name: "Bread",
+            createdAt: originalDate,
+            updatedAt: originalDate
+        )
+        try await itemRepo.create(item)
+
+        item.name = "Sourdough"
+        item.updatedAt = Date(timeIntervalSince1970: 2)  // caller value to be overwritten
+        try await itemRepo.update(item)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.name == "Sourdough")
+        #expect(after.createdAt == originalDate)
+        #expect(after.updatedAt > Date(timeIntervalSince1970: 2))
+    }
+
+    @Test(
+        "search matches case-insensitively and trims empty queries",
+        arguments: RepositoryFactory.all)
+    func searchMatchesAndTrims(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Cherry tomatoes"))
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Tomato paste"))
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Rice"))
+
+        let hits = try await itemRepo.search("toma", in: house.id)
+        #expect(Set(hits.map(\.name)) == ["Cherry tomatoes", "Tomato paste"])
+
+        let empty = try await itemRepo.search("   ", in: house.id)
+        #expect(empty.isEmpty)
+    }
+
+    @Test(
+        "search is scoped to the household, not the location",
+        arguments: RepositoryFactory.all)
+    func searchScopedToHousehold(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let mine = try await household.currentHousehold()
+        let elsewhere = Household(name: "Mom's Pantry")
+        let myKitchen = Location(householdID: mine.id, name: "Kitchen")
+        let momsKitchen = Location(householdID: elsewhere.id, name: "Mom's Kitchen")
+        try await locationRepo.create(myKitchen)
+        try await locationRepo.create(momsKitchen)
+
+        try await itemRepo.create(Item(locationID: myKitchen.id, name: "My Tomatoes"))
+        try await itemRepo.create(Item(locationID: momsKitchen.id, name: "Mom's Tomatoes"))
+
+        let hits = try await itemRepo.search("tomato", in: mine.id)
+        #expect(hits.map(\.name) == ["My Tomatoes"])
+    }
+
+    @Test(
+        "delete removes the item",
+        arguments: RepositoryFactory.all)
+    func deleteRemovesItem(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+        let bread = Item(locationID: kitchen.id, name: "Bread")
+        try await itemRepo.create(bread)
+
+        try await itemRepo.delete(id: bread.id)
+        #expect(try await itemRepo.item(id: bread.id) == nil)
+        #expect(try await itemRepo.items(in: kitchen.id).isEmpty)
+    }
+
+    @Test(
+        "item(id:) returns nil for an unknown id",
+        arguments: RepositoryFactory.all)
+    func itemByUnknownIDIsNil(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let itemRepo = bundle.item
+        let unknown = try await itemRepo.item(id: UUID())
+        #expect(unknown == nil)
+    }
+}
+
+@Suite("ItemPhotoRepository contract")
+struct ItemPhotoRepositoryContractTests {
+    @Test(
+        "create + photos(for:) returns the photo strip",
+        arguments: RepositoryFactory.all)
+    func createAndList(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let photoRepo = bundle.photo
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+        let waffles = Item(locationID: kitchen.id, name: "Waffle mix")
+        try await itemRepo.create(waffles)
+
+        let primary = ItemPhoto(
+            itemID: waffles.id, caption: "front of box", sortOrder: 0
+        )
+        let secondary = ItemPhoto(
+            itemID: waffles.id, caption: "ingredients", sortOrder: 1
+        )
+        try await photoRepo.create(primary)
+        try await photoRepo.create(secondary)
+
+        let strip = try await photoRepo.photos(for: waffles.id)
+        #expect(strip.map(\.id) == [primary.id, secondary.id])
+        #expect(strip.first?.caption == "front of box")
+    }
+
+    @Test(
+        "photos(for:) sorts by sortOrder then createdAt",
+        arguments: RepositoryFactory.all)
+    func sortingByOrderThenDate(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let photoRepo = bundle.photo
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+        let waffles = Item(locationID: kitchen.id, name: "Waffle mix")
+        try await itemRepo.create(waffles)
+        let now = Date()
+
+        let back = ItemPhoto(
+            itemID: waffles.id,
+            caption: "back",
+            sortOrder: 1,
+            createdAt: now
+        )
+        let front = ItemPhoto(
+            itemID: waffles.id,
+            caption: "front",
+            sortOrder: 0,
+            createdAt: now.addingTimeInterval(60)
+        )
+        let lid = ItemPhoto(
+            itemID: waffles.id,
+            caption: "lid",
+            sortOrder: 0,
+            createdAt: now
+        )
+
+        try await photoRepo.create(back)
+        try await photoRepo.create(front)
+        try await photoRepo.create(lid)
+
+        let strip = try await photoRepo.photos(for: waffles.id)
+        #expect(strip.map(\.id) == [lid.id, front.id, back.id])
+    }
+
+    @Test(
+        "delete removes the photo",
+        arguments: RepositoryFactory.all)
+    func deleteRemovesPhoto(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let photoRepo = bundle.photo
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+        let waffles = Item(locationID: kitchen.id, name: "Waffle mix")
+        try await itemRepo.create(waffles)
+        let photo = ItemPhoto(itemID: waffles.id)
+        try await photoRepo.create(photo)
+
+        try await photoRepo.delete(id: photo.id)
+        #expect(try await photoRepo.photos(for: waffles.id).isEmpty)
+    }
+}
+
+/// Cascade-delete is a Core Data behavior driven by the model's
+/// `deletionRule="Cascade"` rule, not part of the protocol contract —
+/// the in-memory mocks deliberately don't simulate it (they're intended
+/// as fast fixtures for the layers above persistence). These tests pin
+/// the schema's cascade rules so a future model edit can't silently
+/// drop them.
+@Suite("Core Data cascade deletes")
+struct CascadeDeleteTests {
+    @Test("Deleting a Location cascades through its Items to their ItemPhotos")
+    func locationCascadesToItemsAndPhotos() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let household = CoreDataHouseholdRepository(container: container)
+        let locationRepo = CoreDataLocationRepository(container: container)
+        let itemRepo = CoreDataItemRepository(container: container)
+        let photoRepo = CoreDataItemPhotoRepository(container: container)
+
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let bread = Item(locationID: kitchen.id, name: "Bread")
+        let milk = Item(locationID: kitchen.id, name: "Milk")
+        try await itemRepo.create(bread)
+        try await itemRepo.create(milk)
+
+        let breadPhoto = ItemPhoto(itemID: bread.id, caption: "front")
+        let milkPhoto = ItemPhoto(itemID: milk.id, caption: "front")
+        try await photoRepo.create(breadPhoto)
+        try await photoRepo.create(milkPhoto)
+
+        // Sanity check before the cascade.
+        #expect(try await itemRepo.items(in: kitchen.id).count == 2)
+        #expect(try await photoRepo.photos(for: bread.id).count == 1)
+        #expect(try await photoRepo.photos(for: milk.id).count == 1)
+
+        try await locationRepo.delete(id: kitchen.id)
+
+        #expect(try await itemRepo.items(in: kitchen.id).isEmpty)
+        #expect(try await itemRepo.item(id: bread.id) == nil)
+        #expect(try await itemRepo.item(id: milk.id) == nil)
+        #expect(try await photoRepo.photos(for: bread.id).isEmpty)
+        #expect(try await photoRepo.photos(for: milk.id).isEmpty)
+    }
+
+    @Test("Deleting an Item cascades to its ItemPhotos")
+    func itemCascadesToPhotos() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let household = CoreDataHouseholdRepository(container: container)
+        let locationRepo = CoreDataLocationRepository(container: container)
+        let itemRepo = CoreDataItemRepository(container: container)
+        let photoRepo = CoreDataItemPhotoRepository(container: container)
+
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+        let bread = Item(locationID: kitchen.id, name: "Bread")
+        try await itemRepo.create(bread)
+        try await photoRepo.create(ItemPhoto(itemID: bread.id, caption: "front"))
+        try await photoRepo.create(ItemPhoto(itemID: bread.id, caption: "back"))
+
+        #expect(try await photoRepo.photos(for: bread.id).count == 2)
+
+        try await itemRepo.delete(id: bread.id)
+        #expect(try await photoRepo.photos(for: bread.id).isEmpty)
     }
 }

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -58,3 +58,107 @@ public actor InMemoryLocationRepository: LocationRepository {
         locations.removeValue(forKey: id)
     }
 }
+
+/// Pure-Swift `ItemRepository` for SwiftUI previews and tests.
+///
+/// `update(_:)` stamps `updatedAt = Date()` per the protocol contract.
+/// `create(_:)` honors the caller-supplied `updatedAt` so deterministic
+/// fixture data still works.
+///
+/// Search resolution depends on knowing each item's household. Since
+/// `Item` only carries `locationID`, the in-memory impl needs a way to
+/// resolve `locationID → householdID` — pass in a `LocationRepository`
+/// (any conforming type) at init time. The resolver runs once per
+/// `search(_:in:)` call.
+public actor InMemoryItemRepository: ItemRepository {
+    private var items: [Item.ID: Item] = [:]
+    private let locationLookup: @Sendable (Location.ID) async throws -> Location?
+
+    /// `locationLookup` defaults to "no household scoping" — search will
+    /// match items in any household. Provide a real lookup (typically
+    /// `locationRepo.location(id:)`) when scoping matters.
+    public init(
+        initial: [Item] = [],
+        locationLookup: @Sendable @escaping (Location.ID) async throws -> Location? = { _ in nil }
+    ) {
+        for item in initial {
+            items[item.id] = item
+        }
+        self.locationLookup = locationLookup
+    }
+
+    public func items(in locationID: Location.ID) async throws -> [Item] {
+        items.values
+            .filter { $0.locationID == locationID }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    public func item(id: Item.ID) async throws -> Item? {
+        items[id]
+    }
+
+    public func search(_ query: String, in householdID: Household.ID) async throws -> [Item] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return [] }
+        let needle = trimmed.lowercased()
+
+        var results: [Item] = []
+        for item in items.values where item.name.lowercased().contains(needle) {
+            let location = try await locationLookup(item.locationID)
+            if location?.householdID == householdID {
+                results.append(item)
+            }
+        }
+        return results.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
+    public func create(_ item: Item) async throws {
+        items[item.id] = item
+    }
+
+    public func update(_ item: Item) async throws {
+        var stamped = item
+        stamped.updatedAt = Date()
+        items[item.id] = stamped
+    }
+
+    public func delete(id: Item.ID) async throws {
+        items.removeValue(forKey: id)
+    }
+}
+
+/// Pure-Swift `ItemPhotoRepository` for SwiftUI previews and tests.
+public actor InMemoryItemPhotoRepository: ItemPhotoRepository {
+    private var photos: [ItemPhoto.ID: ItemPhoto] = [:]
+
+    public init(initial: [ItemPhoto] = []) {
+        for photo in initial {
+            photos[photo.id] = photo
+        }
+    }
+
+    public func photos(for itemID: Item.ID) async throws -> [ItemPhoto] {
+        photos.values
+            .filter { $0.itemID == itemID }
+            .sorted { lhs, rhs in
+                if lhs.sortOrder == rhs.sortOrder {
+                    return lhs.createdAt < rhs.createdAt
+                }
+                return lhs.sortOrder < rhs.sortOrder
+            }
+    }
+
+    public func create(_ photo: ItemPhoto) async throws {
+        photos[photo.id] = photo
+    }
+
+    public func update(_ photo: ItemPhoto) async throws {
+        photos[photo.id] = photo
+    }
+
+    public func delete(id: ItemPhoto.ID) async throws {
+        photos.removeValue(forKey: id)
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemPhotoRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemPhotoRepository.swift
@@ -1,0 +1,105 @@
+import CoreData
+import Foundation
+import NakedPantreeDomain
+
+/// `ItemPhotoRepository` backed by `NSPersistentContainer`. Same
+/// Sendable trade-off as `CoreDataHouseholdRepository` — see that file.
+public final class CoreDataItemPhotoRepository: ItemPhotoRepository, @unchecked Sendable {
+    private let container: NSPersistentContainer
+
+    public init(container: NSPersistentContainer) {
+        self.container = container
+    }
+
+    public func photos(for itemID: Item.ID) async throws -> [ItemPhoto] {
+        try await container.performBackgroundTask { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemPhotoEntity")
+            request.predicate = NSPredicate(format: "item.id == %@", itemID as CVarArg)
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "sortOrder", ascending: true),
+                NSSortDescriptor(key: "createdAt", ascending: true),
+            ]
+            return try context.fetch(request).map(Self.makePhoto)
+        }
+    }
+
+    public func create(_ photo: ItemPhoto) async throws {
+        try await container.performBackgroundTask { context in
+            let row = NSEntityDescription.insertNewObject(
+                forEntityName: "ItemPhotoEntity",
+                into: context
+            )
+            try Self.assignAttributes(photo, to: row)
+            try Self.attachItem(photo.itemID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func update(_ photo: ItemPhoto) async throws {
+        try await container.performBackgroundTask { context in
+            let row =
+                try Self.fetchPhotoRow(id: photo.id, in: context)
+                ?? NSEntityDescription.insertNewObject(
+                    forEntityName: "ItemPhotoEntity",
+                    into: context
+                )
+            try Self.assignAttributes(photo, to: row)
+            try Self.attachItem(photo.itemID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func delete(id: ItemPhoto.ID) async throws {
+        try await container.performBackgroundTask { context in
+            guard let row = try Self.fetchPhotoRow(id: id, in: context) else { return }
+            context.delete(row)
+            try context.save()
+        }
+    }
+
+    private static func assignAttributes(_ photo: ItemPhoto, to row: NSManagedObject) throws {
+        row.setValue(photo.id, forKey: "id")
+        row.setValue(photo.imageData, forKey: "imageData")
+        row.setValue(photo.thumbnailData, forKey: "thumbnailData")
+        row.setValue(photo.caption, forKey: "caption")
+        row.setValue(photo.sortOrder, forKey: "sortOrder")
+        row.setValue(photo.createdAt, forKey: "createdAt")
+    }
+
+    private static func attachItem(
+        _ itemID: Item.ID,
+        to row: NSManagedObject,
+        in context: NSManagedObjectContext
+    ) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+        request.predicate = NSPredicate(format: "id == %@", itemID as CVarArg)
+        request.fetchLimit = 1
+        let item = try context.fetch(request).first
+        row.setValue(item, forKey: "item")
+    }
+
+    private static func fetchPhotoRow(
+        id: ItemPhoto.ID,
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "ItemPhotoEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private static func makePhoto(from row: NSManagedObject) -> ItemPhoto {
+        let itemID =
+            (row.value(forKey: "item") as? NSManagedObject)?
+            .value(forKey: "id") as? UUID ?? UUID()
+        return ItemPhoto(
+            id: row.value(forKey: "id") as? UUID ?? UUID(),
+            itemID: itemID,
+            imageData: row.value(forKey: "imageData") as? Data,
+            thumbnailData: row.value(forKey: "thumbnailData") as? Data,
+            caption: row.value(forKey: "caption") as? String,
+            sortOrder: row.value(forKey: "sortOrder") as? Int16 ?? 0,
+            createdAt: row.value(forKey: "createdAt") as? Date ?? Date()
+        )
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
@@ -1,0 +1,144 @@
+import CoreData
+import Foundation
+import NakedPantreeDomain
+
+/// `ItemRepository` backed by `NSPersistentContainer`. Same Sendable
+/// trade-off as `CoreDataHouseholdRepository` — see that file.
+///
+/// `update(_:)` stamps `updatedAt = Date()` before saving, per the
+/// protocol contract. The caller's `updatedAt` is overwritten on the way
+/// in. `create(_:)` honors the caller-supplied `updatedAt` so seeded
+/// fixture data with deterministic timestamps still works.
+public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
+    private let container: NSPersistentContainer
+
+    public init(container: NSPersistentContainer) {
+        self.container = container
+    }
+
+    public func items(in locationID: Location.ID) async throws -> [Item] {
+        try await container.performBackgroundTask { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+            request.predicate = NSPredicate(format: "location.id == %@", locationID as CVarArg)
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "createdAt", ascending: true)
+            ]
+            return try context.fetch(request).map(Self.makeItem)
+        }
+    }
+
+    public func item(id: Item.ID) async throws -> Item? {
+        try await container.performBackgroundTask { context in
+            try Self.fetchItemRow(id: id, in: context).map(Self.makeItem)
+        }
+    }
+
+    public func search(_ query: String, in householdID: Household.ID) async throws -> [Item] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return [] }
+        return try await container.performBackgroundTask { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+            request.predicate = NSPredicate(
+                format: "location.household.id == %@ AND name CONTAINS[cd] %@",
+                householdID as CVarArg,
+                trimmed
+            )
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "name", ascending: true)
+            ]
+            return try context.fetch(request).map(Self.makeItem)
+        }
+    }
+
+    public func create(_ item: Item) async throws {
+        try await container.performBackgroundTask { context in
+            let row = NSEntityDescription.insertNewObject(
+                forEntityName: "ItemEntity",
+                into: context
+            )
+            try Self.assignAttributes(item, to: row, stampUpdatedAt: false)
+            try Self.attachLocation(item.locationID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func update(_ item: Item) async throws {
+        try await container.performBackgroundTask { context in
+            let row =
+                try Self.fetchItemRow(id: item.id, in: context)
+                ?? NSEntityDescription.insertNewObject(
+                    forEntityName: "ItemEntity",
+                    into: context
+                )
+            try Self.assignAttributes(item, to: row, stampUpdatedAt: true)
+            try Self.attachLocation(item.locationID, to: row, in: context)
+            try context.save()
+        }
+    }
+
+    public func delete(id: Item.ID) async throws {
+        try await container.performBackgroundTask { context in
+            guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
+            context.delete(row)
+            try context.save()
+        }
+    }
+
+    private static func assignAttributes(
+        _ item: Item,
+        to row: NSManagedObject,
+        stampUpdatedAt: Bool
+    ) throws {
+        row.setValue(item.id, forKey: "id")
+        row.setValue(item.name, forKey: "name")
+        row.setValue(item.quantity, forKey: "quantity")
+        row.setValue(item.unit.rawValue, forKey: "unitRaw")
+        row.setValue(item.expiresAt, forKey: "expiresAt")
+        row.setValue(item.notes, forKey: "notes")
+        row.setValue(item.createdAt, forKey: "createdAt")
+        row.setValue(stampUpdatedAt ? Date() : item.updatedAt, forKey: "updatedAt")
+    }
+
+    /// Mirrors `CoreDataLocationRepository.attachHousehold` — if the
+    /// referenced location row doesn't exist yet, we don't insert a
+    /// stub. Items must be created against a real location; the
+    /// alternative leaves dangling rows on a typo'd `locationID`.
+    private static func attachLocation(
+        _ locationID: Location.ID,
+        to row: NSManagedObject,
+        in context: NSManagedObjectContext
+    ) throws {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "LocationEntity")
+        request.predicate = NSPredicate(format: "id == %@", locationID as CVarArg)
+        request.fetchLimit = 1
+        let location = try context.fetch(request).first
+        row.setValue(location, forKey: "location")
+    }
+
+    private static func fetchItemRow(
+        id: Item.ID,
+        in context: NSManagedObjectContext
+    ) throws -> NSManagedObject? {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 1
+        return try context.fetch(request).first
+    }
+
+    private static func makeItem(from row: NSManagedObject) -> Item {
+        let locationID =
+            (row.value(forKey: "location") as? NSManagedObject)?
+            .value(forKey: "id") as? UUID ?? UUID()
+        return Item(
+            id: row.value(forKey: "id") as? UUID ?? UUID(),
+            locationID: locationID,
+            name: row.value(forKey: "name") as? String ?? "",
+            quantity: row.value(forKey: "quantity") as? Int32 ?? 1,
+            unit: Unit(rawValue: row.value(forKey: "unitRaw") as? String ?? "count"),
+            expiresAt: row.value(forKey: "expiresAt") as? Date,
+            notes: row.value(forKey: "notes") as? String,
+            createdAt: row.value(forKey: "createdAt") as? Date ?? Date(),
+            updatedAt: row.value(forKey: "updatedAt") as? Date ?? Date()
+        )
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
+++ b/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
@@ -13,5 +13,27 @@
         <attribute name="name" attributeType="String"/>
         <attribute name="sortOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="HouseholdEntity" inverseName="locations" inverseEntity="HouseholdEntity"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ItemEntity" inverseName="location" inverseEntity="ItemEntity"/>
+    </entity>
+    <entity name="ItemEntity" representedClassName="ItemEntity" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="expiresAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="quantity" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="unitRaw" attributeType="String" defaultValueString="count"/>
+        <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="location" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="LocationEntity" inverseName="items" inverseEntity="LocationEntity"/>
+        <relationship name="photos" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ItemPhotoEntity" inverseName="item" inverseEntity="ItemPhotoEntity"/>
+    </entity>
+    <entity name="ItemPhotoEntity" representedClassName="ItemPhotoEntity" syncable="YES">
+        <attribute name="caption" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imageData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="sortOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="thumbnailData" optional="YES" attributeType="Binary"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ItemEntity" inverseName="photos" inverseEntity="ItemEntity"/>
     </entity>
 </model>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ Every later phase assumes this skeleton exists.
 - [ ] Search returns results across all locations.
 - [ ] Every user-facing string passes the `DESIGN_GUIDELINES.md` §10
       checklist.
-- [ ] Repository protocol tests pass with both the Core Data
+- [x] Repository protocol tests pass with both the Core Data
       implementation and an in-memory mock.
 
 **Sub-milestones**
@@ -106,8 +106,8 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 | --- | --- | --- |
 | 1.1 | Domain types + repository protocols | ✅ Merged ([apps#10](https://github.com/ellisandy/NakedPantree/pull/10)) |
 | 1.2a | Core Data stack + `Household` and `Location` repos | ✅ Merged ([apps#11](https://github.com/ellisandy/NakedPantree/pull/11)) |
-| 1.2b | `Item` and `ItemPhoto` repos + cascade-delete tests | ⬜ Next |
-| 1.3 | `NavigationSplitView` shell (sidebar / content / detail) | ⬜ |
+| 1.2b | `Item` and `ItemPhoto` repos + cascade-delete tests | ✅ Merged ([apps#13](https://github.com/ellisandy/NakedPantree/pull/13)) |
+| 1.3 | `NavigationSplitView` shell (sidebar / content / detail) | ⬜ Next |
 | 1.4 | CRUD wiring for `Location`s and `Item`s | ⬜ |
 | 1.5 | Search across locations + first-launch bootstrap | ⬜ |
 


### PR DESCRIPTION
## Summary

Completes the local persistence layer for Phase 1 ([ROADMAP.md](https://github.com/ellisandy/NakedPantree/blob/main/ROADMAP.md)). With this PR all four repository protocols have working Core Data and in-memory implementations behind a shared contract test suite.

### Schema additions to `NakedPantree.xcdatamodeld`

- `ItemEntity` with the attributes from [ARCHITECTURE.md §4](https://github.com/ellisandy/NakedPantree/blob/main/ARCHITECTURE.md). Includes the Cascade-rule `photos` relationship.
- `ItemPhotoEntity` with `imageData` set to allow **External Storage** so Core Data offloads to the file system (Phase 5 photo work depends on this); `thumbnailData` stays inline.
- Cascade rules on `Location → Item` and `Item → ItemPhoto`. Inverse relationships are Nullify on the child side, optional and bidirectional per CloudKit's eventual requirements.

### Repositories

- **`CoreDataItemRepository`** — `update(_:)` stamps `updatedAt = Date()` before saving (per the protocol contract); `create(_:)` honors the caller's `updatedAt` so seeded fixtures with deterministic timestamps still work. Search predicate: `name CONTAINS[cd] %@` scoped through `location.household.id`.
- **`CoreDataItemPhotoRepository`** — straight CRUD; sorts by `sortOrder` then `createdAt`.
- **`InMemoryItemRepository`** — actor-backed; takes a `locationLookup` closure at init so `search(_:in:)` can resolve `locationID → householdID` without coupling to a concrete `LocationRepository` type.
- **`InMemoryItemPhotoRepository`** — actor-backed CRUD.

### Tests

- **13 new contract tests** across `ItemRepository` and `ItemPhotoRepository`, parameterized over both factories. The parameterization tuple grew past swiftlint's `large_tuple` limit, so it's now a `RepositoryBundle` struct.
- **2 cascade-delete tests** on the Core Data factory only:
  - Deleting a `Location` cascades through its `Item`s to their `ItemPhoto`s.
  - Deleting an `Item` cascades to its `ItemPhoto`s.

  These pin the schema's `deletionRule="Cascade"` rules so a future model edit can't silently drop them. The in-memory mocks deliberately don't simulate cascade — they're fast fixtures for the layers above persistence, not production stores.
- **Dedicated `update stamps updatedAt` test** verifies the protocol-level contract that the caller's `updatedAt` is overwritten.

### Roadmap

- 1.2b row marked merged; 1.3 (`NavigationSplitView` shell) marked as next.
- Phase 1 exit criterion "Repository protocol tests pass with both the Core Data implementation and an in-memory mock" is now ticked — all four repos covered.

## Test plan

- [x] `xcodebuild test -scheme NakedPantree` passes locally — 24 unit tests + UI test.
- [x] `swift test --package-path Packages/Core` still green for domain-only tests.
- [x] `swift-format lint --strict` (in `swift:6.0` container) clean.
- [x] `swiftlint --strict` clean.
- [x] CI green on PR.

## What's deferred

- **Merge-policy property-trump test** — still deferred to Phase 2. Single-context local writes can't trigger conflict resolution; CloudKit makes it real.
- **Phase 1 user-facing exit criteria** (app launches to default household, CRUD via UI, search across locations, voice rules) — those land in 1.3/1.4/1.5 once the UI shell exists.

## Out of scope

- Phase 1.3+: NavigationSplitView shell, CRUD wiring, search, first-launch bootstrap.