### PR TITLE
Phase 4.1: NotificationScheduler + lazy permission + scheduling on save/delete

### DIFF
--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -4,6 +4,7 @@ import Foundation
 import NakedPantreeDomain
 import NakedPantreePersistence
 import SwiftUI
+import UserNotifications
 
 @main
 struct NakedPantreeApp: App {
@@ -13,6 +14,7 @@ struct NakedPantreeApp: App {
     private let remoteChangeMonitor: RemoteChangeMonitor
     private let accountStatusMonitor: AccountStatusMonitor
     private let householdSharing: CloudHouseholdSharingService?
+    private let notificationScheduler: NotificationScheduler
 
     init() {
         if SnapshotFixtures.isSnapshotMode {
@@ -23,6 +25,7 @@ struct NakedPantreeApp: App {
             remoteChangeMonitor = RemoteChangeMonitor()
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
+            notificationScheduler = NotificationScheduler()
         } else if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
             // UI-test escape hatch: empty in-memory repos that exercise
             // the real bootstrap flow without persisting anything to
@@ -32,6 +35,7 @@ struct NakedPantreeApp: App {
             remoteChangeMonitor = RemoteChangeMonitor()
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
+            notificationScheduler = NotificationScheduler()
         } else if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             // Unit tests load us via BUNDLE_LOADER, but the simulator has
             // no iCloud account so `cloudKitContainer()` would fail to
@@ -41,6 +45,7 @@ struct NakedPantreeApp: App {
             remoteChangeMonitor = RemoteChangeMonitor()
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
+            notificationScheduler = NotificationScheduler()
         } else {
             // Phase 2.1: production stack is CloudKit-mirrored. Phase 3
             // adds the sharing service against the same container.
@@ -68,6 +73,7 @@ struct NakedPantreeApp: App {
             // invite. The delegate is instantiated by the system before
             // this init runs, so a static var is the simplest seam.
             NakedPantreeAppDelegate.shareAcceptance = CloudShareAcceptance(container: container)
+            notificationScheduler = NotificationScheduler(center: .current())
         }
     }
 
@@ -78,6 +84,7 @@ struct NakedPantreeApp: App {
                 .environment(\.remoteChangeMonitor, remoteChangeMonitor)
                 .environment(\.accountStatusMonitor, accountStatusMonitor)
                 .environment(\.householdSharing, householdSharing)
+                .environment(\.notificationScheduler, notificationScheduler)
         }
     }
 }

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -19,6 +19,7 @@ struct ItemFormView: View {
     let onSaved: @MainActor () -> Void
 
     @Environment(\.repositories) private var repositories
+    @Environment(\.notificationScheduler) private var notificationScheduler
     @Environment(\.dismiss) private var dismiss
     @State private var name: String = ""
     @State private var quantity: Int32 = 1
@@ -137,6 +138,7 @@ struct ItemFormView: View {
         defer { isSaving = false }
 
         do {
+            let saved: Item
             switch mode {
             case .create(let locationID):
                 let item = Item(
@@ -148,6 +150,7 @@ struct ItemFormView: View {
                     notes: resolvedNotes
                 )
                 try await repositories.item.create(item)
+                saved = item
             case .edit(let original):
                 var updated = original
                 updated.name = trimmedName
@@ -156,7 +159,13 @@ struct ItemFormView: View {
                 updated.expiresAt = resolvedExpiry
                 updated.notes = resolvedNotes
                 try await repositories.item.update(updated)
+                saved = updated
             }
+            // Phase 4.1: schedule (or clear) the expiry notification
+            // off the just-persisted item. `scheduleIfNeeded` handles
+            // the nil-expiry case symmetrically with create vs edit —
+            // clearing an expiry on edit cancels the pending request.
+            await notificationScheduler.scheduleIfNeeded(for: saved)
             onSaved()
             dismiss()
         } catch {

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -10,6 +10,7 @@ struct ItemsView: View {
 
     @Environment(\.repositories) private var repositories
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
+    @Environment(\.notificationScheduler) private var notificationScheduler
     @State private var items: [Item] = []
     @State private var locationName: String?
     @State private var formMode: ItemFormView.Mode?
@@ -161,6 +162,12 @@ struct ItemsView: View {
         if selectedItemID == item.id { selectedItemID = nil }
         do {
             try await repositories.item.delete(id: item.id)
+            // Phase 4.1: cancel any pending expiry notification for
+            // this item so a deleted bottle of milk doesn't ping
+            // someone three days from now. Safe even when no request
+            // was scheduled — `removePendingNotificationRequests` is a
+            // no-op for unknown ids.
+            notificationScheduler.cancel(itemID: item.id)
             if case .location(let id) = selection {
                 await reload(locationID: id)
             }

--- a/NakedPantreeApp/Notifications/NotificationScheduler.swift
+++ b/NakedPantreeApp/Notifications/NotificationScheduler.swift
@@ -1,0 +1,195 @@
+import Foundation
+import NakedPantreeDomain
+import SwiftUI
+import UserNotifications
+
+/// Builds the user-facing notification body for a given expiry, with
+/// the relative phrase pinned to a reference date.
+///
+/// `reference` should be the trigger date (when the notification will
+/// fire), not the save time — `UNMutableNotificationContent.body` is
+/// frozen at scheduling time, so a body computed against `.now` would
+/// drift from reality between save and fire. With the default 3-day
+/// lead, this consistently reads "Expires in 3 days." regardless of
+/// when the user saved the item.
+///
+/// Pure function (not a method on `NotificationScheduler`) so unit
+/// tests can pin the reference date and verify the exact string.
+func expiryNotificationBodyCopy(expiresAt: Date, relativeTo reference: Date) -> String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .full
+    formatter.dateTimeStyle = .named
+    let relative = formatter.localizedString(for: expiresAt, relativeTo: reference)
+    return "Expires \(relative)."
+}
+
+/// Computes the local trigger date for an expiry notification.
+///
+/// Pulled out as a free function so unit tests can pin `calendar` /
+/// `now` without standing up a `UNUserNotificationCenter`. Returns `nil`
+/// when the resulting target is in the past — `UNCalendarNotificationTrigger`
+/// silently drops past dates and produces console noise, so the
+/// scheduler skips registration in that case (lead-time window already
+/// closed; the UI still shows the expiry itself).
+///
+/// Lead time matches `ARCHITECTURE.md` §8: 3 days before `expiresAt`,
+/// fired at 9:00 in the user's local calendar. DST boundaries are
+/// handled by `Calendar.date(bySettingHour:minute:second:of:)`, which
+/// resolves to the wall-clock hour rather than a fixed UTC offset.
+func expiryNotificationTriggerDate(
+    expiresAt: Date,
+    leadDays: Int = 3,
+    hourOfDay: Int = 9,
+    calendar: Calendar = .current,
+    now: Date = .now
+) -> Date? {
+    guard let leadDay = calendar.date(byAdding: .day, value: -leadDays, to: expiresAt) else {
+        return nil
+    }
+    guard
+        let target = calendar.date(
+            bySettingHour: hourOfDay,
+            minute: 0,
+            second: 0,
+            of: leadDay
+        )
+    else {
+        return nil
+    }
+    return target > now ? target : nil
+}
+
+/// Schedules and cancels local expiry notifications for items.
+///
+/// Phase 4.1: callers (`ItemFormView.save()`, `ItemsView.delete()`)
+/// invoke the scheduler directly after a write succeeds. Phase 4.2
+/// will add `NSManagedObjectContextDidSave` / `NSPersistentStoreRemoteChange`
+/// observation so a remote-side edit reschedules without a local UI
+/// round-trip.
+///
+/// **Identifier scheme:** `"item.\(item.id.uuidString).expiry"` — adding
+/// the same identifier replaces any pending request, so re-saving an
+/// item with a changed expiry implicitly reschedules. Clearing the
+/// expiry removes the request.
+///
+/// **Permission flow:** lazy. We never prompt at launch. The first
+/// time a user saves an item with `expiresAt`, we hit
+/// `getNotificationSettings()`. `.notDetermined` → request. `.denied`
+/// → silent skip. `.authorized` / `.provisional` → schedule.
+///
+/// Same architectural placement as `RemoteChangeMonitor` /
+/// `AccountStatusMonitor`: app layer, not behind a Domain protocol.
+/// `UNUserNotificationCenter` is iOS-specific and the future macOS CLI
+/// has no notion of "schedule a banner." Lift behind a protocol if
+/// AppIntents or watchOS need it.
+@MainActor
+final class NotificationScheduler {
+    /// `nonisolated(unsafe)` so the no-op `nonisolated init()` below
+    /// can write the `nil` initial value at construction. The class
+    /// stays `@MainActor` for ergonomic consistency with
+    /// `RemoteChangeMonitor` / `AccountStatusMonitor`;
+    /// `UNUserNotificationCenter` is documented as thread-safe so
+    /// the unsafe qualifier is sound — only the storage write needs
+    /// the relaxation, not the underlying API.
+    nonisolated(unsafe) private let center: UNUserNotificationCenter?
+
+    /// No-op scheduler for previews and tests. `nonisolated` so the
+    /// `@Entry` default value (built in a non-isolated context) can
+    /// call it. The trick is similar in spirit to
+    /// `RemoteChangeMonitor.init()`, but the mechanism differs —
+    /// here the `let center` needs `nonisolated(unsafe)` to be
+    /// settable from a non-isolated init.
+    nonisolated init() {
+        self.center = nil
+    }
+
+    init(center: UNUserNotificationCenter) {
+        self.center = center
+    }
+
+    /// Idempotent. Re-running with the same item replaces any pending
+    /// request (deterministic identifier). Clearing `expiresAt`
+    /// cancels. A past trigger date silently skips.
+    func scheduleIfNeeded(for item: Item) async {
+        guard let center else { return }
+        let id = Self.identifier(for: item.id)
+
+        guard let expiresAt = item.expiresAt else {
+            center.removePendingNotificationRequests(withIdentifiers: [id])
+            return
+        }
+
+        guard let triggerDate = expiryNotificationTriggerDate(expiresAt: expiresAt) else {
+            // Lead-time window has passed. Drop any older request that
+            // might still be pending from a previous expiry value.
+            center.removePendingNotificationRequests(withIdentifiers: [id])
+            return
+        }
+
+        guard await ensureAuthorization(center: center) else {
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = item.name
+        content.body = expiryNotificationBodyCopy(expiresAt: expiresAt, relativeTo: triggerDate)
+        // userInfo is wired in 4.1 even though tap-routing lands in
+        // 4.2 — keeping requests carrying the id means the routing PR
+        // is purely additive (a delegate method) and doesn't need to
+        // backfill identifiers onto already-scheduled requests.
+        content.userInfo = ["itemID": item.id.uuidString]
+        content.sound = .default
+
+        let components = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: triggerDate
+        )
+        let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+
+        do {
+            try await center.add(request)
+        } catch {
+            // No remediation path — `.add` rejects only on system
+            // throttling or denied authorization that flipped between
+            // our check and the call. Silent skip; user has expiry in
+            // the UI either way.
+        }
+    }
+
+    /// Removes the pending request for an item. Used by the delete
+    /// path, which only has the id once the row is gone.
+    func cancel(itemID: Item.ID) {
+        guard let center else { return }
+        center.removePendingNotificationRequests(withIdentifiers: [Self.identifier(for: itemID)])
+    }
+
+    private func ensureAuthorization(center: UNUserNotificationCenter) async -> Bool {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            do {
+                return try await center.requestAuthorization(options: [.alert, .sound, .badge])
+            } catch {
+                return false
+            }
+        @unknown default:
+            return false
+        }
+    }
+
+    /// `nonisolated` — pure function over the id, no instance state.
+    /// Tests call it from a sync `Testing` context.
+    nonisolated static func identifier(for itemID: Item.ID) -> String {
+        "item.\(itemID.uuidString).expiry"
+    }
+
+}
+
+extension EnvironmentValues {
+    @Entry var notificationScheduler = NotificationScheduler()
+}

--- a/NakedPantreeTests/NotificationSchedulerTests.swift
+++ b/NakedPantreeTests/NotificationSchedulerTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+
+@Suite("Expiry notification trigger date")
+struct ExpiryTriggerDateTests {
+    /// Pinned to a fixed timezone + Gregorian calendar so the expected
+    /// instants match across CI runners and developer machines —
+    /// `Calendar.current` would otherwise drift with the host locale.
+    private static func laCalendar() throws -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        let zone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        cal.timeZone = zone
+        return cal
+    }
+
+    private static func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        _ hour: Int = 12,
+        _ minute: Int = 0,
+        in calendar: Calendar
+    ) throws -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return try #require(calendar.date(from: components))
+    }
+
+    @Test("3 days before expiry, fires at 9am local")
+    func threeDaysBeforeAtNineAM() throws {
+        let calendar = try Self.laCalendar()
+        // Item expires Friday March 20, 2026 — 9am local.
+        let expiresAt = try Self.date(2026, 3, 20, 9, 0, in: calendar)
+        let now = try Self.date(2026, 3, 15, 12, 0, in: calendar)
+
+        let trigger = expiryNotificationTriggerDate(
+            expiresAt: expiresAt,
+            calendar: calendar,
+            now: now
+        )
+
+        // 3 days before March 20 is March 17, 9am local.
+        let expected = try Self.date(2026, 3, 17, 9, 0, in: calendar)
+        #expect(trigger == expected)
+    }
+
+    @Test("Trigger fires at 9am local even when expiry is at midnight")
+    func nineAMRegardlessOfExpiryTimeOfDay() throws {
+        let calendar = try Self.laCalendar()
+        let expiresAt = try Self.date(2026, 3, 20, 0, 0, in: calendar)
+        let now = try Self.date(2026, 3, 15, 12, 0, in: calendar)
+
+        let trigger = expiryNotificationTriggerDate(
+            expiresAt: expiresAt,
+            calendar: calendar,
+            now: now
+        )
+
+        let expected = try Self.date(2026, 3, 17, 9, 0, in: calendar)
+        #expect(trigger == expected)
+    }
+
+    @Test("Past trigger date returns nil")
+    func pastTriggerSilentlySkips() throws {
+        let calendar = try Self.laCalendar()
+        // Item expires tomorrow — 3 days before is in the past.
+        let now = try Self.date(2026, 3, 15, 12, 0, in: calendar)
+        let expiresAt = try Self.date(2026, 3, 16, 9, 0, in: calendar)
+
+        let trigger = expiryNotificationTriggerDate(
+            expiresAt: expiresAt,
+            calendar: calendar,
+            now: now
+        )
+
+        #expect(trigger == nil)
+    }
+
+    @Test("Trigger date crosses spring-forward DST boundary cleanly")
+    func dstSpringForwardLandsAtNineAMWallClock() throws {
+        // US spring-forward 2026: clocks jump from 02:00 → 03:00 on
+        // Sunday March 8. An expiry on Wed March 11 with 3-day lead
+        // crosses the boundary — the trigger should still resolve to
+        // 9am wall-clock time on Sunday, not 8am.
+        let calendar = try Self.laCalendar()
+        let expiresAt = try Self.date(2026, 3, 11, 12, 0, in: calendar)
+        let now = try Self.date(2026, 3, 5, 12, 0, in: calendar)
+
+        let trigger = expiryNotificationTriggerDate(
+            expiresAt: expiresAt,
+            calendar: calendar,
+            now: now
+        )
+
+        let expected = try Self.date(2026, 3, 8, 9, 0, in: calendar)
+        let resolved = try #require(trigger)
+        let components = calendar.dateComponents([.hour, .minute], from: resolved)
+        #expect(components.hour == 9)
+        #expect(components.minute == 0)
+        #expect(trigger == expected)
+    }
+
+    @Test("Custom lead days override default")
+    func customLeadDays() throws {
+        let calendar = try Self.laCalendar()
+        let expiresAt = try Self.date(2026, 3, 20, 9, 0, in: calendar)
+        let now = try Self.date(2026, 3, 1, 12, 0, in: calendar)
+
+        let trigger = expiryNotificationTriggerDate(
+            expiresAt: expiresAt,
+            leadDays: 7,
+            calendar: calendar,
+            now: now
+        )
+
+        let expected = try Self.date(2026, 3, 13, 9, 0, in: calendar)
+        #expect(trigger == expected)
+    }
+}
+
+@Suite("Notification body copy")
+struct NotificationBodyCopyTests {
+    @Test("Body relative phrase is anchored to fire time, not save time")
+    func bodyAnchoredToTriggerDate() throws {
+        // User saves item April 1; expires April 30; default 3-day
+        // lead means trigger fires April 27 9am. The body — frozen at
+        // scheduling time — must read "in 3 days" relative to *fire
+        // time*, not "in 4 weeks" relative to save time. This is the
+        // bug-of-record that drove the API shape: `relativeTo` is the
+        // trigger date.
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 4
+        components.day = 30
+        components.hour = 9
+        let calendar = Calendar(identifier: .gregorian)
+        let expiresAt = try #require(calendar.date(from: components))
+
+        components.day = 27
+        let triggerDate = try #require(calendar.date(from: components))
+
+        let body = expiryNotificationBodyCopy(expiresAt: expiresAt, relativeTo: triggerDate)
+        // Lock the prefix; the relative phrase itself is locale-formatted
+        // by `RelativeDateTimeFormatter`. The only invariants we care
+        // about: it starts with "Expires", ends with a period, and the
+        // relative phrase mentions "3 days" — not "4 weeks".
+        #expect(body.hasPrefix("Expires "))
+        #expect(body.hasSuffix("."))
+        #expect(body.contains("3 days"))
+        #expect(!body.contains("week"))
+    }
+}
+
+@Suite("Notification identifier scheme")
+struct NotificationIdentifierTests {
+    @Test("Identifier is deterministic across calls")
+    func identifierIsDeterministic() {
+        let id = UUID()
+        let first = NotificationScheduler.identifier(for: id)
+        let second = NotificationScheduler.identifier(for: id)
+        #expect(first == second)
+    }
+
+    @Test("Identifier matches architecture spec")
+    func identifierFormat() throws {
+        let id = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+        let expected = "item.11111111-2222-3333-4444-555555555555.expiry"
+        #expect(NotificationScheduler.identifier(for: id) == expected)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -196,7 +196,7 @@ household.
 | --- | --- | --- |
 | 3.1 | `CKShare` creation + `UICloudSharingController` bridge + Share Household button | ✅ Merged ([apps#32](https://github.com/ellisandy/NakedPantree/pull/32)) |
 | 3.2 | Share-acceptance handler (`UIApplicationDelegateAdaptor`) | ✅ Merged ([apps#33](https://github.com/ellisandy/NakedPantree/pull/33)) |
-| 3.3 | Cross-store write routing (private vs shared on insert) + verification runbook | 🟡 In review |
+| 3.3 | Cross-store write routing (private vs shared on insert) + verification runbook | ✅ Merged ([apps#34](https://github.com/ellisandy/NakedPantree/pull/34)) |
 
 ---
 
@@ -227,6 +227,14 @@ household.
 - [ ] Tapping the notification opens the app on that item's detail.
 - [ ] On two devices on the same household, both fire — accepted per
       `ARCHITECTURE.md` decisions log #5.
+
+**Sub-milestones**
+
+| # | Title | Status |
+| --- | --- | --- |
+| 4.1 | `NotificationScheduler` + lazy permission + scheduling on item save/delete | 🟡 In review |
+| 4.2 | `NSManagedObjectContextDidSave` / `NSPersistentStoreRemoteChange` observation + tap-to-deep-link routing | ⏳ Pending |
+| 4.3 | Voice-review of notification copy + two-device verification runbook | ⏳ Pending |
 
 ---
 


### PR DESCRIPTION
## Summary

- `NotificationScheduler` (`@MainActor`) wired into `NakedPantreeApp` for production builds; no-op `nonisolated init()` for previews/tests via `@Entry`. Mirrors the `RemoteChangeMonitor` / `AccountStatusMonitor` shape.
- `ItemFormView.save()` calls `scheduleIfNeeded(for:)` after every create/edit; `ItemsView.delete()` calls `cancel(itemID:)`. Deterministic identifier `item.<uuid>.expiry` means re-saving replaces, clearing expiry cancels.
- Permission is lazy — first save with `expiresAt` triggers the prompt; denied returns silently. We never prompt at launch.
- `expiryNotificationTriggerDate` and `expiryNotificationBodyCopy` are pure free functions for testability. Body is anchored to **trigger date**, not save time — `UNMutableNotificationContent.body` is frozen at scheduling, so with the 3-day default lead, the user reads "Expires in 3 days." regardless of how far ahead they saved.
- Past trigger dates silently skip (lead-time window has already closed; `UNCalendarNotificationTrigger` produces console noise on past dates).
- `userInfo["itemID"]` is set now so the 4.2 tap-routing PR is purely additive.

Phase 4.2 (`NSManagedObjectContextDidSave` / `NSPersistentStoreRemoteChange` observation + tap-to-deep-link routing) and 4.3 (voice review + two-device runbook) are scoped separately per ROADMAP.

## Test plan

- [x] `./scripts/lint.sh` exits clean
- [x] Full `xcodebuild test` (minus `SnapshotsUITests`) passes — new suites: trigger-date math (5 tests inc. DST spring-forward), body-copy anchor (the bug-of-record the API shape addresses), identifier format
- [ ] Real-device verification (set/edit/clear `expiresAt`, confirm prompt, confirm fire) — Phase 4 exit criteria, owned by user
- [ ] Two-device verification — deferred to Phase 4.3 runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)