### PR TITLE
Phase 3.2: share-acceptance handler

### DIFF
--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -7,6 +7,8 @@ import SwiftUI
 
 @main
 struct NakedPantreeApp: App {
+    @UIApplicationDelegateAdaptor(NakedPantreeAppDelegate.self) private var appDelegate
+
     private let repositories: Repositories
     private let remoteChangeMonitor: RemoteChangeMonitor
     private let accountStatusMonitor: AccountStatusMonitor
@@ -60,6 +62,12 @@ struct NakedPantreeApp: App {
                 container: container,
                 cloudKitContainer: cloudKitContainer
             )
+            // Phase 3.2: hand the share-acceptance service to the
+            // delegate so `application(_:userDidAcceptCloudKitShareWith:)`
+            // can import shared records when a recipient taps an
+            // invite. The delegate is instantiated by the system before
+            // this init runs, so a static var is the simplest seam.
+            NakedPantreeAppDelegate.shareAcceptance = CloudShareAcceptance(container: container)
         }
     }
 

--- a/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
+++ b/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
@@ -1,0 +1,40 @@
+import CloudKit
+import NakedPantreePersistence
+import SwiftUI
+import UIKit
+
+/// `UIApplicationDelegate` shim for the one event SwiftUI's `App`
+/// lifecycle doesn't natively expose: the iCloud share-accept callback
+/// (`application(_:userDidAcceptCloudKitShareWith:)`). When a recipient
+/// taps an invite link in Messages / Mail / AirDrop, iOS calls this
+/// method on the registered delegate. Wired in via
+/// `@UIApplicationDelegateAdaptor` in `NakedPantreeApp`.
+///
+/// The delegate is instantiated by the system **before** `NakedPantreeApp.init`
+/// runs, so we can't take the acceptance service via the initializer.
+/// `NakedPantreeApp.init` writes to `Self.shareAcceptance` after
+/// constructing the production CloudKit container; preview / test
+/// branches leave it `nil`, which means a stray invite during a test
+/// run no-ops instead of crashing.
+final class NakedPantreeAppDelegate: NSObject, UIApplicationDelegate {
+    nonisolated(unsafe) static var shareAcceptance: CloudShareAcceptance?
+
+    func application(
+        _ application: UIApplication,
+        userDidAcceptCloudKitShareWith metadata: CKShare.Metadata
+    ) {
+        guard let acceptance = Self.shareAcceptance else { return }
+        Task {
+            do {
+                try await acceptance.acceptShare(metadata: metadata)
+            } catch {
+                // The recipient already tapped Accept — there's no
+                // user-actionable surface here without a separate UI
+                // pass. RemoteChangeMonitor will tick once the import
+                // lands; if it doesn't, that's an integration bug to
+                // chase, not a per-tap retry.
+                print("CloudKit share acceptance failed: \(error)")
+            }
+        }
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudShareAcceptance.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudShareAcceptance.swift
@@ -1,0 +1,37 @@
+import CloudKit
+import CoreData
+
+/// Wraps `NSPersistentCloudKitContainer.acceptShareInvitations(from:into:completion:)`
+/// — the API the recipient calls when they tap an iCloud share invite.
+/// Phase 3.2 surfaces this through the app delegate's
+/// `application(_:userDidAcceptCloudKitShareWith:)`, which is the
+/// canonical hook for SwiftUI apps via `UIApplicationDelegateAdaptor`.
+///
+/// Records land in the shared store. Phase 3.3 routes new writes to
+/// the right store (private vs shared) based on the active household's
+/// ownership.
+public final class CloudShareAcceptance: @unchecked Sendable {
+    private let container: NSPersistentCloudKitContainer
+
+    public init(container: NSPersistentCloudKitContainer) {
+        self.container = container
+    }
+
+    /// Imports the shared records described by `metadata` into the
+    /// container's shared store. Throws if the shared store isn't
+    /// loaded (single-store container, in-memory tests) or if Core
+    /// Data + CloudKit reject the invitation.
+    public func acceptShare(metadata: CKShare.Metadata) async throws {
+        guard let sharedStore = CoreDataStack.sharedCloudKitStore(in: container) else {
+            throw CloudShareAcceptanceError.sharedStoreUnavailable
+        }
+        _ = try await container.acceptShareInvitations(
+            from: [metadata],
+            into: sharedStore
+        )
+    }
+}
+
+public enum CloudShareAcceptanceError: Error {
+    case sharedStoreUnavailable
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
@@ -112,6 +112,18 @@ public enum CoreDataStack {
         }
     }
 
+    /// Returns the shared CloudKit-backed store on a multi-store container,
+    /// or `nil` for single-store containers. `acceptShareInvitations`
+    /// from `CloudShareAcceptance` lands shared records here when a
+    /// recipient accepts an invite.
+    public static func sharedCloudKitStore(
+        in container: NSPersistentContainer
+    ) -> NSPersistentStore? {
+        container.persistentStoreCoordinator.persistentStores.first { store in
+            store.url?.lastPathComponent.contains("-shared.sqlite") == true
+        }
+    }
+
     /// Creates an in-memory container — the SQLite store is bound to
     /// `/dev/null`, so nothing reaches disk. Used for tests and SwiftUI
     /// previews. Each call returns a fresh container with an empty store.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -194,8 +194,8 @@ household.
 
 | # | Title | Status |
 | --- | --- | --- |
-| 3.1 | `CKShare` creation + `UICloudSharingController` bridge + Share Household button | 🟡 In review |
-| 3.2 | Share-acceptance handler (`UIApplicationDelegateAdaptor`) | ⏳ Queued |
+| 3.1 | `CKShare` creation + `UICloudSharingController` bridge + Share Household button | ✅ Merged ([apps#32](https://github.com/ellisandy/NakedPantree/pull/32)) |
+| 3.2 | Share-acceptance handler (`UIApplicationDelegateAdaptor`) | 🟡 In review |
 | 3.3 | Cross-store write routing (private vs shared on insert) + verification runbook | ⏳ Queued |
 
 ---


### PR DESCRIPTION
## Summary

Recipient half of household sharing. After this lands, tapping an iCloud invite in Messages / Mail / AirDrop launches the app, the delegate fires, and the shared records land in the local shared store. The shared household doesn't surface in the UI yet — that's 3.3's cross-store write routing plus the `currentHousehold()` fix flagged in 3.1's PR description.

### What's here

- **`CloudShareAcceptance`** ([NakedPantreePersistence](Packages/Core/Sources/NakedPantreePersistence/CloudShareAcceptance.swift)) — thin async wrapper over `NSPersistentCloudKitContainer.acceptShareInvitations(from:into:)`. Uses the iOS 26 async overload directly, no continuation gymnastics.
- **`CoreDataStack.sharedCloudKitStore(in:)`** mirror of the existing `privateCloudKitStore(in:)`. Finds the shared store by URL last-path-component matching `-shared.sqlite`.
- **`NakedPantreeAppDelegate`** ([NakedPantreeApp/App](NakedPantreeApp/App/NakedPantreeAppDelegate.swift)) — a `NSObject, UIApplicationDelegate` that implements `application(_:userDidAcceptCloudKitShareWith:)`. SwiftUI's App lifecycle doesn't natively expose this hook, so we go via `@UIApplicationDelegateAdaptor`.
- **`@UIApplicationDelegateAdaptor(NakedPantreeAppDelegate.self)`** on `NakedPantreeApp` registers it. The delegate is instantiated by the system before `App.init` runs, so we use a `nonisolated(unsafe) static var shareAcceptance` that `App.init` populates after creating the production CloudKit container — the simplest seam between the two lifecycles. Preview / test branches leave it `nil`, so a stray invite during a test no-ops instead of crashing.
- **ROADMAP** 3.1 marked ✅ merged ([apps#32](https://github.com/ellisandy/NakedPantree/pull/32)), 3.2 🟡 in review.

### Verification — needs two devices, two iCloud accounts

Single-device acceptance has nothing to accept. Same caveat as 3.1's PR description — [#23](https://github.com/ellisandy/NakedPantree/issues/23)'s "optional but recommended" second account on a second physical device is required for the full Phase 3 verification flow.

What's testable right now: run on phone A → tap Share Household → invite phone B (different iCloud account) via Messages → on phone B, tap the invite link. The app should launch and the delegate should fire. Records won't appear in the UI yet (3.3), but you can confirm via Xcode console logs or by adding a temporary breakpoint in `NakedPantreeAppDelegate.application(_:userDidAcceptCloudKitShareWith:)`.

## Test plan

- [x] `./scripts/lint.sh` clean.
- [x] Full xcodebuild test minus snapshots — 36 / 10 suites green.
- [x] xcodebuild builds the app target.
- [ ] Manual: phone B accepts a phone A share, delegate fires, no crash. Visible in 3.3 with the routing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)