### PR TITLE
Phase 5.1: app-layer image pipeline (resize + thumbnail)

### DIFF
--- a/NakedPantreeApp/Photos/ImagePipeline.swift
+++ b/NakedPantreeApp/Photos/ImagePipeline.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Default max long-edge for the full-resolution `imageData` we persist
+/// per `ARCHITECTURE.md` §9 / Phase 5 scope. Larger source photos are
+/// downscaled before write; smaller ones pass through untouched.
+let defaultPhotoMaxLongEdge: Int = 2048
+
+/// Default max long-edge for the inline `thumbnailData` blob shown in
+/// list rows and grids. ~256 px keeps the encoded JPEG comfortably under
+/// the ~64 KB inline-storage target while still looking sharp on a
+/// retina display.
+let defaultThumbnailMaxLongEdge: Int = 256
+
+/// Resize-and-encode source image data to a JPEG no larger than
+/// `maxLongEdge` on its longest side.
+///
+/// Uses `ImageIO`'s thumbnail API rather than `UIGraphicsImageRenderer`
+/// for two reasons: it streams the source instead of decoding the full
+/// image into memory first (a 12-megapixel HEIC from a recent iPhone
+/// is ~30MB decoded, ~3MB encoded), and `kCGImageSourceCreateThumbnailWithTransform`
+/// applies the EXIF-orientation rotation in one shot — naive
+/// `UIImage(data:)` → resize loses the orientation, producing
+/// sideways-rotated photos for portrait-shot iPhone images.
+///
+/// Always returns a JPEG (`UTType.jpeg`) regardless of the input
+/// container. Output portability beats source-format fidelity for
+/// pantry photos. Returns `nil` if the input isn't a parseable image.
+///
+/// Pure function so tests can pin synthetic input and verify exact
+/// output dimensions without a UI surface.
+func resizedPhotoData(
+    from data: Data,
+    maxLongEdge: Int = defaultPhotoMaxLongEdge,
+    compressionQuality: Double = 0.85
+) -> Data? {
+    encodeJPEG(
+        from: data,
+        maxLongEdge: maxLongEdge,
+        compressionQuality: compressionQuality
+    )
+}
+
+/// Generate the inline thumbnail JPEG sized for list-row and grid
+/// display. Lower compression quality than the full-size resize since
+/// the thumbnail is small enough that JPEG artifacts disappear into
+/// the rendering scale.
+///
+/// Same `ImageIO` thumbnail-with-transform path as `resizedPhotoData`
+/// — see that function's doc-comment for the EXIF / streaming
+/// rationale.
+func thumbnailPhotoData(
+    from data: Data,
+    maxLongEdge: Int = defaultThumbnailMaxLongEdge,
+    compressionQuality: Double = 0.7
+) -> Data? {
+    encodeJPEG(
+        from: data,
+        maxLongEdge: maxLongEdge,
+        compressionQuality: compressionQuality
+    )
+}
+
+private func encodeJPEG(
+    from data: Data,
+    maxLongEdge: Int,
+    compressionQuality: Double
+) -> Data? {
+    guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+        return nil
+    }
+    let thumbnailOptions: [CFString: Any] = [
+        kCGImageSourceCreateThumbnailFromImageAlways: true,
+        kCGImageSourceCreateThumbnailWithTransform: true,
+        kCGImageSourceShouldCacheImmediately: true,
+        kCGImageSourceThumbnailMaxPixelSize: maxLongEdge,
+    ]
+    guard
+        let scaled = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            thumbnailOptions as CFDictionary
+        )
+    else {
+        return nil
+    }
+    let output = NSMutableData()
+    guard
+        let destination = CGImageDestinationCreateWithData(
+            output,
+            UTType.jpeg.identifier as CFString,
+            1,
+            nil
+        )
+    else {
+        return nil
+    }
+    let writeOptions: [CFString: Any] = [
+        kCGImageDestinationLossyCompressionQuality: compressionQuality
+    ]
+    CGImageDestinationAddImage(destination, scaled, writeOptions as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else { return nil }
+    return output as Data
+}

--- a/NakedPantreeTests/ImagePipelineTests.swift
+++ b/NakedPantreeTests/ImagePipelineTests.swift
@@ -1,0 +1,140 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import NakedPantree
+
+/// Synthesizes a JPEG-encoded `Data` blob of the given pixel dimensions.
+/// Hermetic — no file fixtures, no network. The pixel content is solid
+/// gray so JPEG compression is highly predictable.
+private func makeTestJPEG(width: Int, height: Int) throws -> Data {
+    let colorSpace = try #require(CGColorSpace(name: CGColorSpace.sRGB))
+    let bitmapInfo = CGImageAlphaInfo.noneSkipFirst.rawValue
+    let context = try #require(
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        )
+    )
+    context.setFillColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    let cgImage = try #require(context.makeImage())
+    let output = NSMutableData()
+    let destination = try #require(
+        CGImageDestinationCreateWithData(
+            output, UTType.jpeg.identifier as CFString, 1, nil
+        )
+    )
+    CGImageDestinationAddImage(destination, cgImage, nil)
+    #expect(CGImageDestinationFinalize(destination))
+    return output as Data
+}
+
+/// Reads back the pixel dimensions of an encoded image blob.
+private func pixelDimensions(of data: Data) throws -> (width: Int, height: Int) {
+    let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+    let properties = try #require(
+        CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any]
+    )
+    let width = try #require(properties[kCGImagePropertyPixelWidth] as? Int)
+    let height = try #require(properties[kCGImagePropertyPixelHeight] as? Int)
+    return (width, height)
+}
+
+@Suite("Photo resize pipeline")
+struct ResizedPhotoDataTests {
+    @Test("Square 4096px source resizes to 2048 long edge")
+    func squareSourceCappedAtMaxLongEdge() throws {
+        let source = try makeTestJPEG(width: 4096, height: 4096)
+        let resized = try #require(resizedPhotoData(from: source))
+        let dimensions = try pixelDimensions(of: resized)
+        #expect(dimensions.width == 2048)
+        #expect(dimensions.height == 2048)
+    }
+
+    @Test("Landscape 4000x3000 source preserves aspect ratio")
+    func landscapeAspectRatioPreserved() throws {
+        let source = try makeTestJPEG(width: 4000, height: 3000)
+        let resized = try #require(resizedPhotoData(from: source))
+        let dimensions = try pixelDimensions(of: resized)
+        // 4000 / 2048 = ~1.95; 3000 / 1.95 = ~1536.
+        #expect(dimensions.width == 2048)
+        #expect(dimensions.height == 1536)
+    }
+
+    @Test("Portrait 3000x4000 source caps the longest edge, not width")
+    func portraitCapsLongestEdge() throws {
+        let source = try makeTestJPEG(width: 3000, height: 4000)
+        let resized = try #require(resizedPhotoData(from: source))
+        let dimensions = try pixelDimensions(of: resized)
+        #expect(dimensions.height == 2048)
+        #expect(dimensions.width == 1536)
+    }
+
+    @Test("Already-small source passes through at original dimensions")
+    func alreadySmallSourcePassesThrough() throws {
+        // A 1024x768 source is below the 2048 cap. ImageIO's thumbnail
+        // API clamps at source size when the requested edge exceeds it,
+        // so the output dimensions should match the input exactly. Any
+        // mismatch (upscale, or a quiet off-by-one downscale) is a
+        // regression we want to catch.
+        let source = try makeTestJPEG(width: 1024, height: 768)
+        let resized = try #require(resizedPhotoData(from: source))
+        let dimensions = try pixelDimensions(of: resized)
+        #expect(dimensions.width == 1024)
+        #expect(dimensions.height == 768)
+    }
+
+    @Test("Non-image input returns nil")
+    func garbageInputReturnsNil() {
+        let garbage = Data("not an image".utf8)
+        #expect(resizedPhotoData(from: garbage) == nil)
+    }
+
+    @Test("Custom maxLongEdge overrides default")
+    func customMaxLongEdgeOverridesDefault() throws {
+        let source = try makeTestJPEG(width: 4000, height: 3000)
+        let resized = try #require(resizedPhotoData(from: source, maxLongEdge: 1000))
+        let dimensions = try pixelDimensions(of: resized)
+        #expect(dimensions.width == 1000)
+        #expect(dimensions.height == 750)
+    }
+}
+
+@Suite("Thumbnail pipeline")
+struct ThumbnailPhotoDataTests {
+    @Test("Caps long edge at the thumbnail default")
+    func capsAtThumbnailDefault() throws {
+        let source = try makeTestJPEG(width: 4000, height: 3000)
+        let thumbnail = try #require(thumbnailPhotoData(from: source))
+        let dimensions = try pixelDimensions(of: thumbnail)
+        #expect(dimensions.width == 256)
+        #expect(dimensions.height == 192)
+    }
+
+    @Test("Thumbnail bytes are smaller than full-size resize")
+    func thumbnailIsSmallerThanResize() throws {
+        // The dimension cap (above) is the precise invariant. This
+        // size check is the cheap downstream signal: if the dimension
+        // cap regressed silently and emitted a full-resolution
+        // thumbnail, this assertion would catch it as a side effect.
+        // The exact ~64KB inline budget is content-dependent and gets
+        // verified on real photos in the Phase 5.4 two-device runbook.
+        let source = try makeTestJPEG(width: 4000, height: 3000)
+        let resized = try #require(resizedPhotoData(from: source))
+        let thumbnail = try #require(thumbnailPhotoData(from: source))
+        #expect(thumbnail.count < resized.count)
+    }
+
+    @Test("Non-image input returns nil")
+    func garbageInputReturnsNil() {
+        let garbage = Data("nope".utf8)
+        #expect(thumbnailPhotoData(from: garbage) == nil)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -272,6 +272,21 @@ household.
 > critical path to "track inventory across two phones." Don't defer
 > casually — it's a bait for Phase 7.
 
+**Sub-milestones**
+
+| # | Title | Status |
+| --- | --- | --- |
+| 5.1 | App-layer image pipeline (`ImageIO` resize + thumbnail, EXIF-correct) | 🟡 In review |
+| 5.2 | `PhotosPicker` + camera bridge + primary-photo header in `ItemDetailView` | ⏳ Pending |
+| 5.3 | Secondary photo strip + full-screen pager + reorder/delete-promotes-next | ⏳ Pending |
+| 5.4 | Two-device sync verification + dev schema deploy + `DEVELOPMENT.md` §5d runbook | ⏳ Pending |
+
+**Persistence layer status (sanity check, not a sub-milestone):** the
+`ItemPhoto` Core Data entity, repository protocol/impl, and CRUD tests
+all landed in Phase 1.2b — Phase 5 is pure UI + image-processing work.
+The CloudKit dev-schema record type for `CD_ItemPhotoEntity` is created
+lazily on the first photo write per `DEVELOPMENT.md` §5a step 4.
+
 ---
 
 ## Phase 6 — Cross-household views and adaptive polish


### PR DESCRIPTION
## Summary

- Two pure free functions over `Data` — `resizedPhotoData(from:maxLongEdge:)` (default 2048 px) and `thumbnailPhotoData(from:maxLongEdge:)` (default 256 px). Both output JPEG regardless of input container.
- Built on `ImageIO`'s `CGImageSourceCreateThumbnailAtIndex` with `kCGImageSourceCreateThumbnailWithTransform: true` — applies EXIF rotation in one shot (naive `UIImage(data:)` → resize loses orientation on portrait iPhone photos) and streams the source instead of decoding the full image into memory first.
- 9 unit tests covering dimension caps (square / landscape / portrait), no-upscale pass-through for already-small sources, custom `maxLongEdge`, garbage-data nil return, and the cheap thumbnail-bytes-smaller-than-resize cross-check. Tests synthesize their own JPEGs in-memory — no fixture files.
- Adds the Phase 5 sub-milestone table to ROADMAP.md. Sanity note: the `ItemPhoto` persistence layer landed in Phase 1.2b — Phase 5 is pure UI + image processing.

## Forward flag for Phase 5.2

`PhotosPicker` returns `Data` (HEIC/JPEG/PNG, original-asset format) directly — feeds straight into this pipeline. Camera capture via `UIImagePickerController` returns `UIImage` instead, so the camera path will need an `image.jpegData(compressionQuality:)` (or `cgImage` → `CGImageDestination`) preamble. The two surfaces will look different in 5.2 for that reason.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 72 tests in 19 suites pass (9 new).
- [x] Pure-function unit tests cover the dimension and pass-through invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)