### PR TITLE
Phase 1.5: search across locations + first-launch bootstrap

### DIFF
--- a/NakedPantreeApp/App/BootstrapService.swift
+++ b/NakedPantreeApp/App/BootstrapService.swift
@@ -1,0 +1,20 @@
+import NakedPantreeDomain
+
+/// First-launch setup. `HouseholdRepository.currentHousehold()` already
+/// fetches-or-creates the default `"My Pantry"` household; this service
+/// completes the bootstrap by adding the default `"Kitchen"` location
+/// described in `ARCHITECTURE.md` §6 if (and only if) the user has no
+/// locations yet. Idempotent — safe to call on every launch.
+struct BootstrapService: Sendable {
+    let household: any HouseholdRepository
+    let location: any LocationRepository
+
+    func bootstrapIfNeeded() async throws {
+        let house = try await household.currentHousehold()
+        let existing = try await location.locations(in: house.id)
+        guard existing.isEmpty else { return }
+        try await location.create(
+            Location(householdID: house.id, name: "Kitchen", kind: .pantry)
+        )
+    }
+}

--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -1,0 +1,102 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// "All Items" smart-list content column. Lists every item in the
+/// household, with `.searchable` driving a household-scoped name match
+/// through `ItemRepository.search(_:in:)`. Empty / whitespace queries
+/// fall back to `allItems(in:)`.
+struct AllItemsView: View {
+    @Binding var selectedItemID: Item.ID?
+
+    @Environment(\.repositories) private var repositories
+    @State private var query: String = ""
+    @State private var items: [Item] = []
+    @State private var householdID: Household.ID?
+    @State private var locationsByID: [Location.ID: Location] = [:]
+
+    var body: some View {
+        Group {
+            if items.isEmpty {
+                emptyState
+            } else {
+                List(selection: $selectedItemID) {
+                    ForEach(items) { item in
+                        AllItemsRow(item: item, locationName: locationsByID[item.locationID]?.name)
+                            .tag(item.id)
+                    }
+                }
+            }
+        }
+        .navigationTitle("All Items")
+        .searchable(text: $query, prompt: "Search items")
+        .task { await reload() }
+        .onChange(of: query) { _, _ in
+            Task { await reload() }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            ContentUnavailableView(
+                "Pantry's empty",
+                systemImage: "tray",
+                description: Text("Add a location and a few items to start.")
+            )
+        } else {
+            ContentUnavailableView.search(text: trimmed)
+        }
+    }
+
+    private func reload() async {
+        do {
+            let house = try await repositories.household.currentHousehold()
+            householdID = house.id
+            let locations = try await repositories.location.locations(in: house.id)
+            locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
+
+            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                items = try await repositories.item.allItems(in: house.id)
+            } else {
+                items = try await repositories.item.search(trimmed, in: house.id)
+            }
+        } catch {
+            items = []
+        }
+    }
+}
+
+private struct AllItemsRow: View {
+    let item: Item
+    let locationName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.name)
+                .font(.body)
+            HStack(spacing: 8) {
+                if let locationName {
+                    Text(locationName)
+                }
+                Text("·")
+                Text("\(item.quantity) \(item.unit.displayLabel)")
+                if let expiresAt = item.expiresAt {
+                    Text("·")
+                    Text(expiresAt, style: .date)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedItemID: Item.ID?
+    NavigationStack {
+        AllItemsView(selectedItemID: $selectedItemID)
+    }
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -85,11 +85,18 @@ struct ItemsView: View {
 
     @ViewBuilder
     private func smartListContent(_ list: SmartList) -> some View {
-        ContentUnavailableView(
-            list.title,
-            systemImage: list.systemImage,
-            description: Text("Coming with Smart Lists.")
-        )
+        switch list {
+        case .allItems:
+            AllItemsView(selectedItemID: $selectedItemID)
+        case .expiringSoon, .recentlyAdded:
+            // Projections (Expiring Soon, Recently Added) land with the
+            // Smart Lists feature in Phase 6.
+            ContentUnavailableView(
+                list.title,
+                systemImage: list.systemImage,
+                description: Text("Coming with Smart Lists.")
+            )
+        }
     }
 
     @ViewBuilder

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct RootView: View {
     @State private var sidebarSelection: SidebarSelection? = .smartList(.allItems)
     @State private var selectedItemID: Item.ID?
+    @Environment(\.repositories) private var repositories
 
     var body: some View {
         NavigationSplitView {
@@ -19,6 +20,16 @@ struct RootView: View {
         } detail: {
             ItemDetailView(itemID: selectedItemID)
         }
+        .task {
+            // First-launch bootstrap per ARCHITECTURE.md §6: ensure the
+            // user lands in a household with at least one location. The
+            // service is idempotent — no-op on every subsequent launch.
+            let bootstrap = BootstrapService(
+                household: repositories.household,
+                location: repositories.location
+            )
+            try? await bootstrap.bootstrapIfNeeded()
+        }
     }
 }
 
@@ -30,10 +41,10 @@ enum SidebarSelection: Hashable, Sendable {
     case location(Location.ID)
 }
 
-/// Sidebar Smart Lists. Only the structure lands in Phase 1.3; the
-/// actual computed projections (`expiresAt` within 7 days,
-/// recency, cross-location list) arrive with the Smart Lists feature in
-/// Phase 6. Until then, selecting one shows an empty state.
+/// Sidebar Smart Lists. `All Items` is wired up in Phase 1.5 (cross-
+/// location list with search). The other projections (`expiresAt` within
+/// 7 days, recently-added) arrive with the Smart Lists feature in
+/// Phase 6 — selecting one of those shows a placeholder until then.
 enum SmartList: String, CaseIterable, Identifiable, Sendable {
     case expiringSoon
     case allItems

--- a/NakedPantreeTests/BootstrapServiceTests.swift
+++ b/NakedPantreeTests/BootstrapServiceTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+@testable import NakedPantreeDomain
+
+@Suite("BootstrapService")
+struct BootstrapServiceTests {
+    @Test("First call creates the default Kitchen location")
+    func firstCallSeedsKitchen() async throws {
+        let household = InMemoryHouseholdRepository()
+        let location = InMemoryLocationRepository()
+        let service = BootstrapService(household: household, location: location)
+
+        try await service.bootstrapIfNeeded()
+
+        let house = try await household.currentHousehold()
+        let locations = try await location.locations(in: house.id)
+        #expect(locations.map(\.name) == ["Kitchen"])
+        #expect(locations.first?.kind == .pantry)
+    }
+
+    @Test("Second call is a no-op — Kitchen isn't duplicated")
+    func secondCallIsNoop() async throws {
+        let household = InMemoryHouseholdRepository()
+        let location = InMemoryLocationRepository()
+        let service = BootstrapService(household: household, location: location)
+
+        try await service.bootstrapIfNeeded()
+        try await service.bootstrapIfNeeded()
+
+        let house = try await household.currentHousehold()
+        let locations = try await location.locations(in: house.id)
+        #expect(locations.count == 1)
+    }
+
+    @Test("Existing locations are left alone — Kitchen is not added on top")
+    func existingLocationsLeftAlone() async throws {
+        let household = InMemoryHouseholdRepository()
+        let location = InMemoryLocationRepository()
+        let house = try await household.currentHousehold()
+        try await location.create(
+            Location(householdID: house.id, name: "Garage Freezer", kind: .freezer)
+        )
+
+        let service = BootstrapService(household: household, location: location)
+        try await service.bootstrapIfNeeded()
+
+        let locations = try await location.locations(in: house.id)
+        #expect(locations.map(\.name) == ["Garage Freezer"])
+    }
+}

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -364,6 +364,51 @@ struct ItemRepositoryContractTests {
         let unknown = try await itemRepo.item(id: UUID())
         #expect(unknown == nil)
     }
+
+    @Test(
+        "allItems(in:) returns every item across every location, sorted by name",
+        arguments: RepositoryFactory.all)
+    func allItemsInHousehold(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Kitchen")
+        let freezer = Location(householdID: house.id, name: "Garage Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Tomatoes"))
+        try await itemRepo.create(Item(locationID: freezer.id, name: "Ice Cream"))
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Bread"))
+
+        let all = try await itemRepo.allItems(in: house.id)
+        #expect(all.map(\.name) == ["Bread", "Ice Cream", "Tomatoes"])
+    }
+
+    @Test(
+        "allItems(in:) is scoped — items in other households are filtered out",
+        arguments: RepositoryFactory.all)
+    func allItemsScopedByHousehold(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+
+        let mine = try await household.currentHousehold()
+        let elsewhere = Household(name: "Mom's Pantry")
+        let myKitchen = Location(householdID: mine.id, name: "Kitchen")
+        let momsKitchen = Location(householdID: elsewhere.id, name: "Mom's Kitchen")
+        try await locationRepo.create(myKitchen)
+        try await locationRepo.create(momsKitchen)
+        try await itemRepo.create(Item(locationID: myKitchen.id, name: "My Bread"))
+        try await itemRepo.create(Item(locationID: momsKitchen.id, name: "Mom's Bread"))
+
+        let all = try await itemRepo.allItems(in: mine.id)
+        #expect(all.map(\.name) == ["My Bread"])
+    }
 }
 
 @Suite("ItemPhotoRepository contract")

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -97,6 +97,19 @@ public actor InMemoryItemRepository: ItemRepository {
         items[id]
     }
 
+    public func allItems(in householdID: Household.ID) async throws -> [Item] {
+        var results: [Item] = []
+        for item in items.values {
+            let location = try await locationLookup(item.locationID)
+            if location?.householdID == householdID {
+                results.append(item)
+            }
+        }
+        return results.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
     public func search(_ query: String, in householdID: Household.ID) async throws -> [Item] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return [] }

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -31,6 +31,10 @@ public protocol LocationRepository: Sendable {
 public protocol ItemRepository: Sendable {
     func items(in locationID: Location.ID) async throws -> [Item]
     func item(id: Item.ID) async throws -> Item?
+    /// Every item across every location in the household, sorted by
+    /// name. Backs the `All Items` smart list and is the empty-query
+    /// fallback for `search(_:in:)`.
+    func allItems(in householdID: Household.ID) async throws -> [Item]
     /// Case-insensitive substring match on `Item.name`, scoped to one
     /// household. Empty / whitespace-only queries return an empty array.
     func search(_ query: String, in householdID: Household.ID) async throws -> [Item]

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
@@ -33,6 +33,20 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         }
     }
 
+    public func allItems(in householdID: Household.ID) async throws -> [Item] {
+        try await container.performBackgroundTask { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+            request.predicate = NSPredicate(
+                format: "location.household.id == %@",
+                householdID as CVarArg
+            )
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "name", ascending: true)
+            ]
+            return try context.fetch(request).map(Self.makeItem)
+        }
+    }
+
     public func search(_ query: String, in householdID: Household.ID) async throws -> [Item] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return [] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,9 +62,9 @@ Every later phase assumes this skeleton exists.
 
 ---
 
-## Phase 1 — Single-user MVP (local only) 🟡
+## Phase 1 — Single-user MVP (local only) ✅
 
-**Status:** In progress — see sub-milestones below.
+**Status:** Complete (see sub-milestones below).
 
 **Goal:** a usable inventory app on one device. No iCloud yet.
 
@@ -89,11 +89,11 @@ Every later phase assumes this skeleton exists.
 
 **Exit criteria**
 
-- [ ] App launches to the default household with one location.
+- [x] App launches to the default household with one location.
 - [x] User can add, rename, and delete locations and items with no
       crashes and no console warnings.
-- [ ] Search returns results across all locations.
-- [ ] Every user-facing string passes the `DESIGN_GUIDELINES.md` §10
+- [x] Search returns results across all locations.
+- [x] Every user-facing string passes the `DESIGN_GUIDELINES.md` §10
       checklist.
 - [x] Repository protocol tests pass with both the Core Data
       implementation and an in-memory mock.
@@ -109,7 +109,7 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 | 1.2b | `Item` and `ItemPhoto` repos + cascade-delete tests | ✅ Merged ([apps#13](https://github.com/ellisandy/NakedPantree/pull/13)) |
 | 1.3 | `NavigationSplitView` shell (sidebar / content / detail) | ✅ Merged ([apps#14](https://github.com/ellisandy/NakedPantree/pull/14)) |
 | 1.4 | CRUD wiring for `Location`s and `Item`s | ✅ Merged ([apps#15](https://github.com/ellisandy/NakedPantree/pull/15)) |
-| 1.5 | Search across locations + first-launch bootstrap | ⬜ Next |
+| 1.5 | Search across locations + first-launch bootstrap | ✅ Merged ([apps#17](https://github.com/ellisandy/NakedPantree/pull/17)) |
 
 > The split is not load-bearing — it's a guide. If a piece of work
 > doesn't fit cleanly, retitle a row or add one. Don't force scope into
@@ -117,7 +117,9 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 
 ---
 
-## Phase 2 — CloudKit sync (private database only)
+## Phase 2 — CloudKit sync (private database only) ▶
+
+**Status:** Up next.
 
 **Goal:** two devices on the same iCloud account stay in sync.
 


### PR DESCRIPTION
## Summary

Closes Phase 1. The single-user MVP is now usable end-to-end: first launch lands in a default household with a `"Kitchen"` location; the **All Items** smart list aggregates every item household-wide and supports household-scoped search.

### Repository protocol

- Adds `ItemRepository.allItems(in householdID:)` — sorted, household-scoped aggregate. Implemented in both the Core Data repo (single `NSPredicate` through `location.household.id`) and the in-memory mock (filter via the `locationLookup` resolver passed at init).
- Two new contract tests cover the happy path and household-scope filtering — both factories.

### Bootstrap

- New `BootstrapService` lives in the app target. `bootstrapIfNeeded()` fetches-or-creates the household via `HouseholdRepository`, then inserts a `Kitchen` location **only** when the household has none. Idempotent — safe to call on every launch.
- `RootView`'s `.task` invokes it on first appear. Three Swift Testing cases cover first call, idempotent second call, and the existing-locations-leave-alone branch.

### UI

- New `AllItemsView` — content column for the All Items smart list. `.searchable` drives a household-scoped name match through `ItemRepository.search(_:in:)`; empty / whitespace queries fall back to `allItems(in:)`. Rows show the item's location alongside quantity and expiry so users have a sense of *where* a hit lives.
- `ItemsView` routes `.smartList(.allItems)` to `AllItemsView`. **Expiring Soon** and **Recently Added** keep their "Coming with Smart Lists" placeholder — those projections land in Phase 6.

### Roadmap

- 1.5 row marked merged.
- **Phase 1 marked ✅ Complete; all five exit criteria ticked.**
- Phase 2 (CloudKit sync) marked Up Next.

## Test plan

- [x] `xcodebuild test -scheme NakedPantree` passes locally — 29 unit tests + UI test green.
- [x] `swift test --package-path Packages/Core` still green.
- [x] `swift-format lint --strict` (in `swift:6.0` container) clean.
- [x] `swiftlint --strict` clean.
- [x] Manual sim run from a clean derived-data state: app boots into a populated sidebar (Smart Lists + Kitchen location), All Items lists every item household-wide, search filters live, adding a location/item refreshes both the sidebar and the All Items view.
- [ ] CI green on PR.

## Out of scope

- Phase 6 Smart Lists projections (`expiringWithin(_:)`, recently-added query).
- Reordering / drag-to-sort.
- Inline rename in the sidebar.
- Phase 2 — CloudKit sync — picks up next.