### PR TITLE
Document the roadmap-milestone tagging convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,36 @@ follow-up PR. The doc reflects state as-of-merge: by the time the PR
 lands on `main`, anyone reading `ROADMAP.md` should see the work
 already counted.
 
+### Tag every roadmap milestone
+
+Each PR that completes a roadmap row gets an annotated git tag on the
+merge commit. Two namespaces, separate jobs:
+
+| Pattern | When to apply | Example |
+| --- | --- | --- |
+| `phase-<N>.<M>` | A sub-milestone PR merges. Tag points at the merge commit on `main`. | `phase-1.2a` (Core Data stack + Household/Location repos) |
+| `phase-<N>` | The final sub-milestone of a phase merges. Same commit as the closing sub-milestone tag — annotates "Phase N done" at a glance. | `phase-1` (lives on the same commit as `phase-1.5`) |
+| `v<X>.<Y>.<Z>` | Builds shipped to TestFlight / App Store. Triggers the `Screenshots` workflow and (when set up) the TestFlight upload. Pre-1.0 uses `v0.<phase>.<fix>`. | `v0.1.0` for the first Phase 1 build to TestFlight |
+
+How to tag (post-merge, from the main checkout):
+
+```bash
+git fetch origin main
+git tag -a phase-1.2a <merge-sha> -m "Phase 1.2a — Core Data stack + Household and Location repos (apps#11)"
+git push origin phase-1.2a
+```
+
+Conventions inside the tag message:
+
+- One-line summary that mirrors the PR title — past-tense, no period.
+- Reference the PR with `apps#<n>` so the tag is greppable.
+- For phase-closing tags (`phase-N`), enumerate the sub-milestones.
+
+Tags are permanent. Don't delete or move them once pushed — `Screenshots`
+and the future TestFlight workflow consume them. If you tagged the
+wrong commit, push a corrected tag with a `-fix` suffix rather than
+re-using the original name.
+
 ---
 
 ## 5. Things that look fine but aren't


### PR DESCRIPTION
## Summary

Codifies in `AGENTS.md §4` the convention I just backfilled — every PR that completes a roadmap row gets an annotated git tag on the merge commit. Stacked on top of [apps#19](https://github.com/ellisandy/NakedPantree/pull/19) (will retarget to `main` once that merges).

## What's documented

| Pattern | When | Example |
| --- | --- | --- |
| `phase-<N>.<M>` | Sub-milestone PR merges. Tag → merge commit on `main`. | `phase-1.2a` |
| `phase-<N>` | Final sub-milestone of a phase merges. Same commit as the closing sub-milestone tag. | `phase-1` (same commit as `phase-1.5`) |
| `v<X>.<Y>.<Z>` | TestFlight / App Store builds. Triggers `Screenshots` ([apps#21](https://github.com/ellisandy/NakedPantree/pull/21)) and the future TestFlight upload ([apps#20](https://github.com/ellisandy/NakedPantree/issues/20)). Pre-1.0: `v0.<phase>.<fix>`. | `v0.1.0` for the first Phase 1 build |

Tag-message format, plus the rule that tags are permanent (no deletes / moves; push `-fix` suffix if you got it wrong) — both in the doc.

## Phase 1 tags backfilled out-of-band

I pushed these directly to `origin` since they're metadata (no source diff), all annotated tags pointing at the existing merge commits:

| Tag | Commit | Sub-milestone |
| --- | --- | --- |
| `phase-1.1` | `c7671ee` | Domain types + repository protocols |
| `phase-1.2a` | `e126c9d` | Core Data stack + Household/Location repos |
| `phase-1.2b` | `4263fb2` | Item/ItemPhoto repos + cascade-delete tests |
| `phase-1.3` | `4e5a29b` | NavigationSplitView shell *(pre-existing)* |
| `phase-1.4` | `d05fbbf` | Location & Item CRUD |
| `phase-1.5` | `9853212` | All Items search + bootstrap |
| `phase-1` | `9853212` | Phase 1 complete (same commit as 1.5) |

Verify with `git fetch --tags origin && git tag -l "phase-*"`.

## Test plan

- [x] Doc-only diff to `AGENTS.md` — no code paths affected.
- [x] Phase 1 tags pushed and visible on GitHub.
- [x] Confirm CI doesn't run on this PR (no path filters match an `AGENTS.md` change in either workflow — that's expected).

## Out of scope — follow-ups

- **Tag-protection rules** (repo settings → Tags → Protected tags). Worth turning on `v*` once we have a TestFlight build out so released tags can't be deleted or moved. Not blocking — flagging for whenever you set up [apps#20](https://github.com/ellisandy/NakedPantree/issues/20).
- Auto-tagging from CI (e.g. a workflow that pushes `phase-X.Y` when an aligned PR merges). Manual is fine while phases are agent-driven; revisit if it becomes a chore.