### PR TITLE
Change bundle id to cc.mnmlst.nakedpantree

### DIFF
--- a/NakedPantreeApp/Resources/NakedPantree.entitlements
+++ b/NakedPantreeApp/Resources/NakedPantree.entitlements
@@ -6,7 +6,7 @@
     <string>development</string>
     <key>com.apple.developer.icloud-container-identifiers</key>
     <array>
-        <string>iCloud.com.ellisandy.NakedPantree</string>
+        <string>iCloud.cc.mnmlst.nakedpantree</string>
     </array>
     <key>com.apple.developer.icloud-services</key>
     <array>

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
@@ -30,7 +30,7 @@ public enum CoreDataStack {
     /// `com.apple.developer.icloud-container-identifiers` entry in
     /// `NakedPantree.entitlements` and the container provisioned in
     /// the developer portal (see issue #23).
-    public static let cloudKitContainerIdentifier = "iCloud.com.ellisandy.NakedPantree"
+    public static let cloudKitContainerIdentifier = "iCloud.cc.mnmlst.nakedpantree"
 
     /// Creates a disk-backed local-only container — SQLite at the OS-default
     /// location (Application Support / `<name>.sqlite`). Used by tests and

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 name: NakedPantree
 options:
-  bundleIdPrefix: com.ellisandy
+  bundleIdPrefix: cc.mnmlst
   deploymentTarget:
     iOS: "26.0"
   developmentLanguage: en
@@ -42,7 +42,7 @@ targets:
         product: NakedPantreePersistence
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.ellisandy.NakedPantree
+        PRODUCT_BUNDLE_IDENTIFIER: cc.mnmlst.nakedpantree
         PRODUCT_NAME: "Naked Pantree"
         PRODUCT_MODULE_NAME: NakedPantree
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
## Summary

Aligns the app's bundle ID with the user's other apps under the `cc.mnmlst` prefix.

| | Before | After |
| --- | --- | --- |
| Bundle ID | `com.ellisandy.NakedPantree` | `cc.mnmlst.nakedpantree` |
| iCloud container | `iCloud.com.ellisandy.NakedPantree` | `iCloud.cc.mnmlst.nakedpantree` |

Three call sites:
- [project.yml](project.yml) — `bundleIdPrefix` and `PRODUCT_BUNDLE_IDENTIFIER`.
- [NakedPantreeApp/Resources/NakedPantree.entitlements](NakedPantreeApp/Resources/NakedPantree.entitlements) — iCloud container identifier.
- [Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift](Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift) — `cloudKitContainerIdentifier` constant.

[Issue #23](https://github.com/ellisandy/NakedPantree/issues/23)'s provisioning checklist also updated in-place to reference the new identifiers. Nothing to migrate — the old container never shipped to a real device.

## Test plan

- [x] Full xcodebuild test minus snapshots — 35 tests / 10 suites green.
- [x] `swift-format lint --recursive --strict .` and `swiftlint --strict` clean.
- [x] xcodebuild builds the app target with the new bundle id + entitlements.
- [ ] Apple-side: when you do the [#23](https://github.com/ellisandy/NakedPantree/issues/23) provisioning, use the new identifiers in the developer portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)