### PR TITLE
Debounce All Items search + close out Phase 2

### DIFF
--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -30,9 +30,26 @@ struct AllItemsView: View {
         }
         .navigationTitle("All Items")
         .searchable(text: $query, prompt: "Search items")
-        .task(id: remoteChangeMonitor.changeToken) { await reload() }
-        .onChange(of: query) { _, _ in
-            Task { await reload() }
+        // Shell (household + locations) only refetches when CloudKit
+        // imports a remote change — typing in the search bar shouldn't
+        // re-hit those rows.
+        .task(id: remoteChangeMonitor.changeToken) {
+            await loadShell()
+        }
+        // Items refetch on query change, debounced so a flurry of
+        // keystrokes resolves into one Core Data hop instead of one
+        // per character. `.task(id:)` cancels the previous task when
+        // `query` changes, and `Task.sleep` throws on cancel — so only
+        // the last keystroke after a 250ms pause actually fetches.
+        .task(id: query) {
+            do {
+                if !query.isEmpty {
+                    try await Task.sleep(for: .milliseconds(250))
+                }
+                await loadItems()
+            } catch {
+                // Cancelled — the next .task takes over.
+            }
         }
     }
 
@@ -50,18 +67,32 @@ struct AllItemsView: View {
         }
     }
 
-    private func reload() async {
+    /// Fetch the household + locations once on appear and on each remote
+    /// change. Triggers an items load at the end so the initial render
+    /// shows data without waiting for the query-task to fire.
+    private func loadShell() async {
         do {
             let house = try await repositories.household.currentHousehold()
             householdID = house.id
             let locations = try await repositories.location.locations(in: house.id)
             locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
+        } catch {
+            return
+        }
+        await loadItems()
+    }
 
-            let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// Fetch items for the current `query`. Bails if the shell hasn't
+    /// resolved a household yet — `loadShell()` calls back into this
+    /// once it has, so the empty state never sticks.
+    private func loadItems() async {
+        guard let house = householdID else { return }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
             if trimmed.isEmpty {
-                items = try await repositories.item.allItems(in: house.id)
+                items = try await repositories.item.allItems(in: house)
             } else {
-                items = try await repositories.item.search(trimmed, in: house.id)
+                items = try await repositories.item.search(trimmed, in: house)
             }
         } catch {
             items = []

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -117,9 +117,9 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 
 ---
 
-## Phase 2 — CloudKit sync (private database only) 🟡
+## Phase 2 — CloudKit sync (private database only) ✅
 
-**Status:** In progress.
+**Status:** Complete (verified on real devices, see sub-milestones below).
 
 **Goal:** two devices on the same iCloud account stay in sync.
 
@@ -140,13 +140,13 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 
 **Exit criteria**
 
-- [ ] Two devices signed into the same iCloud account see inserts within
+- [x] Two devices signed into the same iCloud account see inserts within
       ~5s of each other.
-- [ ] Airplane-mode write replays cleanly on reconnect with no
+- [x] Airplane-mode write replays cleanly on reconnect with no
       duplicates.
-- [ ] No `unique constraint` errors at runtime — uniqueness is enforced
+- [x] No `unique constraint` errors at runtime — uniqueness is enforced
       in code at insert time.
-- [ ] CloudKit dev schema matches the model exactly.
+- [x] CloudKit dev schema matches the model exactly.
 
 **Sub-milestones**
 
@@ -155,7 +155,7 @@ The phase is large enough to land in chunks. Each row tracks one PR.
 | 2.1 | CloudKit container + entitlements + private-store assignment | ✅ Merged ([apps#24](https://github.com/ellisandy/NakedPantree/pull/24)) |
 | 2.2 | `NSPersistentStoreRemoteChange` observer + view auto-refresh | ✅ Merged ([apps#25](https://github.com/ellisandy/NakedPantree/pull/25)) |
 | 2.3 | Account-status banner | ✅ Merged ([apps#26](https://github.com/ellisandy/NakedPantree/pull/26)) |
-| 2.4 | CloudKit dev schema deploy verification | 🟡 In review |
+| 2.4 | CloudKit dev schema deploy verification | ✅ Merged ([apps#29](https://github.com/ellisandy/NakedPantree/pull/29)) |
 
 ---
 


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled because they're both small.

### 1. Typing-lag fix in `AllItemsView`

The search bar fired `Task { await reload() }` on every keystroke with no debounce. Each `reload()` ran **three sequential Core Data fetches** (household → locations → items). Typing "tomato" spawned six racing tasks, eighteen background-context fetches. With CloudKit-mirrored disk-backed storage on a real iPhone, that's visible lag.

- Split the single `reload()` into `loadShell()` (household + locations) and `loadItems()` (search/allItems).
- `loadShell()` keys on `remoteChangeMonitor.changeToken` — household + locations don't change while typing.
- `loadItems()` keys on `query` with `Task.sleep(for: .milliseconds(250))` inside the `.task(id:)`. SwiftUI cancels the previous task on each keystroke; `Task.sleep` throws on cancel, so only the last keystroke after a 250ms pause actually hits Core Data.
- `loadShell()` calls `loadItems()` after the household resolves, so the initial render isn't blocked on the query-task firing.

Net effect: typing six characters fast = one debounced fetch, two sequential fetches total (shell + items) instead of eighteen.

### 2. Phase 2 closure

Per real-device verification confirmed offline. ROADMAP Phase 2:
- All four exit-criteria boxes ticked.
- Status flipped from 🟡 In progress → ✅ Complete.
- Sub-milestone table now shows 2.4 merged ([apps#29](https://github.com/ellisandy/NakedPantree/pull/29)).

The `phase-2` git tag was pushed separately on the 2.4 merge commit (`d1a2e1b`) per the milestone-tag convention.

## Test plan

- [x] Full xcodebuild test minus snapshots — 35 tests / 10 suites green.
- [x] `swift-format lint --recursive --strict .` and `swiftlint --strict` clean.
- [ ] You typing in the All Items search bar on iPhone — should feel responsive now. If it doesn't, the lag is somewhere else (form fields? keyboard?) and we'll track that down separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)