### PR TITLE
Phase 6.2a: Recently Added smart list

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -93,13 +93,7 @@ struct ItemsView: View {
         case .expiringSoon:
             ExpiringSoonView(selectedItemID: $selectedItemID)
         case .recentlyAdded:
-            // Recently Added is the remaining Smart List projection
-            // — pending its own Phase 6 sub-milestone.
-            ContentUnavailableView(
-                list.title,
-                systemImage: list.systemImage,
-                description: Text("Coming with Smart Lists.")
-            )
+            RecentlyAddedView(selectedItemID: $selectedItemID)
         }
     }
 

--- a/NakedPantreeApp/Features/Items/RecentlyAddedView.swift
+++ b/NakedPantreeApp/Features/Items/RecentlyAddedView.swift
@@ -1,0 +1,106 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Sorts a household's items by `createdAt` descending — most-recent
+/// adds first. Pure free function so tests can pin the input order
+/// and verify the sort without a Core Data round-trip.
+///
+/// No time-window or count cap. The smart list is "items by recency,"
+/// not "items added in the last N days" — a household with 50 items
+/// total still scrolls cheaply, and capping is a polish decision
+/// better made when real-world household sizes are visible. Same
+/// shape as `itemsExpiringSoon` (no cutoff there either) — keep the
+/// two consistent.
+func itemsRecentlyAdded(_ items: [Item]) -> [Item] {
+    items.sorted { $0.createdAt > $1.createdAt }
+}
+
+/// "Recently Added" smart-list content column. Cross-location list of
+/// every item in the household, sorted with the most-recently-added
+/// first. Useful for "what did I just put in" and "did my partner add
+/// anything since I last looked."
+struct RecentlyAddedView: View {
+    @Binding var selectedItemID: Item.ID?
+
+    @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
+    @State private var items: [Item] = []
+    @State private var locationsByID: [Location.ID: Location] = [:]
+    @State private var didLoad = false
+
+    var body: some View {
+        Group {
+            if !didLoad {
+                ProgressView()
+            } else if items.isEmpty {
+                emptyState
+            } else {
+                List(selection: $selectedItemID) {
+                    ForEach(items) { item in
+                        RecentlyAddedRow(
+                            item: item,
+                            locationName: locationsByID[item.locationID]?.name
+                        )
+                        .tag(item.id)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Recently Added")
+        .task(id: remoteChangeMonitor.changeToken) {
+            await load()
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Nothing added yet",
+            systemImage: "sparkles",
+            description: Text("Items you add will show up here.")
+        )
+    }
+
+    private func load() async {
+        do {
+            let household = try await repositories.household.currentHousehold()
+            let locations = try await repositories.location.locations(in: household.id)
+            locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
+            let allItems = try await repositories.item.allItems(in: household.id)
+            items = itemsRecentlyAdded(allItems)
+        } catch {
+            items = []
+        }
+        didLoad = true
+    }
+}
+
+private struct RecentlyAddedRow: View {
+    let item: Item
+    let locationName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.name).font(.body)
+            HStack(spacing: 8) {
+                if let locationName {
+                    Text(locationName)
+                    Text("·")
+                }
+                Text("\(item.quantity) \(item.unit.displayLabel)")
+                Text("·")
+                Text(item.createdAt, style: .relative)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedItemID: Item.ID?
+    NavigationStack {
+        RecentlyAddedView(selectedItemID: $selectedItemID)
+    }
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeTests/RecentlyAddedTests.swift
+++ b/NakedPantreeTests/RecentlyAddedTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import NakedPantreeDomain
+import Testing
+@testable import NakedPantree
+
+@Suite("Recently Added sort")
+struct RecentlyAddedSortTests {
+    private static func makeItem(name: String, createdAt: Date) -> Item {
+        Item(locationID: UUID(), name: name, createdAt: createdAt)
+    }
+
+    @Test("Sort is descending by createdAt — newest first")
+    func sortsDescendingByCreatedAt() {
+        let now = Date()
+        let oldest = Self.makeItem(name: "First", createdAt: now.addingTimeInterval(-86400 * 7))
+        let middle = Self.makeItem(name: "Middle", createdAt: now.addingTimeInterval(-86400))
+        let newest = Self.makeItem(name: "Newest", createdAt: now)
+
+        let result = itemsRecentlyAdded([oldest, middle, newest])
+
+        #expect(result.map(\.id) == [newest.id, middle.id, oldest.id])
+    }
+
+    @Test("Empty input returns empty output")
+    func emptyInputReturnsEmpty() {
+        #expect(itemsRecentlyAdded([]).isEmpty)
+    }
+
+    @Test("Items with the same createdAt both appear")
+    func sameCreatedAtBothAppear() {
+        let shared = Date()
+        let first = Self.makeItem(name: "First", createdAt: shared)
+        let second = Self.makeItem(name: "Second", createdAt: shared)
+        let result = itemsRecentlyAdded([first, second])
+        #expect(Set(result.map(\.id)) == Set([first.id, second.id]))
+        #expect(result.count == 2)
+    }
+
+    @Test("Items with no expiry are still included — Recently Added is sort-only, not filter")
+    func includesItemsWithoutExpiry() {
+        let now = Date()
+        let withExpiry = Item(
+            locationID: UUID(),
+            name: "Milk",
+            expiresAt: now.addingTimeInterval(86400),
+            createdAt: now
+        )
+        let withoutExpiry = Item(
+            locationID: UUID(),
+            name: "Pasta",
+            expiresAt: nil,
+            createdAt: now.addingTimeInterval(-3600)
+        )
+        let result = itemsRecentlyAdded([withoutExpiry, withExpiry])
+        #expect(result.map(\.id) == [withExpiry.id, withoutExpiry.id])
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -321,8 +321,9 @@ household-shaped.
 
 | # | Title | Status |
 | --- | --- | --- |
-| 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | 🟡 In review |
-| 6.2 | Recently Added smart list + sidebar search surface | ⏳ Pending |
+| 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | ✅ Merged ([apps#45](https://github.com/ellisandy/NakedPantree/pull/45)) |
+| 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | 🟡 In review |
+| 6.2b | Cross-household search surface from the sidebar | ⏳ Pending |
 | 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ⏳ Pending |
 | 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
 


### PR DESCRIPTION
## Summary

- New `RecentlyAddedView` replaces the `ContentUnavailableView` placeholder for the Recently Added smart list. Cross-location list sorted by `createdAt` descending — newest adds first.
- Pure free function `itemsRecentlyAdded` is the testable seam (sort-only, no filter — items without an expiry are still included; this is "by recency," not "actionable").
- No time-window or count cap — same shape as `ExpiringSoonView`. Capping is a polish decision better made when real-world household sizes are visible. Documented in the function doc-comment for the next person.
- Empty state: "Nothing added yet" / "Items you add will show up here." — matches the §9 empty-state voice.

## Scope split

Original 6.2 was "Recently Added smart list + sidebar search surface." Splitting into:
- **6.2a** (this PR) — Recently Added.
- **6.2b** — Cross-household sidebar search.

The sidebar search piece is a real refactor (query state lifts to RootView; content column gains a "search results" mode separate from `SidebarSelection`) and deserves its own design conversation. Three plausible readings of "search surfaced from the sidebar" — `.searchable(placement: .sidebar)`, a "Search" entry in Smart Lists, or moving the existing `AllItemsView.searchable` up — and they have very different costs. Punting that decision to 6.2b.

## Test plan

- [x] Lint clean (`./scripts/lint.sh`).
- [x] Full test suite: 88 tests in 23 suites pass (4 new for `itemsRecentlyAdded`).
- [x] **Manual simulator verification (iPhone 17, EMPTY_STORE):** sidebar → Recently Added shows the new view (not the old placeholder) with the empty-state copy "Nothing added yet."
- [ ] **Real-device verification (USER-OWNED):** add a few items, confirm they appear sorted with the most-recent first; remote-add from a second device, confirm the list updates on the next remote-change tick. Will be covered formally in Phase 6.3 runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)