### PR TITLE
Phase 4.2: notification-tap deep-link routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -362,6 +362,13 @@ app to the corresponding `Item` detail via the navigation state's
 - If the app is launched cold from the notification, the routing is applied
   after the persistent store loads, not during onboarding.
 
+**Phase 4.2 interim:** Expiring Soon is stubbed until Phase 6, so routing
+to it on a missing item lands on a placeholder that has nothing to do with
+the deleted item — worse than no navigation at all. Until Smart Lists ship,
+the missing-item case shows the "That item is gone." copy as a one-shot
+alert in place and leaves the user on whatever surface they were viewing.
+Restore the Expiring Soon hand-off when Phase 6 lands the real list.
+
 ### Multi-device behavior
 
 If two household members both have the app installed, both phones will fire

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -15,8 +15,16 @@ struct NakedPantreeApp: App {
     private let accountStatusMonitor: AccountStatusMonitor
     private let householdSharing: CloudHouseholdSharingService?
     private let notificationScheduler: NotificationScheduler
+    private let notificationRouting: NotificationRoutingService
 
     init() {
+        // Phase 4.2: a single routing service across all branches —
+        // preview / snapshot / test surfaces never get tap callbacks
+        // (no scheduled notifications) but the environment value still
+        // needs to resolve, and a fresh service is cheap.
+        let routing = NotificationRoutingService()
+        notificationRouting = routing
+
         if SnapshotFixtures.isSnapshotMode {
             // Bypass Core Data when the snapshot UI tests launch us —
             // they need a deterministic, populated state and never want
@@ -75,6 +83,11 @@ struct NakedPantreeApp: App {
             NakedPantreeAppDelegate.shareAcceptance = CloudShareAcceptance(container: container)
             notificationScheduler = NotificationScheduler(center: .current())
         }
+        // Phase 4.2: the delegate routes notification taps into this
+        // service. Same static-var pattern as `shareAcceptance` —
+        // delegate construction precedes app init, so the seam is a
+        // post-hoc handoff.
+        NakedPantreeAppDelegate.notificationRouting = routing
     }
 
     var body: some Scene {
@@ -85,6 +98,7 @@ struct NakedPantreeApp: App {
                 .environment(\.accountStatusMonitor, accountStatusMonitor)
                 .environment(\.householdSharing, householdSharing)
                 .environment(\.notificationScheduler, notificationScheduler)
+                .environment(\.notificationRouting, notificationRouting)
         }
     }
 }

--- a/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
+++ b/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
@@ -2,22 +2,43 @@ import CloudKit
 import NakedPantreePersistence
 import SwiftUI
 import UIKit
+import UserNotifications
 
-/// `UIApplicationDelegate` shim for the one event SwiftUI's `App`
-/// lifecycle doesn't natively expose: the iCloud share-accept callback
-/// (`application(_:userDidAcceptCloudKitShareWith:)`). When a recipient
-/// taps an invite link in Messages / Mail / AirDrop, iOS calls this
-/// method on the registered delegate. Wired in via
-/// `@UIApplicationDelegateAdaptor` in `NakedPantreeApp`.
+/// `UIApplicationDelegate` shim for the events SwiftUI's `App` lifecycle
+/// doesn't natively expose:
 ///
-/// The delegate is instantiated by the system **before** `NakedPantreeApp.init`
-/// runs, so we can't take the acceptance service via the initializer.
-/// `NakedPantreeApp.init` writes to `Self.shareAcceptance` after
-/// constructing the production CloudKit container; preview / test
-/// branches leave it `nil`, which means a stray invite during a test
-/// run no-ops instead of crashing.
-final class NakedPantreeAppDelegate: NSObject, UIApplicationDelegate {
+/// 1. `application(_:userDidAcceptCloudKitShareWith:)` — Phase 3.2:
+///    iCloud share-accept callback when a recipient taps an invite.
+/// 2. `userNotificationCenter(_:didReceive:withCompletionHandler:)` —
+///    Phase 4.2: notification-tap deep link to the relevant item.
+///
+/// Wired in via `@UIApplicationDelegateAdaptor` in `NakedPantreeApp`.
+/// The delegate is instantiated by the system **before**
+/// `NakedPantreeApp.init` runs, so we can't take collaborators via the
+/// initializer. `NakedPantreeApp.init` writes the production
+/// dependencies to the static vars below; preview / test branches
+/// leave them `nil`, which means a stray invite or notification tap
+/// during a test run no-ops instead of crashing.
+final class NakedPantreeAppDelegate:
+    NSObject,
+    UIApplicationDelegate,
+    UNUserNotificationCenterDelegate
+{
     nonisolated(unsafe) static var shareAcceptance: CloudShareAcceptance?
+    nonisolated(unsafe) static var notificationRouting: NotificationRoutingService?
+
+    /// Setting `UNUserNotificationCenter.delegate` later than this
+    /// (e.g. from a SwiftUI `.task`) drops cold-launch tap responses
+    /// — iOS holds the response only until the launch sequence
+    /// completes. Assigning here, with the `@UIApplicationDelegateAdaptor`-
+    /// owned delegate already alive, is the system-supported seam.
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
 
     func application(
         _ application: UIApplication,
@@ -35,6 +56,34 @@ final class NakedPantreeAppDelegate: NSObject, UIApplicationDelegate {
                 // chase, not a per-tap retry.
                 print("CloudKit share acceptance failed: \(error)")
             }
+        }
+    }
+
+    /// Tap → publish parsed `itemID` to the routing service. RootView
+    /// observes and either navigates to the detail or shows the
+    /// "That item is gone" alert (item missing, e.g. another household
+    /// member deleted it before the tap). Per ARCHITECTURE.md §8 the
+    /// missing-item case should land on Expiring Soon — the smart list
+    /// is stubbed until Phase 6, so the interim is a banner alert in
+    /// place; the §8 note records the divergence.
+    /// `nonisolated` because `UIApplicationDelegate` makes this class
+    /// implicitly main-actor-isolated, but `UNUserNotificationCenterDelegate`
+    /// requirements are nonisolated. The delegate method itself does
+    /// only synchronous, thread-safe work (parse the payload, call the
+    /// completion handler) and hops to the main actor before touching
+    /// the routing service's stored property.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping @Sendable () -> Void
+    ) {
+        defer { completionHandler() }
+        guard
+            let id = notificationItemID(from: response.notification.request.content.userInfo),
+            let routing = Self.notificationRouting
+        else { return }
+        Task { @MainActor in
+            routing.pendingItemID = id
         }
     }
 }

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -21,8 +21,10 @@ struct RootView: View {
     @State private var sidebarSelection: SidebarSelection?
     @State private var selectedItemID: Item.ID?
     @State private var bootstrapComplete = false
+    @State private var isShowingMissingItemAlert = false
     @Environment(\.repositories) private var repositories
     @Environment(\.accountStatusMonitor) private var accountStatusMonitor
+    @Environment(\.notificationRouting) private var notificationRouting
 
     var body: some View {
         Group {
@@ -48,6 +50,35 @@ struct RootView: View {
         .task {
             await runBootstrap()
             bootstrapComplete = true
+            // Cold-launch path: a tap before the view appeared will have
+            // already published `pendingItemID`. `.onChange` only fires
+            // on changes after the view is alive, so we apply once here.
+            // Clear *before* awaiting so a second tap during the
+            // suspended apply queues into `pendingItemID` instead of
+            // being lost.
+            if let pending = notificationRouting.pendingItemID {
+                notificationRouting.pendingItemID = nil
+                await applyDeepLink(itemID: pending)
+            }
+        }
+        .onChange(of: notificationRouting.pendingItemID) { _, newValue in
+            // Warm-tap path: app already running, user taps a banner.
+            // Bootstrap-complete gate keeps the cold-launch case from
+            // double-applying — the `.task` block above handles that
+            // and clears `pendingItemID` before the change observer
+            // would fire on the cleared-back-to-nil value.
+            guard bootstrapComplete, let id = newValue else { return }
+            // Same ordering rationale as the cold-launch path: clear
+            // before awaiting so a second tap during the suspended
+            // apply re-publishes onto `pendingItemID` rather than
+            // racing with this completion.
+            notificationRouting.pendingItemID = nil
+            Task {
+                await applyDeepLink(itemID: id)
+            }
+        }
+        .alert("That item is gone.", isPresented: $isShowingMissingItemAlert) {
+            Button("OK", role: .cancel) {}
         }
     }
 
@@ -68,6 +99,31 @@ struct RootView: View {
             if let itemID = await SnapshotFixtures.resolveInitialItem(in: repositories) {
                 selectedItemID = itemID
             }
+        }
+    }
+
+    /// Resolves a notification-tap deep link. Sets the sidebar to the
+    /// item's location and selects the item, or shows the
+    /// "That item is gone." alert if the item has been deleted (e.g.
+    /// remote household member tossed it before the tap landed).
+    ///
+    /// Per ARCHITECTURE.md §8 the missing-item case should land on the
+    /// Expiring Soon smart list. That list is stubbed until Phase 6, so
+    /// the interim is a deselect + alert in place. The §8 note records
+    /// the divergence; revisit when Smart Lists ship.
+    private func applyDeepLink(itemID: Item.ID) async {
+        do {
+            guard let item = try await repositories.item.item(id: itemID) else {
+                isShowingMissingItemAlert = true
+                return
+            }
+            sidebarSelection = .location(item.locationID)
+            selectedItemID = item.id
+        } catch {
+            // Repository read failed — most likely a transient store
+            // hiccup. Keep the user where they were rather than dumping
+            // them into an alert; if it was a real bug, the next tap or
+            // remote-change tick will reload state.
         }
     }
 }

--- a/NakedPantreeApp/Notifications/NotificationRoutingService.swift
+++ b/NakedPantreeApp/Notifications/NotificationRoutingService.swift
@@ -1,0 +1,52 @@
+import Foundation
+import NakedPantreeDomain
+import SwiftUI
+
+/// Extracts the `Item.ID` from a notification's `userInfo` payload.
+///
+/// Pulled out as a free function so the
+/// `UNUserNotificationCenterDelegate` callback stays synchronous (and
+/// fast — the system gives us until the completion handler fires) and
+/// unit tests can pin a payload without standing up a delegate.
+///
+/// The payload contract is `["itemID": "<uuid-string>"]`, set in
+/// `NotificationScheduler.scheduleIfNeeded`. Returns `nil` for missing
+/// keys, non-string values, or malformed UUIDs — the caller silently
+/// skips routing in those cases.
+func notificationItemID(from userInfo: [AnyHashable: Any]) -> Item.ID? {
+    guard let raw = userInfo["itemID"] as? String else { return nil }
+    return UUID(uuidString: raw)
+}
+
+/// Bridges notification taps from the `UIApplicationDelegate` layer to
+/// the `RootView` navigation state.
+///
+/// Tap handling can't live directly in the view layer:
+/// `UNUserNotificationCenter.delegate` must be assigned **before**
+/// `application(_:didFinishLaunchingWithOptions:)` returns, otherwise
+/// cold-launch responses are silently dropped. The delegate publishes
+/// the parsed `itemID` to this service; `RootView` observes via
+/// `.onChange` (warm-tap path) and reads `pendingItemID` once after
+/// bootstrap completes (cold-launch path) before clearing it back to
+/// nil.
+///
+/// Same architectural placement as `RemoteChangeMonitor` /
+/// `NotificationScheduler`: app layer, not behind a Domain protocol.
+/// `UNUserNotificationCenter` is iOS-specific.
+@Observable
+@MainActor
+final class NotificationRoutingService {
+    /// Set by the notification delegate when the user taps a banner.
+    /// `RootView` resolves the item, navigates, then clears this back
+    /// to nil. Cleared value avoids re-routing on subsequent unrelated
+    /// changeToken bumps.
+    var pendingItemID: Item.ID?
+
+    /// `nonisolated` so the `@Entry` environment default value
+    /// (constructed in a non-isolated context) can call it.
+    nonisolated init() {}
+}
+
+extension EnvironmentValues {
+    @Entry var notificationRouting = NotificationRoutingService()
+}

--- a/NakedPantreeTests/NotificationRoutingTests.swift
+++ b/NakedPantreeTests/NotificationRoutingTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+
+@Suite("Notification routing payload parsing")
+struct NotificationItemIDParsingTests {
+    @Test("Valid uuid string round-trips")
+    func validUUIDStringParses() throws {
+        let id = UUID()
+        let payload: [AnyHashable: Any] = ["itemID": id.uuidString]
+        let parsed = try #require(notificationItemID(from: payload))
+        #expect(parsed == id)
+    }
+
+    @Test("Missing itemID key returns nil")
+    func missingKeyReturnsNil() {
+        let payload: [AnyHashable: Any] = ["other": "value"]
+        #expect(notificationItemID(from: payload) == nil)
+    }
+
+    @Test("Non-string itemID value returns nil")
+    func nonStringValueReturnsNil() {
+        // Defensive: a malformed payload from a third party (or a
+        // hand-crafted notification in tests) shouldn't crash the
+        // routing layer. UUIDs are encoded as strings per the
+        // scheduler's contract.
+        let payload: [AnyHashable: Any] = ["itemID": 42]
+        #expect(notificationItemID(from: payload) == nil)
+    }
+
+    @Test("Malformed UUID string returns nil")
+    func malformedUUIDStringReturnsNil() {
+        let payload: [AnyHashable: Any] = ["itemID": "not-a-uuid"]
+        #expect(notificationItemID(from: payload) == nil)
+    }
+
+    @Test("Empty payload returns nil")
+    func emptyPayloadReturnsNil() {
+        #expect(notificationItemID(from: [:]) == nil)
+    }
+}
+
+@Suite("Notification routing service")
+@MainActor
+struct NotificationRoutingServiceTests {
+    @Test("Pending itemID round-trips through the service")
+    func pendingIDRoundTrips() {
+        let service = NotificationRoutingService()
+        let id = UUID()
+        #expect(service.pendingItemID == nil)
+        service.pendingItemID = id
+        #expect(service.pendingItemID == id)
+        service.pendingItemID = nil
+        #expect(service.pendingItemID == nil)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -232,9 +232,10 @@ household.
 
 | # | Title | Status |
 | --- | --- | --- |
-| 4.1 | `NotificationScheduler` + lazy permission + scheduling on item save/delete | 🟡 In review |
-| 4.2 | `NSManagedObjectContextDidSave` / `NSPersistentStoreRemoteChange` observation + tap-to-deep-link routing | ⏳ Pending |
-| 4.3 | Voice-review of notification copy + two-device verification runbook | ⏳ Pending |
+| 4.1 | `NotificationScheduler` + lazy permission + scheduling on item save/delete | ✅ Merged ([apps#35](https://github.com/ellisandy/NakedPantree/pull/35)) |
+| 4.2 | Tap-to-deep-link routing (`UNUserNotificationCenterDelegate` + `RootView` navigation) | 🟡 In review |
+| 4.3 | Auto-reschedule on `NSPersistentStoreRemoteChange` (depends on issue #28 history-token bookkeeping) | ⏳ Pending |
+| 4.4 | Voice-review of notification copy + two-device verification runbook | ⏳ Pending |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `UNUserNotificationCenterDelegate` conformance on `NakedPantreeAppDelegate` and a `NotificationRoutingService` that bridges notification taps into `RootView` navigation state.
- Tapping a scheduled expiry notification opens the app to the item's detail (sidebar selects the item's location, content selects the item).
- Missing-item case (item deleted from another device before the tap) shows a one-shot "That item is gone." alert in place — interim documented in ARCHITECTURE.md §8 because Expiring Soon is stubbed until Phase 6.
- `UNUserNotificationCenter.delegate` is assigned in `application(_:didFinishLaunchingWithOptions:)` so cold-launch tap responses survive the launch sequence.
- Splits the original Phase 4.2 scope: `NSPersistentStoreRemoteChange` auto-reschedule moves to Phase 4.3 (depends on issue #28); voice review + two-device runbook moves to Phase 4.4. ROADMAP table updated.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 51 tests in 15 suites pass, including 6 new tests covering payload parsing edge cases (5) and routing-service round-trip (1).
- [ ] **Real-device verification (USER-OWNED, Phase 4 exit criteria):** schedule an expiry, foreground- and cold-launch-tap the banner, confirm navigation lands on the item; delete the item from a second device, tap the banner on the first, confirm the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)