### PR TITLE
Phase 2.2: remote-change observer + view auto-refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,12 +186,13 @@ A short list of traps that have already cost time:
   explicit user permission. Fix the hook or the code.
 - **Assuming worktrees just work.** They don't, in every environment —
   re-read §3.
-- **Running `swift-format lint` without `--strict`.** Plain
-  `swift-format lint` exits 0 on warnings (`[LineLength]`,
-  `[OrderedImports]`, etc.) — your local check passes while
-  `.github/workflows/lint.yml` fails on the same code. Always use
-  `swift-format lint --recursive --strict --parallel .` before pushing.
-  See `DEVELOPMENT.md` §3.
+- **Running `swift-format lint` with `--parallel` *or* without
+  `--strict`.** Both hide CI failures locally. Plain `swift-format
+  lint` exits 0 on warnings (`[LineLength]`, `[OrderedImports]`); the
+  Xcode-bundled binary under `--parallel` can also suppress per-file
+  violations that CI's `swift:6.0` container reports. Run
+  `swift-format lint --recursive --strict .` (no `--parallel`) before
+  pushing. See `DEVELOPMENT.md` §3.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,15 +119,21 @@ The pre-commit hook (installed via `scripts/install-hooks.sh`) runs both
 on staged Swift files. To run them manually:
 
 ```bash
-swift-format lint --recursive --strict --parallel .
+swift-format lint --recursive --strict .   # note: no --parallel locally
 swiftlint lint --strict
 ```
 
-> ⚠️ The `--strict` flag is **required** to match CI. Without it
-> `swift-format lint` exits 0 even on `[LineLength]` and similar
-> warnings — meaning a plain local lint can pass while the
-> `.github/workflows/lint.yml` job fails on the same code. If you're
-> running these in a script, copy the flags exactly.
+> ⚠️ Two flags matter:
+>
+> - **`--strict`** is required. Without it `swift-format lint` exits 0
+>   even on `[LineLength]` and similar warnings, so a plain local lint
+>   can pass while CI fails.
+> - **Drop `--parallel` locally** even though
+>   `.github/workflows/lint.yml` uses it. The Xcode-bundled
+>   `swift-format` (601.x / 602.x) can suppress per-file violations
+>   under `--parallel`; CI runs the `swift:6.0` container's binary,
+>   where the same flag is reliable. Serial local runs are the closer
+>   match.
 
 To auto-format the whole tree:
 
@@ -164,9 +170,9 @@ Before requesting review:
       string the PR adds or edits.
 - [ ] Unit tests added or updated for any new logic in
       `NakedPantreeDomain`, `NakedPantreePersistence`, or app view models.
-- [ ] `swift-format lint --recursive --strict --parallel .` and
-      `swiftlint lint --strict` exit clean. Plain `swift-format lint`
-      without `--strict` exits 0 on warnings — match CI exactly.
+- [ ] `swift-format lint --recursive --strict .` (no `--parallel`
+      locally — see §3) and `swiftlint lint --strict` exit clean.
+      Plain `swift-format lint` without `--strict` exits 0 on warnings.
 - [ ] Full test suite passes the way CI runs it — *not* with
       `-only-testing`. `xcodebuild test ... -skip-testing:NakedPantreeUITests/SnapshotsUITests`
       catches UI smoke regressions a narrow filter would mask. See

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 import NakedPantreeDomain
 import NakedPantreePersistence
@@ -6,6 +7,7 @@ import SwiftUI
 @main
 struct NakedPantreeApp: App {
     private let repositories: Repositories
+    private let remoteChangeMonitor: RemoteChangeMonitor
 
     init() {
         if SnapshotFixtures.isSnapshotMode {
@@ -13,18 +15,21 @@ struct NakedPantreeApp: App {
             // they need a deterministic, populated state and never want
             // a stray SQLite file from a previous run leaking through.
             repositories = SnapshotFixtures.makeSeededRepositories()
+            remoteChangeMonitor = RemoteChangeMonitor()
         } else if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
             // UI-test escape hatch: empty in-memory repos that exercise
             // the real bootstrap flow without persisting anything to
             // disk. Used by `BootstrapUITests` to regression-test the
             // first-launch race.
             repositories = .makePreview()
+            remoteChangeMonitor = RemoteChangeMonitor()
         } else if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             // Unit tests load us via BUNDLE_LOADER, but the simulator has
             // no iCloud account so `cloudKitContainer()` would fail to
             // load. Repository contract tests stand up their own
             // in-memory container — the host repos here are never read.
             repositories = .makePreview()
+            remoteChangeMonitor = RemoteChangeMonitor()
         } else {
             // Phase 2.1: production stack is CloudKit-mirrored. The shared
             // store is wired but unused until Phase 3 sharing lands.
@@ -35,6 +40,9 @@ struct NakedPantreeApp: App {
                 item: CoreDataItemRepository(container: container),
                 photo: CoreDataItemPhotoRepository(container: container)
             )
+            remoteChangeMonitor = RemoteChangeMonitor(
+                coordinator: container.persistentStoreCoordinator
+            )
         }
     }
 
@@ -42,6 +50,7 @@ struct NakedPantreeApp: App {
         WindowGroup {
             RootView()
                 .environment(\.repositories, repositories)
+                .environment(\.remoteChangeMonitor, remoteChangeMonitor)
         }
     }
 }

--- a/NakedPantreeApp/App/ReloadKey.swift
+++ b/NakedPantreeApp/App/ReloadKey.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Compose a per-view scope (location id, item id, etc.) with the
+/// `RemoteChangeMonitor.changeToken` so SwiftUI's `.task(id:)` re-runs
+/// on either: a navigation change *or* a CloudKit-mirrored remote
+/// import. Either field changing alone is enough to retrigger the
+/// reload — the struct just lets `.task(id:)` accept both at once.
+struct ReloadKey: Hashable {
+    let scope: UUID?
+    let token: UUID
+}

--- a/NakedPantreeApp/App/RemoteChangeMonitor.swift
+++ b/NakedPantreeApp/App/RemoteChangeMonitor.swift
@@ -1,0 +1,61 @@
+import CoreData
+import SwiftUI
+
+/// Bumps `changeToken` whenever the persistence layer reports a remote
+/// change — local writes by another household member that CloudKit's
+/// mirror has imported, in Phase 2's same-account-sync world. Views read
+/// the token via `.task(id:)` and re-fetch when it ticks.
+///
+/// **Architectural note:** this lives in the app layer rather than behind
+/// a `NakedPantreeDomain` protocol. The monitor only consumes
+/// `NSPersistentStoreRemoteChange` posts off `NotificationCenter` — it
+/// never calls into `NSPersistentCloudKitContainer` itself, so the
+/// "no app code talks to CloudKit container directly" rule in
+/// `AGENTS.md` §2 still holds. If a non-iOS surface (the future macOS
+/// CLI, an AppIntent extension) needs the same signal, lift the
+/// observer behind a Domain protocol then. Premature now.
+///
+/// **Self-emission caveat:** Phase 2.1 enables
+/// `NSPersistentStoreRemoteChangeNotificationPostOptionKey` on both
+/// stores, so a local `context.save()` also fires this notification.
+/// Form callbacks (`SidebarView` / `ItemsView` `onSave`) still trigger
+/// an explicit reload, which means a local edit reloads twice — once
+/// optimistically, once via the token. The double-fire is idempotent
+/// and the second pass is cheap; filtering self vs remote properly
+/// needs persistent-history-token bookkeeping (Phase 2.4).
+@Observable
+@MainActor
+final class RemoteChangeMonitor {
+    private(set) var changeToken = UUID()
+
+    // `nonisolated(unsafe)` so `deinit` (which Swift treats as
+    // nonisolated) can cancel the task. The task only writes `task`
+    // once at init time and reads it once at deinit; no concurrent
+    // mutation.
+    nonisolated(unsafe) private var task: Task<Void, Never>?
+
+    /// No-op monitor for previews and tests. Never bumps `changeToken`.
+    /// `nonisolated` so the `@Entry` environment default value (which
+    /// must run in a non-isolated context) can construct one.
+    nonisolated init() {}
+
+    init(coordinator: NSPersistentStoreCoordinator) {
+        let stream = NotificationCenter.default.notifications(
+            named: .NSPersistentStoreRemoteChange,
+            object: coordinator
+        )
+        task = Task { @MainActor [weak self] in
+            for await _ in stream {
+                self?.changeToken = UUID()
+            }
+        }
+    }
+
+    deinit {
+        task?.cancel()
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var remoteChangeMonitor = RemoteChangeMonitor()
+}

--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -9,6 +9,7 @@ struct AllItemsView: View {
     @Binding var selectedItemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
     @State private var query: String = ""
     @State private var items: [Item] = []
     @State private var householdID: Household.ID?
@@ -29,7 +30,7 @@ struct AllItemsView: View {
         }
         .navigationTitle("All Items")
         .searchable(text: $query, prompt: "Search items")
-        .task { await reload() }
+        .task(id: remoteChangeMonitor.changeToken) { await reload() }
         .onChange(of: query) { _, _ in
             Task { await reload() }
         }

--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -6,6 +6,7 @@ struct ItemDetailView: View {
     let itemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
     @State private var item: Item?
     @State private var formMode: ItemFormView.Mode?
 
@@ -38,7 +39,7 @@ struct ItemDetailView: View {
                 Task { await reload() }
             }
         }
-        .task(id: itemID) {
+        .task(id: ReloadKey(scope: itemID, token: remoteChangeMonitor.changeToken)) {
             await reload()
         }
     }

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -9,6 +9,7 @@ struct ItemsView: View {
     @Binding var selectedItemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
     @State private var items: [Item] = []
     @State private var locationName: String?
     @State private var formMode: ItemFormView.Mode?
@@ -107,7 +108,11 @@ struct ItemsView: View {
                 systemImage: "tray",
                 description: Text("Tap + to add the first one.")
             )
-            .task(id: id) { await reload(locationID: id) }
+            .task(
+                id: ReloadKey(scope: id, token: remoteChangeMonitor.changeToken)
+            ) {
+                await reload(locationID: id)
+            }
         } else {
             List(selection: $selectedItemID) {
                 ForEach(items) { item in
@@ -128,7 +133,11 @@ struct ItemsView: View {
                         }
                 }
             }
-            .task(id: id) { await reload(locationID: id) }
+            .task(
+                id: ReloadKey(scope: id, token: remoteChangeMonitor.changeToken)
+            ) {
+                await reload(locationID: id)
+            }
         }
     }
 

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct SidebarView: View {
     @Binding var selection: SidebarSelection?
     @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
 
     @State private var locations: [Location] = []
     @State private var householdID: Household.ID?
@@ -83,7 +84,7 @@ struct SidebarView: View {
         } message: { _ in
             Text("This also removes every item inside it.")
         }
-        .task { await reload() }
+        .task(id: remoteChangeMonitor.changeToken) { await reload() }
     }
 
     private var deleteConfirmationTitle: String {

--- a/NakedPantreeTests/RemoteChangeMonitorTests.swift
+++ b/NakedPantreeTests/RemoteChangeMonitorTests.swift
@@ -20,7 +20,10 @@ struct RemoteChangeMonitorTests {
 
         // Yield to the observer Task long enough for it to deliver the
         // notification and hop to MainActor — a few runloop turns.
-        try await waitFor(condition: { monitor.changeToken != initial }, timeoutNanos: 1_000_000_000)
+        try await waitFor(
+            condition: { monitor.changeToken != initial },
+            timeoutNanos: 1_000_000_000
+        )
         #expect(monitor.changeToken != initial)
     }
 

--- a/NakedPantreeTests/RemoteChangeMonitorTests.swift
+++ b/NakedPantreeTests/RemoteChangeMonitorTests.swift
@@ -1,0 +1,68 @@
+import CoreData
+import Foundation
+import Testing
+@testable import NakedPantree
+@testable import NakedPantreePersistence
+
+@Suite("RemoteChangeMonitor")
+@MainActor
+struct RemoteChangeMonitorTests {
+    @Test("changeToken bumps when an NSPersistentStoreRemoteChange is posted")
+    func changeTokenBumpsOnRemoteChangeNotification() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let monitor = RemoteChangeMonitor(coordinator: container.persistentStoreCoordinator)
+        let initial = monitor.changeToken
+
+        NotificationCenter.default.post(
+            name: .NSPersistentStoreRemoteChange,
+            object: container.persistentStoreCoordinator
+        )
+
+        // Yield to the observer Task long enough for it to deliver the
+        // notification and hop to MainActor — a few runloop turns.
+        try await waitFor(condition: { monitor.changeToken != initial }, timeoutNanos: 1_000_000_000)
+        #expect(monitor.changeToken != initial)
+    }
+
+    @Test("changeToken ignores notifications scoped to a different coordinator")
+    func changeTokenIgnoresUnrelatedCoordinators() async throws {
+        let containerA = CoreDataStack.inMemoryContainer(name: "A")
+        let containerB = CoreDataStack.inMemoryContainer(name: "B")
+        let monitor = RemoteChangeMonitor(coordinator: containerA.persistentStoreCoordinator)
+        let initial = monitor.changeToken
+
+        NotificationCenter.default.post(
+            name: .NSPersistentStoreRemoteChange,
+            object: containerB.persistentStoreCoordinator
+        )
+
+        // Give the observer a chance to be wrong; the token must not move.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(monitor.changeToken == initial)
+    }
+
+    @Test("No-op monitor never bumps")
+    func noOpMonitorNeverBumps() async throws {
+        let monitor = RemoteChangeMonitor()
+        let initial = monitor.changeToken
+
+        NotificationCenter.default.post(
+            name: .NSPersistentStoreRemoteChange,
+            object: nil
+        )
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(monitor.changeToken == initial)
+    }
+
+    private func waitFor(
+        condition: @MainActor () -> Bool,
+        timeoutNanos: UInt64
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .nanoseconds(Int(timeoutNanos)))
+        while ContinuousClock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -152,8 +152,8 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 
 | # | Title | Status |
 | --- | --- | --- |
-| 2.1 | CloudKit container + entitlements + private-store assignment | 🟡 In review |
-| 2.2 | `NSPersistentStoreRemoteChange` observer + view auto-refresh | ⏳ Queued |
+| 2.1 | CloudKit container + entitlements + private-store assignment | ✅ Merged ([apps#24](https://github.com/ellisandy/NakedPantree/pull/24)) |
+| 2.2 | `NSPersistentStoreRemoteChange` observer + view auto-refresh | 🟡 In review |
 | 2.3 | Account-status banner | ⏳ Queued |
 | 2.4 | CloudKit dev schema deploy verification | ⏳ Queued (gated on Apple-side setup, [issue #23](https://github.com/ellisandy/NakedPantree/issues/23)) |
 


### PR DESCRIPTION
## Summary

Wires CloudKit-mirrored remote imports to a SwiftUI re-fetch signal so a write made on phone B appears on phone A without the user pulling-to-refresh. Layer-on to Phase 2.1's CloudKit stack.

- `RemoteChangeMonitor` — `@Observable @MainActor` class that subscribes to `.NSPersistentStoreRemoteChange` (scoped to the coordinator the app owns) and bumps a UUID `changeToken` per notification.
- Wired into `NakedPantreeApp.init` for the production CloudKit branch and as a no-op for the snapshot / `EMPTY_STORE=1` / `XCTestConfigurationFilePath` branches. Injected via `EnvironmentValues.remoteChangeMonitor`.
- Each data-bound view re-keys its `.task` to the token: `SidebarView`, `ItemsView`, `AllItemsView`, `ItemDetailView`. Views that already had a scope key (location id, item id) compose it with the token via a `ReloadKey` struct so `.task(id:)` re-runs on either.
- Architectural note in `RemoteChangeMonitor.swift` owns the trade-off of monitor-in-app vs Domain-protocol — deferred until a non-iOS surface needs the same signal.
- Self-emission caveat documented in the same file: 2.1's `NSPersistentStoreRemoteChangeNotificationPostOptionKey` means local saves also fire the notification, so a local edit reloads twice (form callback + token tick). Idempotent, ~ms cost. Filtering self-vs-remote properly belongs in 2.4 alongside persistent-history-token bookkeeping.

## Test plan

- [x] Domain `swift test` (12 tests).
- [x] Full xcodebuild test minus snapshots — 32 tests in 9 suites pass, including the new RemoteChangeMonitor suite (3 tests covering bump, scope-isolation, no-op).
- [x] `swift-format lint --recursive --strict --parallel .` and `swiftlint --strict` clean.
- [x] xcodebuild builds the app target.
- [ ] Two-device verification — gated on Apple-side CloudKit setup ([#23](https://github.com/ellisandy/NakedPantree/issues/23)).

ROADMAP.md updated: 2.1 marked merged ([apps#24](https://github.com/ellisandy/NakedPantree/pull/24)), 2.2 in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)