### PR TITLE
Phase 6.4: empty-state voice pass + icon+text everywhere

### DIFF
--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -37,10 +37,12 @@ struct AllItemsView: View {
 
     @ViewBuilder
     private var emptyState: some View {
+        // Voice-rule copy per `DESIGN_GUIDELINES.md` §9 — the canonical
+        // empty-pantry line.
         ContentUnavailableView(
-            "Pantry's empty",
+            "Your pantry is empty.",
             systemImage: "tray",
-            description: Text("Add a location and a few items to start.")
+            description: Text("This feels like a bigger problem.")
         )
     }
 

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -73,7 +73,9 @@ struct ItemFormView: View {
 
                 if let saveError {
                     Section {
-                        Text(saveError)
+                        // Icon + text per `DESIGN_GUIDELINES.md` §10 /
+                        // Phase 6 exit criterion — never color alone.
+                        Label(saveError, systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.red)
                     }
                 }

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -122,9 +122,9 @@ struct ItemsView: View {
     private func locationContent(id: Location.ID) -> some View {
         if items.isEmpty {
             ContentUnavailableView(
-                "No items here yet",
+                "Empty in here.",
                 systemImage: "tray",
-                description: Text("Tap + to add the first one.")
+                description: Text("Tap + to add the first item.")
             )
             .task(
                 id: ReloadKey(scope: id, token: remoteChangeMonitor.changeToken)

--- a/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
+++ b/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
@@ -51,7 +51,9 @@ struct LocationFormView: View {
 
                 if let saveError {
                     Section {
-                        Text(saveError)
+                        // Icon + text per `DESIGN_GUIDELINES.md` §10 /
+                        // Phase 6 exit criterion — never color alone.
+                        Label(saveError, systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.red)
                     }
                 }

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -28,7 +28,11 @@ struct SidebarView: View {
 
             Section("Locations") {
                 if locations.isEmpty {
-                    Text("No locations yet. Tap + to add one.")
+                    // Phase 6.4: icon + text for the empty-state row so
+                    // the sidebar matches the rest of the app's empty-
+                    // state pattern (`DESIGN_GUIDELINES.md` §10 / Phase 6
+                    // exit criterion).
+                    Label("No locations yet. Tap + to add one.", systemImage: "tray")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -310,11 +310,11 @@ household-shaped.
 
 **Exit criteria**
 
-- [ ] Expiring-soon view lists items from every location, ordered by
+- [x] Expiring-soon view lists items from every location, ordered by
       expiry.
 - [ ] App is usable on iPad in both orientations and on Mac at multiple
       window sizes.
-- [ ] Empty states across the app pass voice rules and use icon + text
+- [x] Empty states across the app pass voice rules and use icon + text
       (never color alone).
 
 **Sub-milestones**
@@ -324,8 +324,8 @@ household-shaped.
 | 6.1 | `ExpiringSoonView` (cross-location, sorted by expiry) + restore §8 missing-item routing | ✅ Merged ([apps#45](https://github.com/ellisandy/NakedPantree/pull/45)) |
 | 6.2a | `RecentlyAddedView` (cross-location, sorted by `createdAt` desc) | ✅ Merged ([apps#46](https://github.com/ellisandy/NakedPantree/pull/46)) |
 | 6.2b | Cross-household search surface from the sidebar (`.searchable(placement: .sidebar)`) | ✅ Merged ([apps#48](https://github.com/ellisandy/NakedPantree/pull/48)) |
-| 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | 🟡 In review |
-| 6.4 | Empty-state copy pass with brand voice | ⏳ Pending |
+| 6.3 | iPad / Mac (Designed for iPad) verification + `DEVELOPMENT.md` §5e runbook | ✅ Merged ([apps#50](https://github.com/ellisandy/NakedPantree/pull/50)) |
+| 6.4 | Empty-state copy pass with brand voice | 🟡 In review |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the "Empty states across the app pass voice rules and use icon + text (never color alone)" exit criterion for Phase 6.

**Empty-state copy lifts (3 surfaces):**

- `AllItemsView` → adopts the `DESIGN_GUIDELINES.md` §9 canonical line *"Your pantry is empty. / This feels like a bigger problem."* The guidelines call this exact copy out by name for this exact moment.
- `ItemsView` per-location empty state → *"Empty in here." / "Tap + to add the first item."* Punchier title; description names the unit explicitly.

**Icon + text additions (3 surfaces):**

- `SidebarView` empty-locations row was a plain `Text` — now a `Label` with `tray` systemImage. Was the only empty state in the app without an icon.
- `LocationFormView` and `ItemFormView` save-error banners were red text alone — now `Label` + `exclamationmark.triangle.fill`. Color stays for emphasis but the icon carries the state for accessibility / reduce-color users.

## Restraint, not blanket re-voicing

Per §11 (*"The key is restraint"*), I deliberately left these surfaces alone — they already pass the §10 checklist:

- `ExpiringSoonView` — "Nothing's expiring" already inverts the §9 "Expiry warning" voice nicely.
- `RecentlyAddedView` — "Nothing added yet" is short, useful, no eye-roll.
- `SearchResultsView` — "Nothing by that name yet." was already voice-rule per [apps#48](https://github.com/ellisandy/NakedPantree/pull/48).
- `ItemsView` `Pick a list or location.` placeholder — clear instruction.
- `ItemDetailView` `Pick an item` — clear instruction.

## ROADMAP

- Ticks Phase 6 exit criteria 1 (Expiring-soon — was already met by 6.1, never ticked) and 3 (empty-state voice — this PR).
- Exit criterion 2 (iPad/Mac usability) is human-gated on `DEVELOPMENT.md §5e` and stays unchecked.
- 6.3 row flipped to `✅ Merged ([apps#50](https://github.com/ellisandy/NakedPantree/pull/50))` — was stale.
- 6.4 row → `🟡 In review`.

Phase 6 doesn't fully close (and `phase-6` tag doesn't go on) until the human ticks criterion 2.

## Test plan

- [x] `./scripts/lint.sh` clean (per-file swift-format + swiftlint --strict)
- [x] `swift test` in `Packages/Core` passes
- [x] `xcodebuild test` on iPhone 17 sim, scheme `NakedPantree`, with `-skip-testing:NakedPantreeUITests/SnapshotsUITests` — **TEST SUCCEEDED**
- [ ] Visual spot-check: empty states render with the new copy on iPhone (manual; pure copy / Label changes — low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)