### PR TITLE
Phase 6.2b: cross-household search via sidebar .searchable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -310,9 +310,11 @@ The sidebar has two sections, in this order. The pattern mirrors Apple Mail,
 Reminders, and Notes — users already know it.
 
 ```
+🔍 Search items          (.searchable on the sidebar, cross-household)
+
 Smart Lists
   ▢ Expiring Soon       (items with expiresAt within 7 days, sorted soonest)
-  ▢ All Items           (every item across every location, with search)
+  ▢ All Items           (every item across every location, sorted by name)
   ▢ Recently Added      (items added in the last 14 days)
 
 Locations
@@ -327,6 +329,14 @@ you're doing inventory cleanup you want a *single* location view (focused,
 edit-heavy). When you're deciding what to cook tonight or what's about to
 spoil, you need a *cross-household* view. The sidebar serves both modes
 without modal switching.
+
+**Search is a peer content-column mode, not a `SidebarSelection` case.**
+The sidebar `.searchable(placement: .sidebar)` lifts a `searchQuery`
+string to `RootView`. When the trimmed query is non-empty, the content
+column renders `SearchResultsView` regardless of the current sidebar
+selection; clearing the field reverts to the selection-driven view. This
+keeps `SidebarSelection` (Smart List | Location) clean and lets the
+detail column behave normally when a result is tapped.
 
 Smart Lists are pure projections — they read from the same Core Data store
 as Locations and don't introduce new entities. They are computed via

--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -2,22 +2,23 @@ import NakedPantreeDomain
 import SwiftUI
 
 /// "All Items" smart-list content column. Lists every item in the
-/// household, with `.searchable` driving a household-scoped name match
-/// through `ItemRepository.search(_:in:)`. Empty / whitespace queries
-/// fall back to `allItems(in:)`.
+/// household, sorted by name (the repository contract on
+/// `ItemRepository.allItems(in:)`). Cross-household search is the
+/// sibling sidebar surface — see `SearchResultsView`.
 struct AllItemsView: View {
     @Binding var selectedItemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
-    @State private var query: String = ""
     @State private var items: [Item] = []
-    @State private var householdID: Household.ID?
     @State private var locationsByID: [Location.ID: Location] = [:]
+    @State private var didLoad = false
 
     var body: some View {
         Group {
-            if items.isEmpty {
+            if !didLoad {
+                ProgressView()
+            } else if items.isEmpty {
                 emptyState
             } else {
                 List(selection: $selectedItemID) {
@@ -29,74 +30,30 @@ struct AllItemsView: View {
             }
         }
         .navigationTitle("All Items")
-        .searchable(text: $query, prompt: "Search items")
-        // Shell (household + locations) only refetches when CloudKit
-        // imports a remote change — typing in the search bar shouldn't
-        // re-hit those rows.
         .task(id: remoteChangeMonitor.changeToken) {
-            await loadShell()
-        }
-        // Items refetch on query change, debounced so a flurry of
-        // keystrokes resolves into one Core Data hop instead of one
-        // per character. `.task(id:)` cancels the previous task when
-        // `query` changes, and `Task.sleep` throws on cancel — so only
-        // the last keystroke after a 250ms pause actually fetches.
-        .task(id: query) {
-            do {
-                if !query.isEmpty {
-                    try await Task.sleep(for: .milliseconds(250))
-                }
-                await loadItems()
-            } catch {
-                // Cancelled — the next .task takes over.
-            }
+            await load()
         }
     }
 
     @ViewBuilder
     private var emptyState: some View {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            ContentUnavailableView(
-                "Pantry's empty",
-                systemImage: "tray",
-                description: Text("Add a location and a few items to start.")
-            )
-        } else {
-            ContentUnavailableView.search(text: trimmed)
-        }
+        ContentUnavailableView(
+            "Pantry's empty",
+            systemImage: "tray",
+            description: Text("Add a location and a few items to start.")
+        )
     }
 
-    /// Fetch the household + locations once on appear and on each remote
-    /// change. Triggers an items load at the end so the initial render
-    /// shows data without waiting for the query-task to fire.
-    private func loadShell() async {
+    private func load() async {
         do {
             let house = try await repositories.household.currentHousehold()
-            householdID = house.id
             let locations = try await repositories.location.locations(in: house.id)
             locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
-        } catch {
-            return
-        }
-        await loadItems()
-    }
-
-    /// Fetch items for the current `query`. Bails if the shell hasn't
-    /// resolved a household yet — `loadShell()` calls back into this
-    /// once it has, so the empty state never sticks.
-    private func loadItems() async {
-        guard let house = householdID else { return }
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        do {
-            if trimmed.isEmpty {
-                items = try await repositories.item.allItems(in: house)
-            } else {
-                items = try await repositories.item.search(trimmed, in: house)
-            }
+            items = try await repositories.item.allItems(in: house.id)
         } catch {
             items = []
         }
+        didLoad = true
     }
 }
 

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// empty state until 1.5 / Phase 6.
 struct ItemsView: View {
     let selection: SidebarSelection?
+    let searchQuery: String
     @Binding var selectedItemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
@@ -16,20 +17,37 @@ struct ItemsView: View {
     @State private var formMode: ItemFormView.Mode?
     @State private var pendingDelete: Item?
 
+    private var trimmedQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSearching: Bool { !trimmedQuery.isEmpty }
+
     var body: some View {
         Group {
-            switch selection {
-            case .none:
-                placeholder("Pick a list or location.")
-            case .smartList(let list):
-                smartListContent(list)
-            case .location(let id):
-                locationContent(id: id)
+            if isSearching {
+                // Phase 6.2b: a non-empty sidebar search query routes the
+                // content column to a peer mode that ignores `selection`.
+                // Clearing the field falls back to the selection-driven
+                // view below.
+                SearchResultsView(
+                    query: trimmedQuery,
+                    selectedItemID: $selectedItemID
+                )
+            } else {
+                switch selection {
+                case .none:
+                    placeholder("Pick a list or location.")
+                case .smartList(let list):
+                    smartListContent(list)
+                case .location(let id):
+                    locationContent(id: id)
+                }
             }
         }
         .navigationTitle(title)
         .toolbar {
-            if case .location(let locationID) = selection {
+            if !isSearching, case .location(let locationID) = selection {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
                         formMode = .create(locationID: locationID)
@@ -62,10 +80,13 @@ struct ItemsView: View {
     }
 
     private var title: String {
+        if isSearching {
+            return "Search"
+        }
         switch selection {
-        case .none: "Naked Pantree"
-        case .smartList(let list): list.title
-        case .location: locationName ?? "Location"
+        case .none: return "Naked Pantree"
+        case .smartList(let list): return list.title
+        case .location: return locationName ?? "Location"
         }
     }
 
@@ -219,7 +240,7 @@ extension NakedPantreeDomain.Unit {
     @Previewable @State var selectedItemID: Item.ID?
     let repos = Repositories.makePreview()
     NavigationStack {
-        ItemsView(selection: nil, selectedItemID: $selectedItemID)
+        ItemsView(selection: nil, searchQuery: "", selectedItemID: $selectedItemID)
     }
     .environment(\.repositories, repos)
 }

--- a/NakedPantreeApp/Features/Items/SearchResultsView.swift
+++ b/NakedPantreeApp/Features/Items/SearchResultsView.swift
@@ -1,0 +1,121 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Phase 6.2b: cross-household search results column. Driven by the
+/// sidebar `.searchable` field on `RootView`, so this view receives the
+/// (trimmed) query as a `let` and re-fetches whenever it changes. Empty
+/// queries never reach here — `ItemsView` falls back to the
+/// selection-driven view in that case.
+///
+/// Mirrors `AllItemsView`'s repository-call pattern: 250ms debounce on
+/// query change, locations cached per remote-change tick, fetch via
+/// `ItemRepository.search(_:in:)`. The repository search is already
+/// household-scoped (case-insensitive substring on `Item.name`) so the
+/// "cross-household" behavior here is purely about the surface, not the
+/// query.
+struct SearchResultsView: View {
+    let query: String
+    @Binding var selectedItemID: Item.ID?
+
+    @Environment(\.repositories) private var repositories
+    @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
+    @State private var items: [Item] = []
+    @State private var householdID: Household.ID?
+    @State private var locationsByID: [Location.ID: Location] = [:]
+    @State private var didSearch = false
+
+    var body: some View {
+        Group {
+            if !didSearch {
+                ProgressView()
+            } else if items.isEmpty {
+                emptyState
+            } else {
+                List(selection: $selectedItemID) {
+                    ForEach(items) { item in
+                        SearchResultsRow(
+                            item: item,
+                            locationName: locationsByID[item.locationID]?.name
+                        )
+                        .tag(item.id)
+                    }
+                }
+            }
+        }
+        .task(id: remoteChangeMonitor.changeToken) {
+            await loadShell()
+        }
+        .task(id: query) {
+            do {
+                try await Task.sleep(for: .milliseconds(250))
+                await loadResults()
+            } catch {
+                // Cancelled by the next keystroke — that task takes over.
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Nothing by that name yet.",
+            systemImage: "magnifyingglass",
+            description: Text("Try a shorter or different search.")
+        )
+    }
+
+    private func loadShell() async {
+        do {
+            let house = try await repositories.household.currentHousehold()
+            householdID = house.id
+            let locations = try await repositories.location.locations(in: house.id)
+            locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
+        } catch {
+            return
+        }
+        await loadResults()
+    }
+
+    private func loadResults() async {
+        guard let house = householdID else { return }
+        do {
+            items = try await repositories.item.search(query, in: house)
+        } catch {
+            items = []
+        }
+        didSearch = true
+    }
+}
+
+private struct SearchResultsRow: View {
+    let item: Item
+    let locationName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(item.name)
+                .font(.body)
+            HStack(spacing: 8) {
+                if let locationName {
+                    Text(locationName)
+                    Text("·")
+                }
+                Text("\(item.quantity) \(item.unit.displayLabel)")
+                if let expiresAt = item.expiresAt {
+                    Text("·")
+                    Text(expiresAt, style: .date)
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var selectedItemID: Item.ID?
+    NavigationStack {
+        SearchResultsView(query: "tom", selectedItemID: $selectedItemID)
+    }
+    .environment(\.repositories, .makePreview())
+}

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -20,6 +20,7 @@ struct RootView: View {
     // both columns; the placeholder in `ItemsView` covers the nil case.
     @State private var sidebarSelection: SidebarSelection?
     @State private var selectedItemID: Item.ID?
+    @State private var searchQuery: String = ""
     @State private var bootstrapComplete = false
     @State private var isShowingMissingItemAlert = false
     @Environment(\.repositories) private var repositories
@@ -38,11 +39,23 @@ struct RootView: View {
                     } content: {
                         ItemsView(
                             selection: sidebarSelection,
+                            searchQuery: searchQuery,
                             selectedItemID: $selectedItemID
                         )
                     } detail: {
                         ItemDetailView(itemID: selectedItemID)
                     }
+                    // Phase 6.2b: cross-household search lives on the
+                    // sidebar so a non-empty query routes the content
+                    // column to a peer "search results" mode without
+                    // adding a `SidebarSelection` case. Compact iPhone
+                    // collapses `.sidebar` placement to the navigation
+                    // bar drawer for free.
+                    .searchable(
+                        text: $searchQuery,
+                        placement: .sidebar,
+                        prompt: "Search items"
+                    )
                 }
                 // Phase 4.3: every remote-change tick (including the
                 // first cold-launch one) reconciles pending expiry

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -335,6 +335,32 @@ struct ItemRepositoryContractTests {
     }
 
     @Test(
+        "search returns matches from every location in the household",
+        arguments: RepositoryFactory.all)
+    func searchSpansAllLocations(factory: RepositoryFactory) async throws {
+        // Phase 6.2b acceptance: the sidebar search surface filters
+        // across every location in the household. The repository call
+        // is the same `search(_:in:)` AllItemsView used; this test
+        // pins the cross-location guarantee that surface depends on.
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Kitchen Pantry")
+        let freezer = Location(householdID: house.id, name: "Garage Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Pantry Tomatoes"))
+        try await itemRepo.create(Item(locationID: freezer.id, name: "Freezer Tomatoes"))
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Bread"))
+
+        let hits = try await itemRepo.search("tomato", in: house.id)
+        #expect(Set(hits.map(\.name)) == ["Pantry Tomatoes", "Freezer Tomatoes"])
+    }
+
+    @Test(
         "search is scoped to the household, not the location",
         arguments: RepositoryFactory.all)
     func searchScopedToHousehold(factory: RepositoryFactory) async throws {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -323,7 +323,7 @@ household-shaped.
 | --- | --- | --- |
 | 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | ✅ Merged ([apps#45](https://github.com/ellisandy/NakedPantree/pull/45)) |
 | 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | ✅ Merged ([apps#46](https://github.com/ellisandy/NakedPantree/pull/46)) |
-| 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | 🟡 In review |
+| 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | 🟡 In review ([apps#48](https://github.com/ellisandy/NakedPantree/pull/48)) |
 | 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ⏳ Pending |
 | 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -322,8 +322,8 @@ household-shaped.
 | # | Title | Status |
 | --- | --- | --- |
 | 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | ✅ Merged ([apps#45](https://github.com/ellisandy/NakedPantree/pull/45)) |
-| 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | 🟡 In review |
-| 6.2b | Cross-household search surface from the sidebar | ⏳ Pending |
+| 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | ✅ Merged ([apps#46](https://github.com/ellisandy/NakedPantree/pull/46)) |
+| 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | 🟡 In review |
 | 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ⏳ Pending |
 | 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
 


### PR DESCRIPTION
Closes #47.

## Summary

- Adds `.searchable(text:placement:.sidebar, prompt:)` on `RootView`'s `NavigationSplitView` (Option A from #47). Query state lifts to `RootView`; a non-empty trimmed query routes the content column to a peer `SearchResultsView` regardless of `SidebarSelection`.
- New `SearchResultsView` mirrors `AllItemsView`'s repository-call pattern: 250ms debounce on the query, locations cached per remote-change tick, fetch via the existing `ItemRepository.search(_:in:)` (case-insensitive substring on `Item.name`).
- `SidebarSelection` is unchanged — search is a peer content-column mode, not a sidebar case. Keeps the existing routing clean.
- Detail navigation works through the same `selectedItemID` binding used by every other content view; tapping a result selects the item, back-nav stays in the search results.

## Notes for review

- **`AllItemsView` `.searchable` removed.** Two stacked search bars (sidebar + content) is a UX bug, not a side-effect — the sidebar surface is now the single search entry point. `AllItemsView` is now a plain sorted-by-name list backed by `ItemRepository.allItems(in:)`. Called out so reviewers don't flag it as scope creep.
- **6.2a ROADMAP status fixed.** That row was still `🟡 In review` despite [PR #46](https://github.com/ellisandy/NakedPantree/pull/46) having merged — bundled the `✅ Merged` cleanup since I was already touching the table.
- **Empty-state copy** is voice-rule per `DESIGN_GUIDELINES.md` §10 ("Nothing by that name yet."), per the issue's open question.
- **`ARCHITECTURE.md` §7** updated: the sidebar shape now lists the search field above Smart Lists, and a new paragraph documents search as a peer content-column mode.
- **Back-nav verification** is at the code level only. Column-based nav with no clear-on-tap should give "back returns to search results, not sidebar root" for free; formal iPad/Mac verification rolls up into 6.3 per the issue.

## Test plan

- [x] `./scripts/lint.sh` clean (per-file swift-format + swiftlint --strict, matches CI)
- [x] `swift test` in `Packages/Core` passes
- [x] `xcodebuild test` on iPhone 17 sim, scheme `NakedPantree`, with `-skip-testing:NakedPantreeUITests/SnapshotsUITests` (matches `.github/workflows/build-test.yml`) — **TEST SUCCEEDED**
- [x] New repository contract test (`searchSpansAllLocations`) parameterized over `InMemory` and `CoreData` factories
- [x] Manual: typing a query in the sidebar shows cross-location results in the content column
- [x] Manual: clearing the field reverts to the previous sidebar selection
- [x] Manual: tapping a result opens the detail; back-nav returns to results
- [x] Manual: empty-results state shows the §10 voice copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)