### PR TITLE
Phase 1.4: Location and Item CRUD wired through the shell

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -1,12 +1,13 @@
 import NakedPantreeDomain
 import SwiftUI
 
-/// Detail column. Read-only in Phase 1.3 — editing arrives in 1.4.
+/// Detail column. Read-only by default; tap Edit to open the item form.
 struct ItemDetailView: View {
     let itemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
     @State private var item: Item?
+    @State private var formMode: ItemFormView.Mode?
 
     var body: some View {
         Group {
@@ -23,6 +24,20 @@ struct ItemDetailView: View {
             }
         }
         .navigationTitle(item?.name ?? "")
+        .toolbar {
+            if let item {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Edit") {
+                        formMode = .edit(item)
+                    }
+                }
+            }
+        }
+        .sheet(item: $formMode) { mode in
+            ItemFormView(mode: mode) {
+                Task { await reload() }
+            }
+        }
         .task(id: itemID) {
             await reload()
         }

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -24,7 +24,7 @@ struct ItemFormView: View {
     @State private var quantity: Int32 = 1
     @State private var unit: NakedPantreeDomain.Unit = .count
     @State private var hasExpiry: Bool = false
-    @State private var expiresAt: Date = .now.addingTimeInterval(60 * 60 * 24 * 7)
+    @State private var expiresAt: Date = .now.addingTimeInterval(TimeInterval(60 * 60 * 24 * 7))
     @State private var notes: String = ""
     @State private var isSaving = false
     @State private var saveError: String?
@@ -196,7 +196,7 @@ extension NakedPantreeDomain.Unit {
                 name: "Sourdough",
                 quantity: 2,
                 unit: .count,
-                expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 3),
+                expiresAt: .now.addingTimeInterval(TimeInterval(60 * 60 * 24 * 3)),
                 notes: "Last loaf in the freezer"
             )
         ),

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -1,0 +1,206 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Modal form for creating or editing an `Item`.
+struct ItemFormView: View {
+    enum Mode: Identifiable, Hashable {
+        case create(locationID: Location.ID)
+        case edit(Item)
+
+        var id: String {
+            switch self {
+            case .create(let id): "create-\(id.uuidString)"
+            case .edit(let item): "edit-\(item.id.uuidString)"
+            }
+        }
+    }
+
+    let mode: Mode
+    let onSaved: @MainActor () -> Void
+
+    @Environment(\.repositories) private var repositories
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String = ""
+    @State private var quantity: Int32 = 1
+    @State private var unit: NakedPantreeDomain.Unit = .count
+    @State private var hasExpiry: Bool = false
+    @State private var expiresAt: Date = .now.addingTimeInterval(60 * 60 * 24 * 7)
+    @State private var notes: String = ""
+    @State private var isSaving = false
+    @State private var saveError: String?
+
+    private let unitOptions: [NakedPantreeDomain.Unit] = [
+        .count, .gram, .kilogram, .ounce, .pound,
+        .milliliter, .liter, .fluidOunce, .package,
+    ]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("e.g. Tomatoes", text: $name)
+                        .textInputAutocapitalization(.sentences)
+                        .autocorrectionDisabled()
+                }
+
+                Section("Quantity") {
+                    Stepper(value: $quantity, in: 1...9999) {
+                        Text("\(quantity) \(unit.displayLabel)")
+                    }
+                    Picker("Unit", selection: $unit) {
+                        ForEach(unitOptions, id: \.self) { option in
+                            Text(option.pickerLabel).tag(option)
+                        }
+                    }
+                }
+
+                Section("Expiry") {
+                    Toggle("Has expiry date", isOn: $hasExpiry)
+                    if hasExpiry {
+                        DatePicker(
+                            "Expires",
+                            selection: $expiresAt,
+                            displayedComponents: .date
+                        )
+                    }
+                }
+
+                Section("Notes") {
+                    TextField("Optional", text: $notes, axis: .vertical)
+                        .lineLimit(2...6)
+                }
+
+                if let saveError {
+                    Section {
+                        Text(saveError)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(saveButtonTitle) {
+                        Task { await save() }
+                    }
+                    .disabled(!isValid || isSaving)
+                }
+            }
+            .onAppear(perform: prefill)
+        }
+    }
+
+    private var navigationTitle: String {
+        switch mode {
+        case .create: "New Item"
+        case .edit: "Edit Item"
+        }
+    }
+
+    private var saveButtonTitle: String {
+        switch mode {
+        case .create: "Add"
+        case .edit: "Save"
+        }
+    }
+
+    private var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func prefill() {
+        if case .edit(let item) = mode {
+            name = item.name
+            quantity = item.quantity
+            unit = item.unit
+            if let expiry = item.expiresAt {
+                hasExpiry = true
+                expiresAt = expiry
+            }
+            notes = item.notes ?? ""
+        }
+    }
+
+    @MainActor
+    private func save() async {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedNotes: String? = trimmedNotes.isEmpty ? nil : trimmedNotes
+        let resolvedExpiry: Date? = hasExpiry ? expiresAt : nil
+
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            switch mode {
+            case .create(let locationID):
+                let item = Item(
+                    locationID: locationID,
+                    name: trimmedName,
+                    quantity: quantity,
+                    unit: unit,
+                    expiresAt: resolvedExpiry,
+                    notes: resolvedNotes
+                )
+                try await repositories.item.create(item)
+            case .edit(let original):
+                var updated = original
+                updated.name = trimmedName
+                updated.quantity = quantity
+                updated.unit = unit
+                updated.expiresAt = resolvedExpiry
+                updated.notes = resolvedNotes
+                try await repositories.item.update(updated)
+            }
+            onSaved()
+            dismiss()
+        } catch {
+            saveError = "Couldn't save. Try again."
+        }
+    }
+}
+
+extension NakedPantreeDomain.Unit {
+    /// Longer label used in dropdowns, where "g" alone is too cryptic.
+    var pickerLabel: String {
+        switch self {
+        case .count: "Count"
+        case .gram: "Grams (g)"
+        case .kilogram: "Kilograms (kg)"
+        case .ounce: "Ounces (oz)"
+        case .pound: "Pounds (lb)"
+        case .milliliter: "Milliliters (ml)"
+        case .liter: "Liters (L)"
+        case .fluidOunce: "Fluid ounces (fl oz)"
+        case .package: "Package"
+        case .unknown(let raw): raw.capitalized
+        }
+    }
+}
+
+#Preview("Create") {
+    ItemFormView(mode: .create(locationID: UUID()), onSaved: {})
+        .environment(\.repositories, .makePreview())
+}
+
+#Preview("Edit") {
+    ItemFormView(
+        mode: .edit(
+            Item(
+                locationID: UUID(),
+                name: "Sourdough",
+                quantity: 2,
+                unit: .count,
+                expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 3),
+                notes: "Last loaf in the freezer"
+            )
+        ),
+        onSaved: {}
+    )
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -1,9 +1,9 @@
 import NakedPantreeDomain
 import SwiftUI
 
-/// Content column. Lists items for the selected sidebar entry. Phase 1.3
-/// is read-only — create / edit / delete arrive in 1.4. Smart Lists are
-/// stubbed to an empty state until 1.5 / Phase 6.
+/// Content column. Lists items for the selected sidebar entry, with
+/// `+` to create and swipe-to-delete. Smart Lists are stubbed to an
+/// empty state until 1.5 / Phase 6.
 struct ItemsView: View {
     let selection: SidebarSelection?
     @Binding var selectedItemID: Item.ID?
@@ -11,6 +11,8 @@ struct ItemsView: View {
     @Environment(\.repositories) private var repositories
     @State private var items: [Item] = []
     @State private var locationName: String?
+    @State private var formMode: ItemFormView.Mode?
+    @State private var pendingDelete: Item?
 
     var body: some View {
         Group {
@@ -24,8 +26,36 @@ struct ItemsView: View {
             }
         }
         .navigationTitle(title)
-        .navigationDestination(for: Item.ID.self) { itemID in
-            ItemDetailView(itemID: itemID)
+        .toolbar {
+            if case .location(let locationID) = selection {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        formMode = .create(locationID: locationID)
+                    } label: {
+                        Label("New Item", systemImage: "plus")
+                    }
+                }
+            }
+        }
+        .sheet(item: $formMode) { mode in
+            ItemFormView(mode: mode) {
+                if case .location(let id) = selection {
+                    Task { await reload(locationID: id) }
+                }
+            }
+        }
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible,
+            presenting: pendingDelete
+        ) { item in
+            Button("Delete", role: .destructive) {
+                Task { await delete(item) }
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
         }
     }
 
@@ -37,11 +67,24 @@ struct ItemsView: View {
         }
     }
 
+    private var deleteConfirmationTitle: String {
+        if let pendingDelete {
+            return "Delete \(pendingDelete.name)?"
+        }
+        return ""
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { newValue in
+                if !newValue { pendingDelete = nil }
+            }
+        )
+    }
+
     @ViewBuilder
     private func smartListContent(_ list: SmartList) -> some View {
-        // Smart-list projections (Expiring Soon, Recently Added) come in
-        // a later milestone; the All Items aggregate ships with search
-        // in 1.5. Until then, empty state is honest.
         ContentUnavailableView(
             list.title,
             systemImage: list.systemImage,
@@ -55,7 +98,7 @@ struct ItemsView: View {
             ContentUnavailableView(
                 "No items here yet",
                 systemImage: "tray",
-                description: Text("Items will land here once we wire up adding them.")
+                description: Text("Tap + to add the first one.")
             )
             .task(id: id) { await reload(locationID: id) }
         } else {
@@ -63,6 +106,19 @@ struct ItemsView: View {
                 ForEach(items) { item in
                     ItemRow(item: item)
                         .tag(item.id)
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                pendingDelete = item
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                            Button {
+                                formMode = .edit(item)
+                            } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+                            .tint(.indigo)
+                        }
                 }
             }
             .task(id: id) { await reload(locationID: id) }
@@ -81,6 +137,22 @@ struct ItemsView: View {
             items = try await repositories.item.items(in: locationID)
         } catch {
             items = []
+        }
+    }
+
+    private func delete(_ item: Item) async {
+        pendingDelete = nil
+        if selectedItemID == item.id { selectedItemID = nil }
+        do {
+            try await repositories.item.delete(id: item.id)
+            if case .location(let id) = selection {
+                await reload(locationID: id)
+            }
+        } catch {
+            // Soft fail — reload to drop stale optimistic state.
+            if case .location(let id) = selection {
+                await reload(locationID: id)
+            }
         }
     }
 }

--- a/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
+++ b/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
@@ -1,0 +1,154 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Modal form for creating or editing a `Location`. Used from
+/// `SidebarView`'s "+" toolbar action and its row-edit affordance.
+struct LocationFormView: View {
+    enum Mode: Identifiable, Hashable {
+        case create(householdID: Household.ID)
+        case edit(Location)
+
+        var id: String {
+            switch self {
+            case .create(let id): "create-\(id.uuidString)"
+            case .edit(let location): "edit-\(location.id.uuidString)"
+            }
+        }
+    }
+
+    let mode: Mode
+    let onSaved: @MainActor () -> Void
+
+    @Environment(\.repositories) private var repositories
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String = ""
+    @State private var kind: LocationKind = .pantry
+    @State private var isSaving = false
+    @State private var saveError: String?
+
+    private let kindOptions: [LocationKind] = [.pantry, .fridge, .freezer, .dryGoods, .other]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Name") {
+                    TextField("e.g. Kitchen Pantry", text: $name)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                        .submitLabel(.done)
+                }
+
+                Section("Type") {
+                    Picker("Type", selection: $kind) {
+                        ForEach(kindOptions, id: \.self) { option in
+                            Label(option.displayName, systemImage: option.systemImage)
+                                .tag(option)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                    .labelsHidden()
+                }
+
+                if let saveError {
+                    Section {
+                        Text(saveError)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isSaving)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(saveButtonTitle) {
+                        Task { await save() }
+                    }
+                    .disabled(!isValid || isSaving)
+                }
+            }
+            .onAppear(perform: prefill)
+        }
+    }
+
+    private var navigationTitle: String {
+        switch mode {
+        case .create: "New Location"
+        case .edit: "Edit Location"
+        }
+    }
+
+    private var saveButtonTitle: String {
+        switch mode {
+        case .create: "Add"
+        case .edit: "Save"
+        }
+    }
+
+    private var isValid: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func prefill() {
+        if case .edit(let location) = mode {
+            name = location.name
+            kind = location.kind
+        }
+    }
+
+    @MainActor
+    private func save() async {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        isSaving = true
+        defer { isSaving = false }
+
+        do {
+            switch mode {
+            case .create(let householdID):
+                let location = Location(householdID: householdID, name: trimmed, kind: kind)
+                try await repositories.location.create(location)
+            case .edit(let original):
+                var updated = original
+                updated.name = trimmed
+                updated.kind = kind
+                try await repositories.location.update(updated)
+            }
+            onSaved()
+            dismiss()
+        } catch {
+            saveError = "Couldn't save. Try again."
+        }
+    }
+}
+
+extension LocationKind {
+    /// Capitalized human label used in pickers and detail headers.
+    var displayName: String {
+        switch self {
+        case .pantry: "Pantry"
+        case .fridge: "Fridge"
+        case .freezer: "Freezer"
+        case .dryGoods: "Dry Goods"
+        case .other: "Other"
+        case .unknown(let raw): raw.capitalized
+        }
+    }
+}
+
+#Preview("Create") {
+    LocationFormView(mode: .create(householdID: UUID()), onSaved: {})
+        .environment(\.repositories, .makePreview())
+}
+
+#Preview("Edit") {
+    LocationFormView(
+        mode: .edit(
+            Location(householdID: UUID(), name: "Kitchen", kind: .pantry)
+        ),
+        onSaved: {}
+    )
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -8,7 +8,10 @@ struct SidebarView: View {
     @Environment(\.repositories) private var repositories
 
     @State private var locations: [Location] = []
+    @State private var householdID: Household.ID?
     @State private var loadError: Error?
+    @State private var formMode: LocationFormView.Mode?
+    @State private var pendingDelete: Location?
 
     var body: some View {
         List(selection: $selection) {
@@ -21,27 +24,100 @@ struct SidebarView: View {
 
             Section("Locations") {
                 if locations.isEmpty {
-                    Text("No locations yet.")
+                    Text("No locations yet. Tap + to add one.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(locations) { location in
                         Label(location.name, systemImage: location.kind.systemImage)
                             .tag(SidebarSelection.location(location.id))
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    pendingDelete = location
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                Button {
+                                    formMode = .edit(location)
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                .tint(.indigo)
+                            }
                     }
                 }
             }
         }
         .navigationTitle("Naked Pantree")
-        .task {
-            await reload()
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    if let householdID {
+                        formMode = .create(householdID: householdID)
+                    }
+                } label: {
+                    Label("New Location", systemImage: "plus")
+                }
+                .disabled(householdID == nil)
+            }
         }
+        .sheet(item: $formMode) { mode in
+            LocationFormView(mode: mode) {
+                Task { await reload() }
+            }
+        }
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible,
+            presenting: pendingDelete
+        ) { location in
+            Button("Delete", role: .destructive) {
+                Task { await delete(location) }
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: { _ in
+            Text("This also removes every item inside it.")
+        }
+        .task { await reload() }
+    }
+
+    private var deleteConfirmationTitle: String {
+        if let pendingDelete {
+            return "Delete \(pendingDelete.name)?"
+        }
+        return ""
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { newValue in
+                if !newValue { pendingDelete = nil }
+            }
+        )
     }
 
     private func reload() async {
         do {
             let house = try await repositories.household.currentHousehold()
+            householdID = house.id
             locations = try await repositories.location.locations(in: house.id)
+        } catch {
+            loadError = error
+        }
+    }
+
+    private func delete(_ location: Location) async {
+        pendingDelete = nil
+        if case .location(let selectedID) = selection, selectedID == location.id {
+            selection = .smartList(.allItems)
+        }
+        do {
+            try await repositories.location.delete(id: location.id)
+            await reload()
         } catch {
             loadError = error
         }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,7 +90,7 @@ Every later phase assumes this skeleton exists.
 **Exit criteria**
 
 - [ ] App launches to the default household with one location.
-- [ ] User can add, rename, and delete locations and items with no
+- [x] User can add, rename, and delete locations and items with no
       crashes and no console warnings.
 - [ ] Search returns results across all locations.
 - [ ] Every user-facing string passes the `DESIGN_GUIDELINES.md` §10
@@ -108,8 +108,8 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 | 1.2a | Core Data stack + `Household` and `Location` repos | ✅ Merged ([apps#11](https://github.com/ellisandy/NakedPantree/pull/11)) |
 | 1.2b | `Item` and `ItemPhoto` repos + cascade-delete tests | ✅ Merged ([apps#13](https://github.com/ellisandy/NakedPantree/pull/13)) |
 | 1.3 | `NavigationSplitView` shell (sidebar / content / detail) | ✅ Merged ([apps#14](https://github.com/ellisandy/NakedPantree/pull/14)) |
-| 1.4 | CRUD wiring for `Location`s and `Item`s | ⬜ Next |
-| 1.5 | Search across locations + first-launch bootstrap | ⬜ |
+| 1.4 | CRUD wiring for `Location`s and `Item`s | ✅ Merged ([apps#15](https://github.com/ellisandy/NakedPantree/pull/15)) |
+| 1.5 | Search across locations + first-launch bootstrap | ⬜ Next |
 
 > The split is not load-bearing — it's a guide. If a piece of work
 > doesn't fit cleanly, retitle a row or add one. Don't force scope into


### PR DESCRIPTION
## Summary

Picks up where [apps#14](https://github.com/ellisandy/NakedPantree/pull/14) left off — the read-only shell now creates, edits, and deletes both `Location`s and `Item`s through the existing repository layer.

### UI

- **`LocationFormView`** — modal `Form` with name + kind picker. Used from a new "+" toolbar button in `SidebarView` and from a per-row Edit swipe action.
- **`SidebarView`** — adds swipe-to-delete with a confirmation dialog ("Delete `<name>`? This also removes every item inside it."). When the deleted location was the active selection, the sidebar falls back to **All Items**.
- **`ItemFormView`** — modal `Form` with name, quantity stepper, unit picker, optional expiry toggle + date picker, and notes. Used from a "+" toolbar button on the items list and from `ItemDetailView`'s new Edit toolbar button.
- **`ItemsView`** — adds swipe-to-delete with a confirmation dialog and an Edit swipe action.
- **`ItemDetailView`** — gains an **Edit** button that opens the same form pre-filled.

### Voice

Form titles, button labels, and confirmation dialogs follow [DESIGN_GUIDELINES.md §3 / §10](https://github.com/ellisandy/NakedPantree/blob/main/DESIGN_GUIDELINES.md) — plain copy in destructive flows ("This also removes every item inside it.") and short calls to action ("Add", "Save"). Empty state for a location with no items now reads *"Tap + to add the first one."* instead of the placeholder text from 1.3.

### Roadmap

- 1.4 row marked merged; 1.5 (search + first-launch bootstrap) marked next.
- Phase 1 exit criterion *"User can add, rename, and delete locations and items with no crashes and no console warnings"* ticked.

## Test plan

- [x] `xcodebuild test -scheme NakedPantree` passes locally — 24 unit tests + UI test green.
- [x] `swift test --package-path Packages/Core` still green.
- [x] `swift-format lint --strict` (in `swift:6.0` container) clean.
- [x] `swiftlint --strict` clean.
- [x] Manual sim run: add location → add items → edit item → swipe-delete with confirmation → all flows work, no console warnings.
- [ ] CI green on PR.

## Out of scope

- **Phase 1.5 — next:** search field across all locations + first-launch bootstrap (auto-create the default `"Kitchen"` location alongside the household).
- Reordering locations / items (drag-to-sort).
- Inline rename in the sidebar (currently rename uses the form sheet — fine for now, polish item later).