### PR TITLE
Phase 5.3: secondary photo strip + full-screen pager + Make Primary

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -18,6 +18,7 @@ struct ItemDetailView: View {
     @State private var isPresentingCamera = false
     @State private var isSavingPhoto = false
     @State private var photoErrorMessage: String?
+    @State private var pagerStartIndex: Int?
 
     var body: some View {
         Group {
@@ -55,6 +56,14 @@ struct ItemDetailView: View {
         .sheet(item: $formMode) { mode in
             ItemFormView(mode: mode) {
                 Task { await reload() }
+            }
+        }
+        .sheet(item: pagerItemBinding) { startIndex in
+            PhotoPagerView(
+                photos: photos,
+                initialIndex: startIndex.value
+            ) { photo in
+                Task { await deletePhoto(photo) }
             }
         }
         .sheet(isPresented: $isPresentingCamera) {
@@ -111,13 +120,27 @@ struct ItemDetailView: View {
         Form {
             if let primary = photos.first, let uiImage = primary.uiImage {
                 Section {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                        .scaledToFill()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 240)
-                        .clipped()
-                        .accessibilityLabel(Text("Photo of \(item.name)"))
+                    Button {
+                        pagerStartIndex = 0
+                    } label: {
+                        Image(uiImage: uiImage)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 240)
+                            .clipped()
+                            .contentShape(Rectangle())
+                            .accessibilityLabel(Text("Photo of \(item.name)"))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("itemDetail.primaryPhoto")
+                }
+                .listRowInsets(EdgeInsets())
+            }
+
+            if photos.count >= 2 {
+                Section {
+                    photoStrip
                 }
                 .listRowInsets(EdgeInsets())
             }
@@ -148,6 +171,79 @@ struct ItemDetailView: View {
                 }
             }
         }
+    }
+
+    /// Horizontal strip of secondary photos. The primary photo is
+    /// already shown in the header section above, so the strip starts
+    /// at index 1. Each tile uses `thumbnailData` (decoded ~256 px)
+    /// rather than the full `imageData` — list-row decode of multiple
+    /// 2048 px JPEGs would hitch on appearance per Phase 5 exit
+    /// criterion #2.
+    @ViewBuilder
+    private var photoStrip: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Array(photos.enumerated()), id: \.element.id) { index, photo in
+                    if index >= 1 {
+                        photoStripTile(for: photo, at: index)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+    }
+
+    @ViewBuilder
+    private func photoStripTile(for photo: ItemPhoto, at index: Int) -> some View {
+        Button {
+            pagerStartIndex = index
+        } label: {
+            Group {
+                if let uiImage = photo.thumbnailUIImage {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    // Thumbnail decode failed — show a neutral
+                    // placeholder rather than a broken-image icon
+                    // (this strip is meant to be glanceable, not a
+                    // diagnostic surface).
+                    Color.secondary.opacity(0.2)
+                }
+            }
+            .frame(width: 64, height: 64)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button {
+                Task { await makePrimary(photo) }
+            } label: {
+                Label("Make Primary", systemImage: "star")
+            }
+            Button(role: .destructive) {
+                Task { await deletePhoto(photo) }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .accessibilityIdentifier("itemDetail.photoStrip.tile.\(index)")
+    }
+
+    /// Bridges the optional `Int` start index into a sheet-`item:`
+    /// binding. The wrapper struct gives `Identifiable` conformance to
+    /// the bare integer.
+    private var pagerItemBinding: Binding<PagerStartIndex?> {
+        Binding(
+            get: {
+                guard let index = pagerStartIndex else { return nil }
+                return PagerStartIndex(value: index)
+            },
+            set: { newValue in
+                pagerStartIndex = newValue?.value
+            }
+        )
     }
 
     @ViewBuilder
@@ -213,6 +309,36 @@ struct ItemDetailView: View {
         }
     }
 
+    /// Deletes a photo and reloads. The repository handles the row
+    /// removal; promote-on-primary-delete falls out for free because
+    /// the strip resorts by sortOrder ascending — the next photo
+    /// (lowest remaining sortOrder) becomes `photos.first` on the
+    /// next reload.
+    private func deletePhoto(_ photo: ItemPhoto) async {
+        do {
+            try await repositories.photo.delete(id: photo.id)
+            await reload()
+        } catch {
+            photoErrorMessage = "Try again."
+        }
+    }
+
+    /// Promotes a non-primary photo to the primary slot. The promote
+    /// service writes a single row with `currentMin - 1` so reorder
+    /// stays an O(1) write rather than an N-row renumber pass.
+    private func makePrimary(_ photo: ItemPhoto) async {
+        do {
+            _ = try await makePhotoPrimary(
+                photo,
+                among: photos,
+                repository: repositories.photo
+            )
+            await reload()
+        } catch {
+            photoErrorMessage = "Try again."
+        }
+    }
+
     private func saveLibraryPick(_ selection: PhotosPickerItem, itemID: Item.ID) async {
         isSavingPhoto = true
         defer {
@@ -242,13 +368,30 @@ struct ItemDetailView: View {
 extension ItemPhoto {
     /// Decoded `UIImage` for the persisted full-resolution data, or
     /// `nil` if the bytes couldn't be parsed (corruption, schema
-    /// mismatch from a version skew, etc.). The thumbnail field could
-    /// be substituted here if `imageData` reads start to dominate
-    /// detail-view appearance time — measure first.
+    /// mismatch from a version skew, etc.). Used for the primary
+    /// header in the detail view.
     fileprivate var uiImage: UIImage? {
         guard let imageData else { return nil }
         return UIImage(data: imageData)
     }
+
+    /// Decoded thumbnail for strip-row display. Reading the smaller
+    /// inline blob keeps strip appearance hitch-free even with a
+    /// five-photo item per Phase 5 exit criterion #2.
+    fileprivate var thumbnailUIImage: UIImage? {
+        guard let thumbnailData else { return nil }
+        return UIImage(data: thumbnailData)
+    }
+}
+
+/// Identifiable wrapper so the `pagerStartIndex` `Int?` can drive a
+/// `sheet(item:)` modifier — the modifier's identity-based reset
+/// behavior is exactly what we want when the user taps a different
+/// strip tile (sheet re-presents at the new index instead of staying
+/// stuck on the old one).
+private struct PagerStartIndex: Identifiable, Hashable {
+    let value: Int
+    var id: Int { value }
 }
 
 #Preview("Empty") {

--- a/NakedPantreeApp/Photos/PhotoPagerView.swift
+++ b/NakedPantreeApp/Photos/PhotoPagerView.swift
@@ -1,0 +1,103 @@
+import NakedPantreeDomain
+import SwiftUI
+import UIKit
+
+/// Full-screen pager for an item's photos, presented as a sheet from
+/// the detail view. Swipe between photos via SwiftUI's paging
+/// `TabView` style; tap **Delete** to remove the current photo, **Done**
+/// to dismiss.
+///
+/// Eager full-resolution decode is intentional for v1.0 — the pager is
+/// a foreground, user-driven surface where the responsiveness of
+/// "swipe and the next photo is already there" beats lazy memory
+/// reclamation. A 5-photo item holds ~10 MB of decoded `UIImage` while
+/// the pager is open. If real-device perf in 5.4 shows this hurts,
+/// move to per-page `.onAppear` decode + `.onDisappear` release.
+struct PhotoPagerView: View {
+    let photos: [ItemPhoto]
+    let initialIndex: Int
+    let onDelete: (ItemPhoto) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var currentIndex: Int
+
+    init(photos: [ItemPhoto], initialIndex: Int, onDelete: @escaping (ItemPhoto) -> Void) {
+        self.photos = photos
+        self.initialIndex = initialIndex
+        self.onDelete = onDelete
+        // `@State`'s initial value is captured once at construction;
+        // subsequent renders honor the in-flight value, not the param.
+        // That's the desired behavior here — the user's swipes update
+        // `currentIndex` and we don't want re-rendering with the same
+        // `initialIndex` to snap back.
+        _currentIndex = State(initialValue: initialIndex)
+    }
+
+    var body: some View {
+        NavigationStack {
+            TabView(selection: $currentIndex) {
+                ForEach(Array(photos.enumerated()), id: \.element.id) { index, photo in
+                    pageContent(for: photo)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: photos.count > 1 ? .always : .never))
+            .indexViewStyle(.page(backgroundDisplayMode: .always))
+            .background(Color.black.ignoresSafeArea())
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                }
+                if photos.indices.contains(currentIndex) {
+                    ToolbarItem(placement: .destructiveAction) {
+                        Button {
+                            let photo = photos[currentIndex]
+                            // Dismiss before the delete callback fires
+                            // — the parent reloads `photos` and the
+                            // pager re-opens with stale data otherwise.
+                            dismiss()
+                            onDelete(photo)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                        .accessibilityIdentifier("photoPager.delete")
+                    }
+                }
+            }
+        }
+    }
+
+    private var navigationTitle: String {
+        guard photos.count > 1, photos.indices.contains(currentIndex) else { return "" }
+        return "\(currentIndex + 1) of \(photos.count)"
+    }
+
+    @ViewBuilder
+    private func pageContent(for photo: ItemPhoto) -> some View {
+        if let uiImage = photo.fullResolutionUIImage {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityLabel(Text("Photo"))
+        } else {
+            // Decode failed — corrupted blob or schema skew. Plain
+            // text per voice rules (failures aren't a personality
+            // moment).
+            Text("This photo can't be loaded.")
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+extension ItemPhoto {
+    /// Decoded full-resolution `UIImage` for the persisted `imageData`.
+    /// `nil` when the bytes can't be parsed. Named so it's distinct
+    /// from the `thumbnailUIImage` accessor used in the strip.
+    fileprivate var fullResolutionUIImage: UIImage? {
+        guard let imageData else { return nil }
+        return UIImage(data: imageData)
+    }
+}

--- a/NakedPantreeApp/Photos/PhotoSaveService.swift
+++ b/NakedPantreeApp/Photos/PhotoSaveService.swift
@@ -73,3 +73,38 @@ func savePhotoFromUIImage(
         repository: repository
     )
 }
+
+/// Promotes a non-primary photo to the primary slot (lowest sortOrder
+/// in the strip) by writing it back with `currentMin - 1`.
+///
+/// Phase 5.3 deliberately leaves gaps in the sortOrder column on
+/// delete and on promote — `photos(for:)` sorts ascending so gaps
+/// are invisible to every reader, and avoiding a renumber pass keeps
+/// the persistence write set small (one row per promote vs. N rows).
+/// `Int16.min` gives O(60K) headroom before the next-min strategy
+/// would wrap; reorder churn at that scale is a Phase 7 problem, not
+/// a v1.0 one.
+///
+/// **Performance flag:** `ItemPhotoRepository.update(_:)` rewrites
+/// every column including `imageData` and `thumbnailData` blobs (~3 MB
+/// for a typical photo). Promote is a metadata change but pays the
+/// full blob write. Acceptable for v1.0 — promote is a rare,
+/// user-initiated action — but a future `updateSortOrder(id:to:)` on
+/// the repo protocol would skip the blob round-trip.
+///
+/// Already-primary input still writes (sortOrder becomes `min - 1`
+/// where the photo *is* the min, so it shifts down by 1). Idempotent
+/// in observable behavior — the photo stays first in the sorted strip
+/// — and harmless. Caller can short-circuit at the call site if the
+/// extra write matters.
+func makePhotoPrimary(
+    _ photo: ItemPhoto,
+    among photos: [ItemPhoto],
+    repository: ItemPhotoRepository
+) async throws -> ItemPhoto {
+    let currentMin = photos.map(\.sortOrder).min() ?? 0
+    var promoted = photo
+    promoted.sortOrder = currentMin - 1
+    try await repository.update(promoted)
+    return promoted
+}

--- a/NakedPantreeTests/PhotoSaveServiceTests.swift
+++ b/NakedPantreeTests/PhotoSaveServiceTests.swift
@@ -115,3 +115,78 @@ struct PhotoSaveServiceTests {
         #expect(saved.thumbnailData != nil)
     }
 }
+
+@Suite("Photo promote service")
+struct PhotoPromoteServiceTests {
+    private static func makePhoto(
+        sortOrder: Int16,
+        itemID: UUID = UUID()
+    ) -> ItemPhoto {
+        ItemPhoto(itemID: itemID, sortOrder: sortOrder)
+    }
+
+    @Test("Promoting a non-primary photo writes sortOrder = currentMin - 1")
+    func promotesToOneBelowCurrentMin() async throws {
+        let itemID = UUID()
+        let primary = Self.makePhoto(sortOrder: 0, itemID: itemID)
+        let middle = Self.makePhoto(sortOrder: 1, itemID: itemID)
+        let last = Self.makePhoto(sortOrder: 2, itemID: itemID)
+        let repo = InMemoryItemPhotoRepository()
+        for photo in [primary, middle, last] {
+            try await repo.create(photo)
+        }
+
+        let promoted = try await makePhotoPrimary(
+            middle,
+            among: [primary, middle, last],
+            repository: repo
+        )
+
+        #expect(promoted.sortOrder == -1)
+        // Repository now sorts ascending, so the promoted photo is
+        // first — the user-visible "primary" slot.
+        let persisted = try await repo.photos(for: itemID)
+        #expect(persisted.first?.id == middle.id)
+    }
+
+    @Test("Empty photo list still produces a valid promote (currentMin defaults to 0)")
+    func emptyListPromotesToMinusOne() async throws {
+        let itemID = UUID()
+        let solo = Self.makePhoto(sortOrder: 5, itemID: itemID)
+        let repo = InMemoryItemPhotoRepository()
+        try await repo.create(solo)
+
+        // The "among" array doesn't include the photo being promoted —
+        // models the corner where the strip's photos array is empty.
+        let promoted = try await makePhotoPrimary(
+            solo,
+            among: [],
+            repository: repo
+        )
+
+        #expect(promoted.sortOrder == -1)
+    }
+
+    @Test("Negative current min still gets one below")
+    func negativeMinKeepsShifting() async throws {
+        // After a promote, the new min sortOrder is negative. A
+        // subsequent promote of a different photo must keep going
+        // negative (currentMin - 1), not collapse to 0.
+        let itemID = UUID()
+        let alreadyPromoted = Self.makePhoto(sortOrder: -1, itemID: itemID)
+        let original = Self.makePhoto(sortOrder: 0, itemID: itemID)
+        let repo = InMemoryItemPhotoRepository()
+        try await repo.create(alreadyPromoted)
+        try await repo.create(original)
+
+        let promoted = try await makePhotoPrimary(
+            original,
+            among: [alreadyPromoted, original],
+            repository: repo
+        )
+
+        #expect(promoted.sortOrder == -2)
+        let persisted = try await repo.photos(for: itemID)
+        #expect(persisted.first?.id == original.id)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -277,8 +277,8 @@ household.
 | # | Title | Status |
 | --- | --- | --- |
 | 5.1 | App-layer image pipeline (`ImageIO` resize + thumbnail, EXIF-correct) | ✅ Merged ([apps#40](https://github.com/ellisandy/NakedPantree/pull/40)) |
-| 5.2 | `PhotosPicker` + camera bridge + primary-photo header in `ItemDetailView` | 🟡 In review |
-| 5.3 | Secondary photo strip + full-screen pager + reorder/delete-promotes-next | ⏳ Pending |
+| 5.2 | `PhotosPicker` + camera bridge + primary-photo header in `ItemDetailView` | ✅ Merged ([apps#41](https://github.com/ellisandy/NakedPantree/pull/41)) |
+| 5.3 | Secondary photo strip + full-screen pager + delete + Make Primary (long-press drag deferred) | 🟡 In review |
 | 5.4 | Two-device sync verification + dev schema deploy + `DEVELOPMENT.md` §5d runbook | ⏳ Pending |
 
 **Persistence layer status (sanity check, not a sub-milestone):** the


### PR DESCRIPTION
## Summary

- Horizontal strip of secondary photos below the primary header in `ItemDetailView`. Renders when `photos.count >= 2`, hidden otherwise. Each tile uses `thumbnailData` (~256px) so a five-photo item still loads without hitch per Phase 5 exit criterion #2.
- New `PhotoPagerView` — full-screen sheet, `TabView` paging style, page-dot indicator, toolbar Done/Delete. Initial index lands on the tapped photo. Tapping the primary header opens at index 0; tapping a strip tile opens at its index.
- Long-press context menu on strip tiles: **Make Primary** (writes the chosen photo back with `currentMin - 1` — one repository write, no renumber pass) and **Delete**.
- Auto-promote-on-delete falls out for free: gap-leaving on delete is invisible to readers because `photos(for:)` already sorts ascending. Deleting the primary makes the next-lowest sortOrder become `photos.first` on the next reload.

## Deferred / flagged

- **Long-press drag reorder** (cf. ARCHITECTURE.md §9 spec target) — Phase 5 exit criteria don't require drag UX; "Make Primary" via context menu provides functional equivalence without the SwiftUI horizontal-strip drag-drop rabbit hole. Filing as a follow-up issue.
- **Performance flag (not blocking):** `ItemPhotoRepository.update(_:)` rewrites every column including `imageData` blobs. "Make Primary" pays the full ~3MB blob round-trip for what's logically a single-column update. Acceptable for v1.0 (rare user action); a future `updateSortOrder(id:to:)` on the repo protocol would skip it.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 79 tests in 21 suites pass (3 new for `makePhotoPrimary`).
- [x] **Manual simulator verification (iPhone 17, EMPTY_STORE):**
  - Add 3 photos via the library picker → strip appears with 2 secondary thumbnails.
  - Tap strip[1] (waterfall) → pager opens at index 2 with the 3-dot indicator showing waterfall as the 3rd page.
  - Pager Delete → photo gone, pager dismisses, strip updates to 1 thumbnail.
  - Long-press strip thumbnail → context menu shows Make Primary + Delete.
  - Tap Make Primary → pink flowers swap into header, abstract drops into strip. Verifies the sortOrder rewrite + reload pipeline end-to-end.
- [ ] **Real-device verification (USER-OWNED):** five-photo perf claim and two-device sync — formally covered in Phase 5.4 runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)