### PR TITLE
Debounce remote-change notifications

### DIFF
--- a/NakedPantreeApp/App/RemoteChangeMonitor.swift
+++ b/NakedPantreeApp/App/RemoteChangeMonitor.swift
@@ -22,17 +22,34 @@ import SwiftUI
 /// an explicit reload, which means a local edit reloads twice — once
 /// optimistically, once via the token. The double-fire is idempotent
 /// and the second pass is cheap; filtering self vs remote properly
-/// needs persistent-history-token bookkeeping (Phase 2.4).
+/// needs persistent-history-token bookkeeping (issue #28).
+///
+/// **Debounce:** notifications fan out — CloudKit fires per-store on
+/// save (private + shared) and per-transaction on initial sync. A
+/// single user action can produce 5+ notifications across one frame,
+/// each previously bumping `changeToken` and triggering SwiftUI's
+/// "onChange tried to update multiple times per frame" warning plus
+/// a thundering herd of `.task(id:)` cancellations on app launch.
+/// We coalesce into one bump per ~120ms quiet window.
 @Observable
 @MainActor
 final class RemoteChangeMonitor {
     private(set) var changeToken = UUID()
 
     // `nonisolated(unsafe)` so `deinit` (which Swift treats as
-    // nonisolated) can cancel the task. The task only writes `task`
-    // once at init time and reads it once at deinit; no concurrent
-    // mutation.
+    // nonisolated) can cancel the task. The compiler nudges to drop
+    // the `(unsafe)` since `Task<Void, Never>` is Sendable, but the
+    // `@Observable` macro's generated backing storage rejects bare
+    // `nonisolated` on mutable stored properties — so we keep
+    // `(unsafe)` and live with the warning.
     nonisolated(unsafe) private var task: Task<Void, Never>?
+
+    /// Pending debounce timer. Each incoming notification cancels the
+    /// previous timer and starts a new one — only the last
+    /// notification followed by ~120ms of quiet actually bumps the
+    /// token. Stays on the main actor; no deinit cleanup needed since
+    /// the task self-terminates after the sleep.
+    private var debounceTask: Task<Void, Never>?
 
     /// No-op monitor for previews and tests. Never bumps `changeToken`.
     /// `nonisolated` so the `@Entry` environment default value (which
@@ -46,13 +63,26 @@ final class RemoteChangeMonitor {
         )
         task = Task { @MainActor [weak self] in
             for await _ in stream {
-                self?.changeToken = UUID()
+                self?.scheduleBump()
             }
         }
     }
 
     deinit {
         task?.cancel()
+    }
+
+    private func scheduleBump() {
+        debounceTask?.cancel()
+        debounceTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .milliseconds(120))
+                self?.changeToken = UUID()
+            } catch {
+                // Cancelled by a newer notification — that newer
+                // notification owns the next bump.
+            }
+        }
     }
 }
 

--- a/NakedPantreeTests/RemoteChangeMonitorTests.swift
+++ b/NakedPantreeTests/RemoteChangeMonitorTests.swift
@@ -40,8 +40,38 @@ struct RemoteChangeMonitorTests {
         )
 
         // Give the observer a chance to be wrong; the token must not move.
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 250_000_000)
         #expect(monitor.changeToken == initial)
+    }
+
+    @Test("A flurry of notifications coalesces into a single token bump")
+    func flurryCoalescesIntoSingleBump() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let monitor = RemoteChangeMonitor(coordinator: container.persistentStoreCoordinator)
+        let initial = monitor.changeToken
+
+        // Fire five notifications back-to-back. Pre-debounce this would
+        // bump the token five times in the same frame and trip SwiftUI's
+        // "onChange tried to update multiple times per frame" warning.
+        for _ in 0..<5 {
+            NotificationCenter.default.post(
+                name: .NSPersistentStoreRemoteChange,
+                object: container.persistentStoreCoordinator
+            )
+        }
+
+        // Wait past the debounce window for the first bump to land.
+        try await waitFor(
+            condition: { monitor.changeToken != initial },
+            timeoutNanos: 1_000_000_000
+        )
+        let firstBump = monitor.changeToken
+        #expect(firstBump != initial)
+
+        // No further notifications — token must remain stable through
+        // another debounce window.
+        try await Task.sleep(nanoseconds: 250_000_000)
+        #expect(monitor.changeToken == firstBump)
     }
 
     @Test("No-op monitor never bumps")
@@ -54,7 +84,7 @@ struct RemoteChangeMonitorTests {
             object: nil
         )
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(nanoseconds: 250_000_000)
         #expect(monitor.changeToken == initial)
     }
 


### PR DESCRIPTION
## Summary

Fixes two symptoms that share a root cause — CloudKit fans out `.NSPersistentStoreRemoteChange` posts (per-store on save, per-transaction on initial sync), and `RemoteChangeMonitor` was bumping `changeToken` once per notification:

- **SwiftUI warnings:** `onChange(of: ReloadKey) action tried to update multiple times per frame` and the same for `UUID`. The token was being mutated multiple times within a single render frame, and every `.task(id:)` in the app was tearing down + restarting.
- **Slow app launch:** initial-sync notification storm triggered one full refetch per notification (sidebar, items, item-detail, all-items shell), each cancelling the previous mid-flight. The thundering herd kept the main thread busy until sync settled.

## Fix

Coalesce notifications into one `changeToken` bump per ~120ms quiet window. Each incoming notification cancels any pending debounce task and starts a new one; only the last notification followed by 120ms of silence ticks the token.

```swift
private func scheduleBump() {
    debounceTask?.cancel()
    debounceTask = Task { @MainActor [weak self] in
        do {
            try await Task.sleep(for: .milliseconds(120))
            self?.changeToken = UUID()
        } catch {
            // newer notification owns the next bump
        }
    }
}
```

The 120ms window is empirical — long enough to coalesce a CloudKit fan-out (typically tens of ms apart), short enough that user-visible latency on a foregrounded edit-then-look stays imperceptible.

The rest of the system is unchanged. Views still key on `changeToken`, just see fewer ticks.

## Test plan

- [x] New test: five back-to-back notifications produce one bump; token stays stable through another debounce window.
- [x] Existing tests still pass (one was racing the new debounce window — bumped its sleep from 100ms to 250ms).
- [x] Full xcodebuild test minus snapshots — 36 / 10 suites green.
- [x] `swift-format lint --recursive --strict .` and `swiftlint --strict` clean.
- [x] You launching on iPhone — the warnings should disappear and launch should feel snappier. If launch is still slow, the bottleneck is somewhere else (Core Data initial schema work, view-body cost, etc.) and we'll dig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)