### PR TITLE
Auto-capture screenshots on v* release tags

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,9 +1,17 @@
 name: Screenshots
 
-# Manual trigger only. App Store / TestFlight screenshots are an
-# on-demand artifact, not a PR gate. See issue #12 for the rationale.
+# Two triggers, both intentional:
+#   - workflow_dispatch: ad-hoc captures (UI tweaks, copy review).
+#   - push of a `v*` tag: every release-cut auto-captures so the PNGs
+#     are versioned alongside the binary that ships to TestFlight /
+#     App Store. See issue #12 for the rationale.
+# Not gated on PRs — captures are slow and most PRs don't change
+# canonical surfaces.
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 concurrency:
   group: screenshots-${{ github.ref }}


### PR DESCRIPTION
## Summary

Stacked on top of [apps#19](https://github.com/ellisandy/NakedPantree/pull/19). Adds a `push: tags: v*` trigger to the `Screenshots` workflow alongside the existing `workflow_dispatch`. Cutting a release tag (e.g. `git tag v1.0.0 && git push --tags`) now produces a versioned set of PNGs as a workflow artifact — no manual click needed.

## Trigger choices

| Option | Why this PR uses it |
| --- | --- |
| `workflow_dispatch` (manual) | Ad-hoc captures during UI / copy review. Already in place. |
| `push: tags: v*` | Release cuts. Tag-pushes happen only when we mean it; matches what App Store Connect consumes (screenshots ship with submission metadata, not per-build). |
| ❌ Every PR | Captures are ~1 min/device and most PRs don't touch the canonical surfaces (sidebar / All Items / location / item detail). Cost-vs-coverage doesn't pencil out. |
| ❌ Every TestFlight | TestFlight builds happen often during release prep; tags happen at the moments where the artifact is actually needed. |

## Test plan

- [x] No code changes — workflow YAML diff only.
- [ ] After this lands, dry-run by pushing a throwaway tag (e.g. `v0.0.0-dryrun`, push, then delete the tag locally and from GitHub) to verify the trigger fires the matrix and uploads artifacts. (Or skip until the first real `v*` tag.)

## Base branch

This PR targets `claude/bootstrap-fix` so it picks up the iPad-Pro-M5 rename from [apps#19](https://github.com/ellisandy/NakedPantree/pull/19). Once #19 merges to `main`, GitHub will retarget this PR to `main` and the diff stays a one-liner against the workflow.

## Out of scope

- Localization beyond en-US in the captures themselves (existing matrix only does en-US; expand the matrix when a second locale ships).
- Auto-uploading captured PNGs to App Store Connect — manual download from the Actions artifact is fine until release cadence justifies automation.
- The TestFlight upload pipeline itself — tracked as [apps#20](https://github.com/ellisandy/NakedPantree/issues/20).