### PR TITLE
ROADMAP: mark 6.2b merged

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -323,7 +323,7 @@ household-shaped.
 | --- | --- | --- |
 | 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | ✅ Merged ([apps#45](https://github.com/ellisandy/NakedPantree/pull/45)) |
 | 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | ✅ Merged ([apps#46](https://github.com/ellisandy/NakedPantree/pull/46)) |
-| 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | 🟡 In review ([apps#48](https://github.com/ellisandy/NakedPantree/pull/48)) |
+| 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | ✅ Merged ([apps#48](https://github.com/ellisandy/NakedPantree/pull/48)) |
 | 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ⏳ Pending |
 | 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
 


### PR DESCRIPTION
## Summary

- Doc-only follow-up to [apps#48](https://github.com/ellisandy/NakedPantree/pull/48): flips the 6.2b row from `🟡 In review` to `✅ Merged`.

The status couldn't be set to `✅ Merged` inside #48 itself (PR-as-doc paradox), and rolling it into the next phase PR (6.3) would let stale state sit on `main` for too long. Cheaper to land a one-line follow-up.

## Test plan

- [x] One-line ROADMAP edit; no code touched
- [x] No CI workflows watch ROADMAP, so no checks expected beyond the basic ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)