### PR TITLE
Phase 4.3: auto-reschedule expiries on remote-change ticks

### DIFF
--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -25,6 +25,8 @@ struct RootView: View {
     @Environment(\.repositories) private var repositories
     @Environment(\.accountStatusMonitor) private var accountStatusMonitor
     @Environment(\.notificationRouting) private var notificationRouting
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
+    @Environment(\.notificationScheduler) private var notificationScheduler
 
     var body: some View {
         Group {
@@ -41,6 +43,14 @@ struct RootView: View {
                     } detail: {
                         ItemDetailView(itemID: selectedItemID)
                     }
+                }
+                // Phase 4.3: every remote-change tick (including the
+                // first cold-launch one) reconciles pending expiry
+                // notifications with the current item set. Lives inside
+                // the `bootstrapComplete` branch so it never runs before
+                // `currentHousehold()` has anything to return.
+                .task(id: remoteChangeMonitor.changeToken) {
+                    await resyncExpiryNotifications()
                 }
             } else {
                 Color.brandWarmCream
@@ -124,6 +134,20 @@ struct RootView: View {
             // hiccup. Keep the user where they were rather than dumping
             // them into an alert; if it was a real bug, the next tap or
             // remote-change tick will reload state.
+        }
+    }
+
+    /// Reconciles pending notification requests with the current item
+    /// set. A read failure leaves the existing requests alone — better
+    /// than nuking pending notifications on a transient hiccup.
+    private func resyncExpiryNotifications() async {
+        do {
+            let household = try await repositories.household.currentHousehold()
+            let items = try await repositories.item.allItems(in: household.id)
+            await notificationScheduler.resync(currentItems: items)
+        } catch {
+            // Swallow — see comment above. The next changeToken tick
+            // will retry.
         }
     }
 }

--- a/NakedPantreeApp/Notifications/NotificationScheduler.swift
+++ b/NakedPantreeApp/Notifications/NotificationScheduler.swift
@@ -59,13 +59,57 @@ func expiryNotificationTriggerDate(
     return target > now ? target : nil
 }
 
+/// Parses the item UUID out of a notification identifier produced by
+/// `NotificationScheduler.identifier(for:)`. Returns `nil` for any
+/// identifier that doesn't match the `"item.<uuid>.expiry"` shape —
+/// keeps the resync sweep tolerant of stray identifiers a future
+/// scheduler variant might add (e.g. low-stock alerts in Phase 6).
+///
+/// Pure function so tests can pin both the parse and the diff logic
+/// without touching `UNUserNotificationCenter`.
+func parseExpiryNotificationItemID(fromIdentifier identifier: String) -> UUID? {
+    let parts = identifier.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts[0] == "item", parts[2] == "expiry" else {
+        return nil
+    }
+    return UUID(uuidString: String(parts[1]))
+}
+
+/// Returns the set of pending notification identifiers that should be
+/// cancelled because the underlying item no longer appears in the
+/// current item set. Identifiers we don't recognize as item-expiry
+/// notifications (e.g. future low-stock alerts) are passed through
+/// untouched — the resync sweep stays narrowly scoped to its own kind.
+///
+/// Pure free function over two id sets so the diff logic is unit-testable
+/// without standing up a `UNUserNotificationCenter`.
+func staleExpiryIdentifiers(
+    pending: [String],
+    currentItemIDs: Set<UUID>
+) -> [String] {
+    pending.filter { identifier in
+        guard let itemID = parseExpiryNotificationItemID(fromIdentifier: identifier) else {
+            return false
+        }
+        return !currentItemIDs.contains(itemID)
+    }
+}
+
 /// Schedules and cancels local expiry notifications for items.
 ///
 /// Phase 4.1: callers (`ItemFormView.save()`, `ItemsView.delete()`)
-/// invoke the scheduler directly after a write succeeds. Phase 4.2
-/// will add `NSManagedObjectContextDidSave` / `NSPersistentStoreRemoteChange`
-/// observation so a remote-side edit reschedules without a local UI
-/// round-trip.
+/// invoke the scheduler directly after a write succeeds — the
+/// low-latency local fast path. Phase 4.3 adds `resync(currentItems:)`,
+/// driven by the `NSPersistentStoreRemoteChange` observer
+/// (`RemoteChangeMonitor.changeToken`) wired in `RootView`. The two
+/// paths are intentionally redundant: form callbacks fire immediately
+/// without the observer's debounce; the observer is the correctness
+/// backstop for remote changes and cold-launch backfill. Both ride
+/// the same idempotent `scheduleIfNeeded`, so the overlap costs only
+/// a few CPU cycles. Issue #28 (history-token bookkeeping) would let
+/// the observer skip locally-authored transactions and remove the
+/// redundancy without changing observable behavior — complementary,
+/// not blocking.
 ///
 /// **Identifier scheme:** `"item.\(item.id.uuidString).expiry"` — adding
 /// the same identifier replaces any pending request, so re-saving an
@@ -162,6 +206,57 @@ final class NotificationScheduler {
     func cancel(itemID: Item.ID) {
         guard let center else { return }
         center.removePendingNotificationRequests(withIdentifiers: [Self.identifier(for: itemID)])
+    }
+
+    /// Brings pending expiry notifications into agreement with the
+    /// current set of items.
+    ///
+    /// Drives:
+    /// - re-schedule each existing item via `scheduleIfNeeded` (idempotent
+    ///   — replaces the pending request when expiry changed, removes it
+    ///   when expiry was cleared, no-ops when nothing changed)
+    /// - cancel pending expiry requests whose underlying item no longer
+    ///   exists (remote delete from another household member)
+    ///
+    /// Called from `RootView` on every `RemoteChangeMonitor.changeToken`
+    /// tick. The first tick fires at cold launch — that's intentional:
+    /// it backfills "user reinstalled," "user re-granted notification
+    /// permission," and "remote changes happened while backgrounded
+    /// for weeks." The cost is O(items) + O(pending requests) per pass;
+    /// fine for typical pantry sizes. The reschedule loop is serial:
+    /// each `scheduleIfNeeded` awaits a settings check then `add`, and
+    /// `TaskGroup`-style fan-out would race the `.notDetermined` path.
+    /// After the gate below fires, the per-item path is fast.
+    ///
+    /// **Permission gate.** A blanket `.notDetermined` bail at the top
+    /// keeps this background sweep from triggering the permission
+    /// prompt — a cold launch with seeded items would otherwise call
+    /// `scheduleIfNeeded` → `ensureAuthorization` → `requestAuthorization`,
+    /// breaking Phase 4.1's "lazy. We never prompt at launch" contract.
+    /// The explicit form-save path (`scheduleIfNeeded` direct) keeps
+    /// its prompt because that's the contextual moment.
+    func resync(currentItems: [Item]) async {
+        guard let center else { return }
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            break
+        case .notDetermined, .denied:
+            // Sweep is a background reconciliation, not a contextual
+            // moment. Bail rather than prompt.
+            return
+        @unknown default:
+            return
+        }
+        for item in currentItems {
+            await scheduleIfNeeded(for: item)
+        }
+        let pending = await center.pendingNotificationRequests().map(\.identifier)
+        let currentIDs = Set(currentItems.map(\.id))
+        let stale = staleExpiryIdentifiers(pending: pending, currentItemIDs: currentIDs)
+        if !stale.isEmpty {
+            center.removePendingNotificationRequests(withIdentifiers: stale)
+        }
     }
 
     private func ensureAuthorization(center: UNUserNotificationCenter) async -> Bool {

--- a/NakedPantreeTests/NotificationResyncTests.swift
+++ b/NakedPantreeTests/NotificationResyncTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+
+@Suite("Notification identifier parsing")
+struct NotificationIdentifierParsingTests {
+    @Test("Round-trips a scheduler-produced identifier")
+    func roundTripsValid() throws {
+        let id = UUID()
+        let identifier = NotificationScheduler.identifier(for: id)
+        let parsed = try #require(parseExpiryNotificationItemID(fromIdentifier: identifier))
+        #expect(parsed == id)
+    }
+
+    @Test("Returns nil for the wrong prefix")
+    func wrongPrefixReturnsNil() {
+        let id = UUID()
+        let identifier = "lowstock.\(id.uuidString).expiry"
+        #expect(parseExpiryNotificationItemID(fromIdentifier: identifier) == nil)
+    }
+
+    @Test("Returns nil for the wrong suffix")
+    func wrongSuffixReturnsNil() {
+        let id = UUID()
+        let identifier = "item.\(id.uuidString).reminder"
+        #expect(parseExpiryNotificationItemID(fromIdentifier: identifier) == nil)
+    }
+
+    @Test("Returns nil for malformed UUID middle segment")
+    func malformedUUIDReturnsNil() {
+        let identifier = "item.not-a-uuid.expiry"
+        #expect(parseExpiryNotificationItemID(fromIdentifier: identifier) == nil)
+    }
+
+    @Test("Returns nil for an identifier with no dots")
+    func noDotsReturnsNil() {
+        #expect(parseExpiryNotificationItemID(fromIdentifier: "garbage") == nil)
+    }
+
+    @Test("Returns nil for the empty string")
+    func emptyStringReturnsNil() {
+        #expect(parseExpiryNotificationItemID(fromIdentifier: "") == nil)
+    }
+
+    @Test("Returns nil for too many dotted segments")
+    func tooManySegmentsReturnsNil() {
+        let id = UUID()
+        let identifier = "item.\(id.uuidString).expiry.extra"
+        #expect(parseExpiryNotificationItemID(fromIdentifier: identifier) == nil)
+    }
+}
+
+@Suite("Stale-identifier diff")
+struct StaleExpiryIdentifiersTests {
+    @Test("Identifiers whose item is gone are returned for cancellation")
+    func returnsStaleIdentifiers() {
+        let kept = UUID()
+        let removed = UUID()
+        let pending = [
+            NotificationScheduler.identifier(for: kept),
+            NotificationScheduler.identifier(for: removed),
+        ]
+        let stale = staleExpiryIdentifiers(
+            pending: pending,
+            currentItemIDs: [kept]
+        )
+        #expect(stale == [NotificationScheduler.identifier(for: removed)])
+    }
+
+    @Test("Empty current item set cancels everything matching the schema")
+    func emptyCurrentSetCancelsAll() {
+        let first = UUID()
+        let second = UUID()
+        let pending = [
+            NotificationScheduler.identifier(for: first),
+            NotificationScheduler.identifier(for: second),
+        ]
+        let stale = staleExpiryIdentifiers(pending: pending, currentItemIDs: [])
+        #expect(Set(stale) == Set(pending))
+    }
+
+    @Test("Foreign identifiers are passed through, not cancelled")
+    func ignoresUnknownSchemaIdentifiers() {
+        // A future scheduler kind (e.g. low-stock alerts) must not have
+        // its requests collateral-cancelled by this expiry sweep.
+        let foreign = "lowstock.\(UUID().uuidString).alert"
+        let stale = staleExpiryIdentifiers(
+            pending: [foreign],
+            currentItemIDs: []
+        )
+        #expect(stale.isEmpty)
+    }
+
+    @Test("All current — nothing stale")
+    func nothingStaleWhenAllPresent() {
+        let first = UUID()
+        let second = UUID()
+        let pending = [
+            NotificationScheduler.identifier(for: first),
+            NotificationScheduler.identifier(for: second),
+        ]
+        let stale = staleExpiryIdentifiers(
+            pending: pending,
+            currentItemIDs: [first, second]
+        )
+        #expect(stale.isEmpty)
+    }
+
+    @Test("Empty pending — nothing stale")
+    func emptyPendingReturnsEmpty() {
+        let stale = staleExpiryIdentifiers(
+            pending: [],
+            currentItemIDs: [UUID(), UUID()]
+        )
+        #expect(stale.isEmpty)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,8 +233,8 @@ household.
 | # | Title | Status |
 | --- | --- | --- |
 | 4.1 | `NotificationScheduler` + lazy permission + scheduling on item save/delete | ✅ Merged ([apps#35](https://github.com/ellisandy/NakedPantree/pull/35)) |
-| 4.2 | Tap-to-deep-link routing (`UNUserNotificationCenterDelegate` + `RootView` navigation) | 🟡 In review |
-| 4.3 | Auto-reschedule on `NSPersistentStoreRemoteChange` (depends on issue #28 history-token bookkeeping) | ⏳ Pending |
+| 4.2 | Tap-to-deep-link routing (`UNUserNotificationCenterDelegate` + `RootView` navigation) | ✅ Merged ([apps#36](https://github.com/ellisandy/NakedPantree/pull/36)) |
+| 4.3 | Auto-reschedule on `NSPersistentStoreRemoteChange` (complementary to issue #28) | 🟡 In review |
 | 4.4 | Voice-review of notification copy + two-device verification runbook | ⏳ Pending |
 
 ---


### PR DESCRIPTION
## Summary

- Adds `NotificationScheduler.resync(currentItems:)` driven by `.task(id: remoteChangeMonitor.changeToken)` in `RootView`. Every remote-change tick (including the first one at cold launch) reschedules each item and cancels pending requests whose underlying item is gone.
- Resync gates on `.authorized` / `.provisional` / `.ephemeral` up front so the background sweep doesn't fire the permission prompt — preserves Phase 4.1's "lazy. We never prompt at launch" contract. The explicit form-save path keeps its contextual prompt.
- Two new pure helpers — `parseExpiryNotificationItemID(fromIdentifier:)` and `staleExpiryIdentifiers(pending:currentItemIDs:)` — backed by 12 new unit tests.
- Form-save callbacks from 4.1 stay in place. They give the immediate scheduling response; resync is the correctness backstop for remote changes and cold-launch backfill. The redundancy is intentional and idempotent. Issue #28 history-token bookkeeping is the natural follow-up: it would let the observer skip locally-authored transactions and remove the overlap without changing behavior — complementary, not blocking.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 63 tests in 17 suites pass (12 new — 7 parsing edge cases, 5 diff-logic cases).
- [ ] **Real-device verification (USER-OWNED, Phase 4 exit criteria):** edit an item's expiry on device A, confirm device B's pending notification updates within a remote-change tick; delete an item on device A, confirm device B cancels its pending request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)