### PR TITLE
Phase 6.1: Expiring Soon list + restore §8 missing-item routing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -362,13 +362,6 @@ app to the corresponding `Item` detail via the navigation state's
 - If the app is launched cold from the notification, the routing is applied
   after the persistent store loads, not during onboarding.
 
-**Phase 4.2 interim:** Expiring Soon is stubbed until Phase 6, so routing
-to it on a missing item lands on a placeholder that has nothing to do with
-the deleted item — worse than no navigation at all. Until Smart Lists ship,
-the missing-item case shows the "That item is gone." copy as a one-shot
-alert in place and leaves the user on whatever surface they were viewing.
-Restore the Expiring Soon hand-off when Phase 6 lands the real list.
-
 ### Multi-device behavior
 
 If two household members both have the app installed, both phones will fire

--- a/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
+++ b/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
@@ -60,12 +60,9 @@ final class NakedPantreeAppDelegate:
     }
 
     /// Tap → publish parsed `itemID` to the routing service. RootView
-    /// observes and either navigates to the detail or shows the
-    /// "That item is gone" alert (item missing, e.g. another household
-    /// member deleted it before the tap). Per ARCHITECTURE.md §8 the
-    /// missing-item case should land on Expiring Soon — the smart list
-    /// is stubbed until Phase 6, so the interim is a banner alert in
-    /// place; the §8 note records the divergence.
+    /// observes and either navigates to the detail or — if the item
+    /// has been deleted — lands on Expiring Soon and shows the
+    /// "That item is gone" alert per ARCHITECTURE.md §8.
     /// `nonisolated` because `UIApplicationDelegate` makes this class
     /// implicitly main-actor-isolated, but `UNUserNotificationCenterDelegate`
     /// requirements are nonisolated. The delegate method itself does

--- a/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
+++ b/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
@@ -1,0 +1,141 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Filters a household's items down to the ones with a set expiry,
+/// sorted ascending so already-expired items lead and the next-up
+/// items follow. Pure free function so tests can pin `now` and
+/// verify the sort without a Core Data round-trip — the view layer
+/// just hands its current `[Item]` straight in.
+///
+/// Items with `expiresAt == nil` are dropped — the smart list is an
+/// "act on this" surface; an item with no expiry isn't actionable
+/// in this context.
+func itemsExpiringSoon(_ items: [Item]) -> [Item] {
+    items
+        .filter { $0.expiresAt != nil }
+        // Force-unwrap is safe: filter above guarantees non-nil. The
+        // ordering puts past-expiry first because past dates are
+        // numerically smaller — that's the desired UX (most-urgent
+        // items lead the list).
+        .sorted { ($0.expiresAt ?? .distantFuture) < ($1.expiresAt ?? .distantFuture) }
+}
+
+/// "Expiring Soon" smart-list content column. Cross-location list of
+/// every item in the household that has an `expiresAt`, sorted with
+/// already-expired items leading and the next-to-expire items
+/// following. Per `ARCHITECTURE.md` §8 this is the surface a
+/// notification-tap deep link routes the user to when the underlying
+/// item has been deleted.
+struct ExpiringSoonView: View {
+    @Binding var selectedItemID: Item.ID?
+
+    @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
+    @State private var items: [Item] = []
+    @State private var locationsByID: [Location.ID: Location] = [:]
+    @State private var didLoad = false
+
+    var body: some View {
+        Group {
+            if !didLoad {
+                ProgressView()
+            } else if items.isEmpty {
+                emptyState
+            } else {
+                List(selection: $selectedItemID) {
+                    ForEach(items) { item in
+                        ExpiringSoonRow(
+                            item: item,
+                            locationName: locationsByID[item.locationID]?.name
+                        )
+                        .tag(item.id)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Expiring Soon")
+        .task(id: remoteChangeMonitor.changeToken) {
+            await load()
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Nothing's expiring",
+            systemImage: "clock.badge.checkmark",
+            description: Text("Items with an expiry date will show up here.")
+        )
+    }
+
+    private func load() async {
+        do {
+            let household = try await repositories.household.currentHousehold()
+            let locations = try await repositories.location.locations(in: household.id)
+            locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
+            let allItems = try await repositories.item.allItems(in: household.id)
+            items = itemsExpiringSoon(allItems)
+        } catch {
+            items = []
+        }
+        didLoad = true
+    }
+}
+
+private struct ExpiringSoonRow: View {
+    let item: Item
+    let locationName: String?
+
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Text(item.name).font(.body)
+                if isExpired {
+                    expiredBadge
+                }
+            }
+            HStack(spacing: 8) {
+                if let locationName {
+                    Text(locationName)
+                    Text("·")
+                }
+                Text("\(item.quantity) \(item.unit.displayLabel)")
+                if let expiresAt = item.expiresAt {
+                    Text("·")
+                    Text(expiresAt, style: .date)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var isExpired: Bool {
+        guard let expiresAt = item.expiresAt else { return false }
+        return expiresAt < Date()
+    }
+
+    /// Icon + text — never color alone, per `DESIGN_GUIDELINES.md` §6
+    /// accessibility rule. The badge stays compact so the row layout
+    /// reads at a glance.
+    @ViewBuilder
+    private var expiredBadge: some View {
+        Label("Expired", systemImage: "exclamationmark.triangle.fill")
+            .labelStyle(.titleAndIcon)
+            .font(.caption.bold())
+            .foregroundStyle(.red)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.red.opacity(0.12), in: Capsule())
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedItemID: Item.ID?
+    NavigationStack {
+        ExpiringSoonView(selectedItemID: $selectedItemID)
+    }
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -90,9 +90,11 @@ struct ItemsView: View {
         switch list {
         case .allItems:
             AllItemsView(selectedItemID: $selectedItemID)
-        case .expiringSoon, .recentlyAdded:
-            // Projections (Expiring Soon, Recently Added) land with the
-            // Smart Lists feature in Phase 6.
+        case .expiringSoon:
+            ExpiringSoonView(selectedItemID: $selectedItemID)
+        case .recentlyAdded:
+            // Recently Added is the remaining Smart List projection
+            // — pending its own Phase 6 sub-milestone.
             ContentUnavailableView(
                 list.title,
                 systemImage: list.systemImage,

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -113,17 +113,15 @@ struct RootView: View {
     }
 
     /// Resolves a notification-tap deep link. Sets the sidebar to the
-    /// item's location and selects the item, or shows the
-    /// "That item is gone." alert if the item has been deleted (e.g.
-    /// remote household member tossed it before the tap landed).
-    ///
-    /// Per ARCHITECTURE.md §8 the missing-item case should land on the
-    /// Expiring Soon smart list. That list is stubbed until Phase 6, so
-    /// the interim is a deselect + alert in place. The §8 note records
-    /// the divergence; revisit when Smart Lists ship.
+    /// item's location and selects the item; if the item has been
+    /// deleted (e.g. another household member tossed it before the
+    /// tap landed) lands on the Expiring Soon smart list and shows
+    /// the "That item is gone." alert per `ARCHITECTURE.md` §8.
     private func applyDeepLink(itemID: Item.ID) async {
         do {
             guard let item = try await repositories.item.item(id: itemID) else {
+                sidebarSelection = .smartList(.expiringSoon)
+                selectedItemID = nil
                 isShowingMissingItemAlert = true
                 return
             }

--- a/NakedPantreeTests/ExpiringSoonTests.swift
+++ b/NakedPantreeTests/ExpiringSoonTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import NakedPantreeDomain
+import Testing
+@testable import NakedPantree
+
+@Suite("Expiring Soon filter and sort")
+struct ExpiringSoonFilterTests {
+    private static func makeItem(name: String, expiresAt: Date?) -> Item {
+        Item(locationID: UUID(), name: name, expiresAt: expiresAt)
+    }
+
+    @Test("Items without an expiry are dropped")
+    func dropsNilExpiry() {
+        let nilItem = Self.makeItem(name: "Pasta", expiresAt: nil)
+        let withExpiry = Self.makeItem(name: "Milk", expiresAt: Date())
+        let result = itemsExpiringSoon([nilItem, withExpiry])
+        #expect(result.map(\.id) == [withExpiry.id])
+    }
+
+    @Test("Result sorts ascending so past-expiry leads, near-future follows")
+    func sortsAscendingByExpiresAt() {
+        let now = Date()
+        let lastWeek = Self.makeItem(name: "Old", expiresAt: now.addingTimeInterval(-7 * 86400))
+        let tomorrow = Self.makeItem(name: "Soon", expiresAt: now.addingTimeInterval(86400))
+        let nextMonth = Self.makeItem(name: "Later", expiresAt: now.addingTimeInterval(30 * 86400))
+
+        let result = itemsExpiringSoon([nextMonth, lastWeek, tomorrow])
+
+        #expect(result.map(\.id) == [lastWeek.id, tomorrow.id, nextMonth.id])
+    }
+
+    @Test("Empty input returns empty output")
+    func emptyInputReturnsEmpty() {
+        #expect(itemsExpiringSoon([]).isEmpty)
+    }
+
+    @Test("All-nil input returns empty output")
+    func allNilInputReturnsEmpty() {
+        let items = [
+            Self.makeItem(name: "A", expiresAt: nil),
+            Self.makeItem(name: "B", expiresAt: nil),
+        ]
+        #expect(itemsExpiringSoon(items).isEmpty)
+    }
+
+    @Test("Stable when two items share the same expiry")
+    func sharedExpiryDoesNotCrash() {
+        let shared = Date()
+        let first = Self.makeItem(name: "First", expiresAt: shared)
+        let second = Self.makeItem(name: "Second", expiresAt: shared)
+        let result = itemsExpiringSoon([first, second])
+        // Both must appear; relative order isn't asserted because the
+        // sort isn't required to be stable on ties.
+        #expect(Set(result.map(\.id)) == Set([first.id, second.id]))
+        #expect(result.count == 2)
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -317,6 +317,15 @@ household-shaped.
 - [ ] Empty states across the app pass voice rules and use icon + text
       (never color alone).
 
+**Sub-milestones**
+
+| # | Title | Status |
+| --- | --- | --- |
+| 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | 🟡 In review |
+| 6.2 | Recently Added smart list + sidebar search surface | ⏳ Pending |
+| 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ⏳ Pending |
+| 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
+
 ---
 
 ## Phase 7 — Pre-TestFlight hardening


### PR DESCRIPTION
## Summary

- New `ExpiringSoonView` renders cross-location items with `expiresAt`, sorted ascending so already-expired items lead. Row UI: name + location + quantity + date, with an "Expired" pill (icon + text — never color alone) for past-due items.
- Filter/sort is a pure free function `itemsExpiringSoon` — fully unit-testable without Core Data.
- Wires into `ItemsView.smartListContent` switch, replacing the `ContentUnavailableView` placeholder for `.expiringSoon`. `Recently Added` stays on the placeholder until 6.2.
- Restores the `ARCHITECTURE.md` §8 spec missing-item routing: `RootView.applyDeepLink` now lands the user on Expiring Soon (not just the alert in place) when the deleted item's notification gets tapped. Removes the §8 "Phase 4.2 interim" note and the matching comment in `NakedPantreeAppDelegate` — both no longer apply.
- Adds the Phase 6 sub-milestone table to ROADMAP.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 84 tests in 22 suites pass (5 new for `itemsExpiringSoon`).
- [x] **Manual simulator verification (iPhone 17, EMPTY_STORE):** sidebar → Expiring Soon shows the new view (not the old placeholder) with brand-voice empty-state copy "Nothing's expiring."
- [ ] **Real-device verification (USER-OWNED):** add items with expiries, confirm they appear sorted ascending; verify the §8 routing by deleting a notified item from a second device and tapping the banner on the first — should land on Expiring Soon with the alert. Will be covered formally in Phase 6.3 runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)