### PR TITLE
ROADMAP: Phase 7 sub-milestones (user/agent split)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -361,6 +361,28 @@ household-shaped.
 - [ ] The full manual checklist passes on iPhone, iPad, and Mac.
 - [ ] CloudKit Production schema matches Development schema exactly.
 
+**Sub-milestones**
+
+Phase 7 is mostly Apple-web-UI work — Xcode Cloud workflows, App Store
+Connect, CloudKit Console — that the agent can't drive directly. The
+**Owner** column is the split: `user` rows happen in Apple's web tools
+(no PR); `agent` rows are doc / config edits that follow once the user
+reports back.
+
+| # | Title | Owner | Status |
+| --- | --- | --- | --- |
+| 7.1 | Xcode Cloud workflows: PR check (build + tests) and `main`-merge beta (build + tests + archive + TestFlight upload) | user | ⏳ Pending |
+| 7.2 | App Store Connect record + TestFlight internal group + default metadata stub (name, bundle id, screenshots) | user | ⏳ Pending |
+| 7.3 | First TestFlight beta build that exercises every field of the dev CloudKit schema (gates 7.4) | user | ⏳ Pending |
+| 7.4 | CloudKit Production schema deploy via the CloudKit Console — one-way ratchet, must follow 7.3 | user | ⏳ Pending |
+| 7.5 | Manual QA pass against `ARCHITECTURE.md` §11 checklist on iPhone, iPad, and Mac (Designed for iPad) — internal-group install, end-to-end | user | ⏳ Pending |
+| 7.6 | `DEVELOPMENT.md` §6 (Release) and §7 (Troubleshooting) fill-ins — workflow names, real failure modes that surface during 7.1–7.5 | agent | ⏳ Pending |
+
+> 7.6 lands as a series of small doc PRs threaded through the rest —
+> not a one-shot at the end. The TODO blocks in §6 / §7 come out as
+> the user lands each step and reports what the names / failure modes
+> actually were.
+
 ---
 
 ## After TestFlight


### PR DESCRIPTION
## Summary

Doc-only. Adds a Phase 7 sub-milestones table with an explicit `Owner` column that splits `user` rows (Apple web-UI work) from `agent` rows (doc/config edits the agent drives). 

Phase 7 has a fundamentally different shape than Phases 0–6: the bulk of the work happens in App Store Connect, the CloudKit Console, and Xcode Cloud's web UI — not in this repo. Without an explicit split, it's easy for the agent to either (a) speculatively write `.xcode-cloud/ci_scripts/` against workflows that don't exist yet, or (b) sit idle waiting for direction. The owner column makes the handoff visible.

## The split

| # | Owner | Why |
| --- | --- | --- |
| 7.1 Xcode Cloud workflows | user | Workflow definitions live in App Store Connect's Xcode Cloud UI, not in the repo |
| 7.2 App Store Connect + TestFlight | user | Web-UI provisioning |
| 7.3 First beta build exercising every dev-schema field | user | Gates 7.4; one-way ratchet |
| 7.4 CloudKit Production schema deploy | user | CloudKit Console; must follow 7.3 |
| 7.5 Manual QA against §11 checklist | user | Two real iCloud accounts, two physical devices |
| 7.6 `DEVELOPMENT.md` §6 + §7 fill-ins | agent | Threaded through — lifts the TODO blocks as the user reports back |

7.6 explicitly **is not** a one-shot at the end. Each time the user lands a step (e.g. Xcode Cloud workflow names, a real troubleshooting failure mode), 7.6 fires a small doc PR that lifts the matching TODO. Same pattern as [apps#49](https://github.com/ellisandy/NakedPantree/pull/49) and [apps#58](https://github.com/ellisandy/NakedPantree/pull/58) used at phase boundaries.

## Test plan

- [x] One file touched (`ROADMAP.md`); no code changes
- [x] No CI workflows watch ROADMAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)