### PR TITLE
Xcode Cloud post-clone hook (XcodeGen)

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Xcode Cloud post-clone hook. Runs once per build after the repo is
+# cloned, before any xcodebuild step.
+#
+# This repo doesn't commit `*.xcodeproj/` (see .gitignore + project.yml
+# — XcodeGen regenerates it) so without this script Xcode Cloud's
+# `xcodebuild` step can't find a project to build.
+#
+# Apple looks for this script at the literal path `ci_scripts/ci_post_clone.sh`
+# next to `project.yml`. Folder and filename are fixed — do not rename.
+
+set -euo pipefail
+
+echo "▶ Installing XcodeGen via Homebrew"
+brew install xcodegen
+
+# Xcode Cloud sets `$CI_PRIMARY_REPOSITORY_PATH` to the repo root.
+# Fall back to the script's parent directory when unset (so the same
+# script runs locally for sanity-checking).
+ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$ROOT"
+
+echo "▶ Generating Xcode project from project.yml"
+xcodegen generate
+
+echo "✓ Xcode Cloud post-clone complete"


### PR DESCRIPTION
## Summary

Adds `ci_scripts/ci_post_clone.sh` so future Xcode Cloud workflows can build this repo.

The repo commits `project.yml` and gitignores `*.xcodeproj/` — XcodeGen regenerates the project on demand. Xcode Cloud has no built-in XcodeGen support, so without a post-clone hook every `xcodebuild` step would fail with *"project does not exist."* The script:

1. `brew install xcodegen` (Homebrew is preinstalled in Xcode Cloud's environment)
2. `cd "$CI_PRIMARY_REPOSITORY_PATH"` (with a fallback for local sanity-checking)
3. `xcodegen generate`

## Why now (and not bundled into 7.1)

7.1 is configuring the workflows themselves in App Store Connect's web UI — that's user work I can't drive. But the post-clone hook is determined by repo shape, not by which workflow runs it: every xcodebuild-driven workflow needs the script regardless of name or trigger. Landing it ahead of 7.1 means the user's first run of either workflow works clean instead of failing on the first job and waiting on a follow-up commit.

This is **prep**, not 7.1 itself — sub-milestone 7.1 stays `⏳ Pending` until the workflows exist in App Store Connect.

## Path is fixed by Apple

Xcode Cloud only invokes scripts at the literal path `ci_scripts/ci_post_clone.sh` next to the project. Don't rename the folder or the file.

## Test plan

- [x] `bash -n ci_scripts/ci_post_clone.sh` — clean parse
- [x] Script chmod +x
- [ ] Real verification: the user's first Xcode Cloud build (during 7.1) — the script either runs and succeeds, or its absence/failure is the first thing the workflow log surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)