### PR TITLE
Phase 5.2: PhotosPicker + camera bridge + primary-photo header

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -1,14 +1,23 @@
 import NakedPantreeDomain
+import PhotosUI
 import SwiftUI
+import UIKit
 
-/// Detail column. Read-only by default; tap Edit to open the item form.
+/// Detail column. Read-only by default; tap Edit to open the item form,
+/// or use the photo menu to attach a new photo.
 struct ItemDetailView: View {
     let itemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
     @State private var item: Item?
+    @State private var photos: [ItemPhoto] = []
     @State private var formMode: ItemFormView.Mode?
+    @State private var pickerSelection: PhotosPickerItem?
+    @State private var isPresentingLibraryPicker = false
+    @State private var isPresentingCamera = false
+    @State private var isSavingPhoto = false
+    @State private var photoErrorMessage: String?
 
     var body: some View {
         Group {
@@ -27,7 +36,16 @@ struct ItemDetailView: View {
         .navigationTitle(item?.name ?? "")
         .toolbar {
             if let item {
-                ToolbarItem(placement: .primaryAction) {
+                // `.topBarTrailing` (vs the original `.secondaryAction`):
+                // iOS collapses lone `.secondaryAction` items into an
+                // overflow that never renders when only one primary
+                // sits beside it — so the photo menu was invisible.
+                // `.topBarTrailing` keeps both buttons inline on the
+                // navigation bar.
+                ToolbarItem(placement: .topBarTrailing) {
+                    photoMenu(for: item)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("Edit") {
                         formMode = .edit(item)
                     }
@@ -39,14 +57,71 @@ struct ItemDetailView: View {
                 Task { await reload() }
             }
         }
+        .sheet(isPresented: $isPresentingCamera) {
+            // The camera sheet ignores safe areas so the live preview
+            // fills the screen edge-to-edge — `UIImagePickerController`
+            // handles its own chrome.
+            PhotoCaptureSheet { image in
+                isPresentingCamera = false
+                guard let image, let itemID else { return }
+                Task { await saveCameraImage(image, itemID: itemID) }
+            }
+            .ignoresSafeArea()
+        }
+        // PhotosPicker presents reliably as a top-level modifier driven
+        // by `isPresented`. Embedding the `PhotosPicker` view inside the
+        // `Menu` swallows the trigger — the menu closes, the picker
+        // never opens. State-driven presentation keeps the menu item as
+        // a plain `Button` and lets the picker layer above the chrome.
+        .photosPicker(
+            isPresented: $isPresentingLibraryPicker,
+            selection: $pickerSelection,
+            matching: .images,
+            photoLibrary: .shared()
+        )
+        .onChange(of: pickerSelection) { _, newValue in
+            guard let newValue, let itemID else { return }
+            Task { await saveLibraryPick(newValue, itemID: itemID) }
+        }
+        .alert(
+            "Couldn't save that photo.",
+            isPresented: photoErrorBinding,
+            presenting: photoErrorMessage
+        ) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { message in
+            Text(message)
+        }
         .task(id: ReloadKey(scope: itemID, token: remoteChangeMonitor.changeToken)) {
             await reload()
         }
     }
 
+    private var photoErrorBinding: Binding<Bool> {
+        Binding(
+            get: { photoErrorMessage != nil },
+            set: { newValue in
+                if !newValue { photoErrorMessage = nil }
+            }
+        )
+    }
+
     @ViewBuilder
     private func detail(for item: Item) -> some View {
         Form {
+            if let primary = photos.first, let uiImage = primary.uiImage {
+                Section {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 240)
+                        .clipped()
+                        .accessibilityLabel(Text("Photo of \(item.name)"))
+                }
+                .listRowInsets(EdgeInsets())
+            }
+
             Section("Quantity") {
                 Text("\(item.quantity) \(item.unit.displayLabel)")
             }
@@ -62,19 +137,117 @@ struct ItemDetailView: View {
                     Text(notes)
                 }
             }
+
+            if isSavingPhoto {
+                Section {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                        Text("Saving photo…")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
         }
+    }
+
+    @ViewBuilder
+    private func photoMenu(for item: Item) -> some View {
+        Menu {
+            // Plain Button → state flag → top-level `.photosPicker`
+            // modifier. PhotosPicker is the modern, out-of-process
+            // library path — no `NSPhotoLibraryUsageDescription`
+            // needed because the user picks in a separate process
+            // and only the chosen asset crosses the boundary.
+            Button {
+                isPresentingLibraryPicker = true
+            } label: {
+                Label("Choose from Library", systemImage: "photo.on.rectangle")
+            }
+            // Camera capture requires `NSCameraUsageDescription` in
+            // Info.plist (added in this PR). Older simulators report
+            // camera unavailable; recent ones with macOS Continuity
+            // Camera report it available. Either way the menu reflects
+            // device capability accurately.
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button {
+                    isPresentingCamera = true
+                } label: {
+                    Label("Take Photo", systemImage: "camera")
+                }
+            }
+        } label: {
+            Label("Add Photo", systemImage: "plus.viewfinder")
+        }
+        .disabled(isSavingPhoto)
+        .accessibilityIdentifier("itemDetail.addPhoto")
     }
 
     private func reload() async {
         guard let itemID else {
             item = nil
+            photos = []
             return
         }
         do {
             item = try await repositories.item.item(id: itemID)
+            photos = try await repositories.photo.photos(for: itemID)
         } catch {
             item = nil
+            photos = []
         }
+    }
+
+    private func saveCameraImage(_ image: UIImage, itemID: Item.ID) async {
+        isSavingPhoto = true
+        defer { isSavingPhoto = false }
+        do {
+            _ = try await savePhotoFromUIImage(
+                image,
+                itemID: itemID,
+                nextSortOrder: Int16(photos.count),
+                repository: repositories.photo
+            )
+            await reload()
+        } catch {
+            photoErrorMessage = "Try again."
+        }
+    }
+
+    private func saveLibraryPick(_ selection: PhotosPickerItem, itemID: Item.ID) async {
+        isSavingPhoto = true
+        defer {
+            isSavingPhoto = false
+            // Drop the selection back to nil so re-picking the same
+            // asset triggers `.onChange` again instead of being
+            // dropped as a duplicate.
+            pickerSelection = nil
+        }
+        do {
+            guard let data = try await selection.loadTransferable(type: Data.self) else {
+                throw PhotoSaveError.invalidImageData
+            }
+            _ = try await savePhotoFromData(
+                data,
+                itemID: itemID,
+                nextSortOrder: Int16(photos.count),
+                repository: repositories.photo
+            )
+            await reload()
+        } catch {
+            photoErrorMessage = "Try again."
+        }
+    }
+}
+
+extension ItemPhoto {
+    /// Decoded `UIImage` for the persisted full-resolution data, or
+    /// `nil` if the bytes couldn't be parsed (corruption, schema
+    /// mismatch from a version skew, etc.). The thumbnail field could
+    /// be substituted here if `imageData` reads start to dominate
+    /// detail-view appearance time — measure first.
+    fileprivate var uiImage: UIImage? {
+        guard let imageData else { return nil }
+        return UIImage(data: imageData)
     }
 }
 

--- a/NakedPantreeApp/Photos/PhotoCaptureSheet.swift
+++ b/NakedPantreeApp/Photos/PhotoCaptureSheet.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UIKit
+
+/// `UIViewControllerRepresentable` wrapping `UIImagePickerController`
+/// with `.camera` as the source.
+///
+/// SwiftUI's `PhotosPicker` covers the photo-library path beautifully,
+/// but it deliberately doesn't surface the camera — capturing live has
+/// to go through `UIImagePickerController`, which is still UIKit. The
+/// representable bridge stays narrow: present, take one photo (no
+/// editing UI), hand the result back as `UIImage`, dismiss.
+///
+/// Camera availability gate lives at the call-site, not here. Calling
+/// code should check `UIImagePickerController.isSourceTypeAvailable(.camera)`
+/// — the iPad simulator and the iPhone-sim-on-Mac pairing both return
+/// false, so the toolbar action that presents this sheet should hide
+/// or disable in those environments to avoid a black-screen no-op.
+struct PhotoCaptureSheet: UIViewControllerRepresentable {
+    /// Called once on capture (fires *before* dismissal so the caller
+    /// can persist before the sheet animates away). `nil` means the
+    /// user cancelled out without taking a photo.
+    let onCapture: (UIImage?) -> Void
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.allowsEditing = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture)
+    }
+
+    final class Coordinator:
+        NSObject,
+        UIImagePickerControllerDelegate,
+        UINavigationControllerDelegate
+    {
+        let onCapture: (UIImage?) -> Void
+
+        init(onCapture: @escaping (UIImage?) -> Void) {
+            self.onCapture = onCapture
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            // `.originalImage` carries the rotated, color-corrected
+            // capture. The picker has already applied EXIF orientation
+            // by this point, so the downstream image pipeline doesn't
+            // need to handle a rotation case from this surface (it
+            // still does, since the library path doesn't make the same
+            // guarantee).
+            let image = info[.originalImage] as? UIImage
+            onCapture(image)
+            picker.dismiss(animated: true)
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            onCapture(nil)
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/NakedPantreeApp/Photos/PhotoSaveService.swift
+++ b/NakedPantreeApp/Photos/PhotoSaveService.swift
@@ -1,0 +1,75 @@
+import Foundation
+import NakedPantreeDomain
+import UIKit
+
+/// Outcome of a photo-save attempt. Surfaced to the UI layer so the
+/// view can decide between an inline error banner, a silent retry, or
+/// a pass-through.
+enum PhotoSaveError: Error {
+    /// Source bytes couldn't be parsed as an image — corrupted file,
+    /// unsupported container, or zero bytes from a cancelled load.
+    case invalidImageData
+}
+
+/// Encodes a source image into the persisted JPEG pair (`imageData`
+/// + `thumbnailData`) and writes a new `ItemPhoto` row through the
+/// repository.
+///
+/// Pulled out of the view layer so the resize → encode → persist
+/// chain has a single seam tests can pin. The function takes the
+/// repository as a parameter rather than reading the environment so
+/// it stays a pure async function — no `@MainActor`, no SwiftUI
+/// dependency leaking into the photos module.
+///
+/// `nextSortOrder` is the caller's responsibility. The natural value
+/// is the current `photos(for:)` count cast to `Int16` — appends to
+/// the end of the strip. Reorder UI in 5.3 will rewrite the column
+/// in bulk; that's not this function's concern.
+func savePhotoFromData(
+    _ source: Data,
+    itemID: Item.ID,
+    nextSortOrder: Int16,
+    repository: ItemPhotoRepository
+) async throws -> ItemPhoto {
+    guard
+        let imageData = resizedPhotoData(from: source),
+        let thumbnailData = thumbnailPhotoData(from: source)
+    else {
+        throw PhotoSaveError.invalidImageData
+    }
+    let photo = ItemPhoto(
+        itemID: itemID,
+        imageData: imageData,
+        thumbnailData: thumbnailData,
+        sortOrder: nextSortOrder
+    )
+    try await repository.create(photo)
+    return photo
+}
+
+/// Camera-path entry. `UIImagePickerController` returns `UIImage`,
+/// not the original asset bytes — there's no way to get raw HEIC out
+/// of the camera capture surface. We re-encode to JPEG (quality 0.95
+/// — barely lossy, the resize pipeline does the heavy lifting from
+/// there) so the rest of the chain operates on the same `Data` shape
+/// the library path produces.
+///
+/// Throws `PhotoSaveError.invalidImageData` if the `UIImage` has no
+/// backing `cgImage` (rare — typically only happens with images
+/// constructed from `CIImage` without rasterization).
+func savePhotoFromUIImage(
+    _ image: UIImage,
+    itemID: Item.ID,
+    nextSortOrder: Int16,
+    repository: ItemPhotoRepository
+) async throws -> ItemPhoto {
+    guard let jpeg = image.jpegData(compressionQuality: 0.95) else {
+        throw PhotoSaveError.invalidImageData
+    }
+    return try await savePhotoFromData(
+        jpeg,
+        itemID: itemID,
+        nextSortOrder: nextSortOrder,
+        repository: repository
+    )
+}

--- a/NakedPantreeApp/Resources/Info.plist
+++ b/NakedPantreeApp/Resources/Info.plist
@@ -20,6 +20,8 @@
     <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>NSCameraUsageDescription</key>
+    <string>Take photos of items in your pantry so you can spot them at a glance.</string>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>

--- a/NakedPantreeTests/PhotoSaveServiceTests.swift
+++ b/NakedPantreeTests/PhotoSaveServiceTests.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import NakedPantreeDomain
+import Testing
+import UIKit
+import UniformTypeIdentifiers
+@testable import NakedPantree
+
+private func makeTestJPEG(width: Int, height: Int) throws -> Data {
+    let colorSpace = try #require(CGColorSpace(name: CGColorSpace.sRGB))
+    let bitmapInfo = CGImageAlphaInfo.noneSkipFirst.rawValue
+    let context = try #require(
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        )
+    )
+    context.setFillColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    let cgImage = try #require(context.makeImage())
+    let output = NSMutableData()
+    let destination = try #require(
+        CGImageDestinationCreateWithData(
+            output, UTType.jpeg.identifier as CFString, 1, nil
+        )
+    )
+    CGImageDestinationAddImage(destination, cgImage, nil)
+    #expect(CGImageDestinationFinalize(destination))
+    return output as Data
+}
+
+@Suite("Photo save service")
+struct PhotoSaveServiceTests {
+    @Test("Persists both imageData and thumbnailData from a Data source")
+    func persistsBothBlobs() async throws {
+        let repo = InMemoryItemPhotoRepository()
+        let item = Item(locationID: UUID(), name: "Cheese")
+        let source = try makeTestJPEG(width: 4000, height: 3000)
+
+        let saved = try await savePhotoFromData(
+            source,
+            itemID: item.id,
+            nextSortOrder: 0,
+            repository: repo
+        )
+
+        #expect(saved.itemID == item.id)
+        #expect(saved.imageData != nil)
+        #expect(saved.thumbnailData != nil)
+        // The thumbnail must be smaller than the persisted full
+        // resize — confirms the resize and thumbnail paths produced
+        // distinct outputs rather than the same blob twice.
+        #expect((saved.thumbnailData?.count ?? 0) < (saved.imageData?.count ?? 0))
+
+        let persisted = try await repo.photos(for: item.id)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.id == saved.id)
+    }
+
+    @Test("Honors caller-supplied sortOrder")
+    func sortOrderRoundTrips() async throws {
+        let repo = InMemoryItemPhotoRepository()
+        let itemID = UUID()
+        let source = try makeTestJPEG(width: 800, height: 600)
+
+        let first = try await savePhotoFromData(
+            source, itemID: itemID, nextSortOrder: 0, repository: repo
+        )
+        let second = try await savePhotoFromData(
+            source, itemID: itemID, nextSortOrder: 1, repository: repo
+        )
+
+        #expect(first.sortOrder == 0)
+        #expect(second.sortOrder == 1)
+
+        let persisted = try await repo.photos(for: itemID)
+        #expect(persisted.map(\.sortOrder) == [0, 1])
+    }
+
+    @Test("Garbage source data throws invalidImageData")
+    func garbageDataThrows() async {
+        let repo = InMemoryItemPhotoRepository()
+        let garbage = Data("not an image".utf8)
+
+        await #expect(throws: PhotoSaveError.invalidImageData) {
+            _ = try await savePhotoFromData(
+                garbage,
+                itemID: UUID(),
+                nextSortOrder: 0,
+                repository: repo
+            )
+        }
+    }
+
+    @Test("UIImage entry point routes through the data path")
+    func uiImageEntryPointRoutesThroughDataPath() async throws {
+        let repo = InMemoryItemPhotoRepository()
+        let source = try makeTestJPEG(width: 1200, height: 900)
+        let image = try #require(UIImage(data: source))
+
+        let saved = try await savePhotoFromUIImage(
+            image,
+            itemID: UUID(),
+            nextSortOrder: 0,
+            repository: repo
+        )
+
+        #expect(saved.imageData != nil)
+        #expect(saved.thumbnailData != nil)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -276,8 +276,8 @@ household.
 
 | # | Title | Status |
 | --- | --- | --- |
-| 5.1 | App-layer image pipeline (`ImageIO` resize + thumbnail, EXIF-correct) | 🟡 In review |
-| 5.2 | `PhotosPicker` + camera bridge + primary-photo header in `ItemDetailView` | ⏳ Pending |
+| 5.1 | App-layer image pipeline (`ImageIO` resize + thumbnail, EXIF-correct) | ✅ Merged ([apps#40](https://github.com/ellisandy/NakedPantree/pull/40)) |
+| 5.2 | `PhotosPicker` + camera bridge + primary-photo header in `ItemDetailView` | 🟡 In review |
 | 5.3 | Secondary photo strip + full-screen pager + reorder/delete-promotes-next | ⏳ Pending |
 | 5.4 | Two-device sync verification + dev schema deploy + `DEVELOPMENT.md` §5d runbook | ⏳ Pending |
 


### PR DESCRIPTION
## Summary

- `ItemDetailView` gains an "Add Photo" toolbar menu with **Choose from Library** (`PhotosPicker`) and **Take Photo** (`UIImagePickerController` bridge). Camera option hides automatically when the device reports no camera.
- Primary photo (lowest `sortOrder`) renders as a full-width header inside the Form. Hidden when the item has no photos. Decoded via `ItemPhoto.uiImage`.
- New `PhotoSaveService` (`savePhotoFromData` / `savePhotoFromUIImage`) is the testable seam: source bytes → 5.1 resize + thumbnail → `ItemPhotoRepository.create`. 4 unit tests cover the encode-both-blobs invariant, sortOrder round-trip, garbage-input throw, and the UIImage entry point.
- Inline "Saving photo…" row + plain "Couldn't save that photo. Try again." alert on failure (per voice rules).
- `NSCameraUsageDescription` added to Info.plist for the camera path. No `NSPhotoLibraryUsageDescription` needed — `PhotosPicker` is out-of-process.

## Bugs caught by manual simulator verification (both fixed)

The advisor pushed me to actually run the app in the simulator before claiming done. Both of these would have shipped if I'd relied on unit tests alone — they're SwiftUI presentation bugs that can't be caught without standing up the view hierarchy:

1. **`.secondaryAction` toolbar placement was invisible on iPhone** when paired with a single `.primaryAction`. iOS collapses it into an overflow that never renders. Switched both buttons to `.topBarTrailing` so they sit inline. See screenshot in commit message.
2. **`PhotosPicker` embedded inside a `Menu` swallowed the trigger** — the menu closed, the picker never opened. Switched to a plain `Button` inside the menu that flips a state flag, with a top-level `.photosPicker(isPresented:selection:)` modifier above the chrome.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 76 tests in 20 suites pass (4 new).
- [x] **Manual simulator verification (iPhone 17, iOS 26.4):**
  - App launches with `EMPTY_STORE=1` (used to bypass CloudKit init on a simulator with no iCloud account).
  - Add Photo button appears next to Edit on item detail.
  - Menu opens with both options.
  - Library picker presents, asset selection completes, primary photo header renders end-to-end with the picked image.
- [ ] **Real-device verification (USER-OWNED):** camera path (`Take Photo` → capture → save). Will be covered formally in Phase 5.4 two-device runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)