### PR TITLE
Phase 2.3: account-status banner

### DIFF
--- a/NakedPantreeApp/App/AccountStatusMonitor.swift
+++ b/NakedPantreeApp/App/AccountStatusMonitor.swift
@@ -1,0 +1,89 @@
+import CloudKit
+import SwiftUI
+
+/// Maps `CKAccountStatus` to the cases the UI actually distinguishes —
+/// the SDK enum has slightly more states than the banner cares about.
+enum AccountStatus: Sendable, Hashable {
+    /// Signed in and ready. Banner is hidden.
+    case available
+    /// User is not signed into iCloud at all. Banner offers "Open Settings".
+    case noAccount
+    /// iCloud is restricted (parental controls, MDM, …). No remediation
+    /// from inside the app — banner explains and steps back.
+    case restricted
+    /// Couldn't reach iCloud servers. Usually transient (offline,
+    /// captive portal). Banner explains; status will recheck when
+    /// `.CKAccountChanged` fires.
+    case couldNotDetermine
+    /// iOS 15+: account exists but iCloud is unavailable right now
+    /// (Apple-side issue or device throttling). Banner explains; same
+    /// recheck path as `.couldNotDetermine`.
+    case temporarilyUnavailable
+}
+
+/// Tracks the user's iCloud account state and surfaces problems via a
+/// banner above the main UI. Voice rules in `DESIGN_GUIDELINES.md` §9
+/// classify sync failures as off-limits for personality — copy here
+/// stays plain, calm, and direct.
+///
+/// Same architectural trade-off as `RemoteChangeMonitor`: lives in the
+/// app layer because it consumes a `CKContainer` API + a
+/// `NotificationCenter` post, never touching `NSPersistentCloudKitContainer`.
+/// If a non-iOS surface needs the same signal later, lift behind a
+/// Domain protocol then.
+///
+/// Default state is `.available` so previews and tests render without
+/// a banner. The production initializer kicks off an immediate probe
+/// and refreshes whenever `.CKAccountChanged` fires; the brief moment
+/// before the first probe finishes shows no banner, which is the same
+/// outcome as a healthy account — acceptable.
+@Observable
+@MainActor
+final class AccountStatusMonitor {
+    private(set) var status: AccountStatus = .available
+
+    nonisolated(unsafe) private var task: Task<Void, Never>?
+
+    /// No-op monitor for previews and tests. Status stays `.available`
+    /// so the banner is hidden. `nonisolated` so the `@Entry` default
+    /// can construct one outside any actor.
+    nonisolated init() {}
+
+    init(container: CKContainer) {
+        let stream = NotificationCenter.default.notifications(named: .CKAccountChanged)
+        task = Task { @MainActor [weak self] in
+            await self?.refresh(using: container)
+            for await _ in stream {
+                await self?.refresh(using: container)
+            }
+        }
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    private func refresh(using container: CKContainer) async {
+        do {
+            let raw = try await container.accountStatus()
+            status = Self.map(raw)
+        } catch {
+            status = .couldNotDetermine
+        }
+    }
+
+    private static func map(_ raw: CKAccountStatus) -> AccountStatus {
+        switch raw {
+        case .available: .available
+        case .noAccount: .noAccount
+        case .restricted: .restricted
+        case .couldNotDetermine: .couldNotDetermine
+        case .temporarilyUnavailable: .temporarilyUnavailable
+        @unknown default: .couldNotDetermine
+        }
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var accountStatusMonitor = AccountStatusMonitor()
+}

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import CoreData
 import Foundation
 import NakedPantreeDomain
@@ -8,6 +9,7 @@ import SwiftUI
 struct NakedPantreeApp: App {
     private let repositories: Repositories
     private let remoteChangeMonitor: RemoteChangeMonitor
+    private let accountStatusMonitor: AccountStatusMonitor
 
     init() {
         if SnapshotFixtures.isSnapshotMode {
@@ -16,6 +18,7 @@ struct NakedPantreeApp: App {
             // a stray SQLite file from a previous run leaking through.
             repositories = SnapshotFixtures.makeSeededRepositories()
             remoteChangeMonitor = RemoteChangeMonitor()
+            accountStatusMonitor = AccountStatusMonitor()
         } else if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
             // UI-test escape hatch: empty in-memory repos that exercise
             // the real bootstrap flow without persisting anything to
@@ -23,6 +26,7 @@ struct NakedPantreeApp: App {
             // first-launch race.
             repositories = .makePreview()
             remoteChangeMonitor = RemoteChangeMonitor()
+            accountStatusMonitor = AccountStatusMonitor()
         } else if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             // Unit tests load us via BUNDLE_LOADER, but the simulator has
             // no iCloud account so `cloudKitContainer()` would fail to
@@ -30,6 +34,7 @@ struct NakedPantreeApp: App {
             // in-memory container — the host repos here are never read.
             repositories = .makePreview()
             remoteChangeMonitor = RemoteChangeMonitor()
+            accountStatusMonitor = AccountStatusMonitor()
         } else {
             // Phase 2.1: production stack is CloudKit-mirrored. The shared
             // store is wired but unused until Phase 3 sharing lands.
@@ -43,6 +48,9 @@ struct NakedPantreeApp: App {
             remoteChangeMonitor = RemoteChangeMonitor(
                 coordinator: container.persistentStoreCoordinator
             )
+            accountStatusMonitor = AccountStatusMonitor(
+                container: CKContainer(identifier: CoreDataStack.cloudKitContainerIdentifier)
+            )
         }
     }
 
@@ -51,6 +59,7 @@ struct NakedPantreeApp: App {
             RootView()
                 .environment(\.repositories, repositories)
                 .environment(\.remoteChangeMonitor, remoteChangeMonitor)
+                .environment(\.accountStatusMonitor, accountStatusMonitor)
         }
     }
 }

--- a/NakedPantreeApp/Features/Root/AccountStatusBanner.swift
+++ b/NakedPantreeApp/Features/Root/AccountStatusBanner.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Unobtrusive banner that surfaces iCloud-account problems. Stays
+/// hidden when `status == .available`. Copy follows the
+/// `DESIGN_GUIDELINES.md` §9 rule that sync failures are off-limits for
+/// personality — plain, calm, useful.
+struct AccountStatusBanner: View {
+    let status: AccountStatus
+
+    var body: some View {
+        if let message = status.message {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                Image(systemName: "exclamationmark.icloud")
+                    .imageScale(.medium)
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 12)
+                if status == .noAccount {
+                    Button("Settings") {
+                        openSettings()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.brandWarmCream)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(.separator)
+                    .frame(height: 0.5)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("banner.accountStatus")
+            .accessibilityLabel(message)
+        }
+    }
+
+    private func openSettings() {
+        #if canImport(UIKit)
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+        #endif
+    }
+}
+
+extension AccountStatus {
+    /// Body copy for the banner. `nil` when `.available` — caller
+    /// decides not to render. Keep these short; voice rules apply.
+    var message: String? {
+        switch self {
+        case .available:
+            nil
+        case .noAccount:
+            "Sign in to iCloud to keep your pantry in sync across devices."
+        case .restricted:
+            "iCloud is restricted on this device. Changes won't sync."
+        case .couldNotDetermine:
+            "iCloud is unreachable. Changes will sync when it's back."
+        case .temporarilyUnavailable:
+            "iCloud is briefly unavailable. Trying again."
+        }
+    }
+}
+
+#Preview("No account") {
+    AccountStatusBanner(status: .noAccount)
+}
+
+#Preview("Restricted") {
+    AccountStatusBanner(status: .restricted)
+}
+
+#Preview("Couldn't determine") {
+    AccountStatusBanner(status: .couldNotDetermine)
+}
+
+#Preview("Available (hidden)") {
+    AccountStatusBanner(status: .available)
+}

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -22,19 +22,23 @@ struct RootView: View {
     @State private var selectedItemID: Item.ID?
     @State private var bootstrapComplete = false
     @Environment(\.repositories) private var repositories
+    @Environment(\.accountStatusMonitor) private var accountStatusMonitor
 
     var body: some View {
         Group {
             if bootstrapComplete {
-                NavigationSplitView {
-                    SidebarView(selection: $sidebarSelection)
-                } content: {
-                    ItemsView(
-                        selection: sidebarSelection,
-                        selectedItemID: $selectedItemID
-                    )
-                } detail: {
-                    ItemDetailView(itemID: selectedItemID)
+                VStack(spacing: 0) {
+                    AccountStatusBanner(status: accountStatusMonitor.status)
+                    NavigationSplitView {
+                        SidebarView(selection: $sidebarSelection)
+                    } content: {
+                        ItemsView(
+                            selection: sidebarSelection,
+                            selectedItemID: $selectedItemID
+                        )
+                    } detail: {
+                        ItemDetailView(itemID: selectedItemID)
+                    }
                 }
             } else {
                 Color.brandWarmCream

--- a/NakedPantreeTests/AccountStatusTests.swift
+++ b/NakedPantreeTests/AccountStatusTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+
+@Suite("AccountStatus banner copy")
+struct AccountStatusTests {
+    @Test(".available has no banner message")
+    func availableSuppressesBanner() {
+        #expect(AccountStatus.available.message == nil)
+    }
+
+    @Test("Each non-available status has a non-empty plain-text message")
+    func nonAvailableHaveMessages() {
+        for status: AccountStatus in [
+            .noAccount,
+            .restricted,
+            .couldNotDetermine,
+            .temporarilyUnavailable,
+        ] {
+            let message = status.message
+            #expect(message != nil, "\(status) should surface a banner message.")
+            if let message {
+                // Voice rule §10: useful + short. Bound on the upper end —
+                // banner runs single-line on iPhone in landscape with
+                // generous DynamicType, so ~120 chars is the practical
+                // ceiling before truncation.
+                #expect(!message.isEmpty)
+                #expect(message.count < 120, "\(status) message is too long: \(message)")
+            }
+        }
+    }
+
+    @Test("Sync-failure copy stays plain — no off-limits humor")
+    func messagesAvoidPersonality() throws {
+        // Voice rule §9: errors that block the user are off-limits for
+        // personality. Spot-check obvious offenders so a future tweak
+        // doesn't accidentally drop a joke into a sync-failure banner.
+        let bannedSubstrings = ["pants", "naked", "🥫", "🧊", "😉"]
+        for status: AccountStatus in [
+            .noAccount,
+            .restricted,
+            .couldNotDetermine,
+            .temporarilyUnavailable,
+        ] {
+            let lowered = (status.message ?? "").lowercased()
+            for banned in bannedSubstrings {
+                #expect(
+                    !lowered.contains(banned),
+                    "\(status) message contains off-limits substring \"\(banned)\"."
+                )
+            }
+        }
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -153,8 +153,8 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 | # | Title | Status |
 | --- | --- | --- |
 | 2.1 | CloudKit container + entitlements + private-store assignment | ✅ Merged ([apps#24](https://github.com/ellisandy/NakedPantree/pull/24)) |
-| 2.2 | `NSPersistentStoreRemoteChange` observer + view auto-refresh | 🟡 In review |
-| 2.3 | Account-status banner | ⏳ Queued |
+| 2.2 | `NSPersistentStoreRemoteChange` observer + view auto-refresh | ✅ Merged ([apps#25](https://github.com/ellisandy/NakedPantree/pull/25)) |
+| 2.3 | Account-status banner | 🟡 In review |
 | 2.4 | CloudKit dev schema deploy verification | ⏳ Queued (gated on Apple-side setup, [issue #23](https://github.com/ellisandy/NakedPantree/issues/23)) |
 
 ---


### PR DESCRIPTION
## Summary

Adds an unobtrusive banner above the main shell that surfaces iCloud account problems — the last UI piece before Phase 2.4 (CloudKit dev schema deploy verification).

- `AccountStatusMonitor` (`@Observable @MainActor`) — wraps `CKContainer.accountStatus()` + `.CKAccountChanged` notifications. Same monitor-in-app trade-off as `RemoteChangeMonitor`: receives notifications and a CK API call, never reaches into `NSPersistentCloudKitContainer`.
- `AccountStatus` enum maps the four failure modes the banner cares about: `noAccount`, `restricted`, `couldNotDetermine`, `temporarilyUnavailable`. Hidden when `.available`.
- `AccountStatusBanner` view — plain copy per `DESIGN_GUIDELINES.md` §9 (sync failures are off-limits for personality), warm-cream background, hairline separator, accessible. "Open Settings" action surfaces only for `.noAccount` where the user has remediation in hand.
- `NakedPantreeApp.init` wires the production monitor against `CKContainer(identifier: CoreDataStack.cloudKitContainerIdentifier)`; no-op in the snapshot / `EMPTY_STORE=1` / test branches, so banner stays hidden in those paths.
- `RootView` mounts the banner above `NavigationSplitView` in a `VStack` — visible across every column on every device.
- `AccountStatusTests` cover suppression on `.available`, copy presence + length cap on every other case, and a no-personality spot-check.

ROADMAP: 2.2 marked merged ([apps#25](https://github.com/ellisandy/NakedPantree/pull/25)), 2.3 in review.

## Test plan

- [x] Domain `swift test` (12 tests).
- [x] Full xcodebuild test minus snapshots — 35 tests in 10 suites, including the new `AccountStatus banner copy` suite.
- [x] `swift-format lint --recursive --strict .` (no `--parallel`, per the corrected guidance) and `swiftlint --strict` clean.
- [x] xcodebuild builds the app target.
- [ ] Real-device verification (sign out of iCloud, observe banner; sign back in, banner disappears) — gated on Apple-side container provisioning ([#23](https://github.com/ellisandy/NakedPantree/issues/23)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)