### PR TITLE
Phase 7.1: GitHub Actions TestFlight upload workflow

### DIFF
--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -1,0 +1,139 @@
+name: TestFlight Beta
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.swift"
+      - "Packages/**"
+      - "NakedPantreeApp/**"
+      - "project.yml"
+      - ".github/workflows/testflight-beta.yml"
+      - "ci_scripts/**"
+  workflow_dispatch:
+
+# Don't cancel an in-flight upload if a second push lands — TestFlight
+# rejects mid-upload aborts and we'd burn a build number for nothing.
+concurrency:
+  group: testflight-beta-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  archive-and-upload:
+    name: Archive & TestFlight upload
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        run: xcodegen generate
+
+      # The .p8 stays on the runner only for this job. The well-known
+      # path lets `xcodebuild -authenticationKeyPath` and
+      # `xcrun altool --apiKey` find it without surfacing the secret
+      # in command lines.
+      - name: Decode App Store Connect API key
+        env:
+          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.appstoreconnect/private_keys
+          KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8
+          printf '%s' "$API_KEY_BASE64" | base64 -d > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+
+      # `CURRENT_PROJECT_VERSION` overrides `CFBundleVersion` (build
+      # number) at archive time. TestFlight requires a strictly
+      # increasing build number per marketing version; deriving from
+      # `GITHUB_RUN_NUMBER` keeps it monotonic without committing
+      # back to the repo. Marketing version (`CFBundleShortVersionString`)
+      # stays at whatever Info.plist holds — bump that by hand when
+      # the milestone changes.
+      - name: Archive
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -o pipefail
+          xcodebuild archive \
+            -project NakedPantree.xcodeproj \
+            -scheme NakedPantree \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/NakedPantree.xcarchive \
+            -skipPackagePluginValidation \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8 \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID" \
+            CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
+
+      # `app-store-connect` is the modern method name; older Xcode
+      # called it `app-store`. `signingStyle = automatic` lets Xcode
+      # fetch / regenerate provisioning profiles via the API key —
+      # avoids storing certs and profiles as repo secrets.
+      - name: Write export options
+        run: |
+          mkdir -p build
+          cat > build/exportOptions.plist <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+            <key>uploadSymbols</key>
+            <true/>
+          </dict>
+          </plist>
+          PLIST
+
+      - name: Export IPA
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -o pipefail
+          xcodebuild -exportArchive \
+            -archivePath build/NakedPantree.xcarchive \
+            -exportPath build/export \
+            -exportOptionsPlist build/exportOptions.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8 \
+            -authenticationKeyID "$API_KEY_ID" \
+            -authenticationKeyIssuerID "$API_ISSUER_ID"
+
+      - name: Upload to TestFlight
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          IPA=$(find build/export -name '*.ipa' | head -n1)
+          [ -n "$IPA" ] || { echo "No .ipa produced"; exit 1; }
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$IPA" \
+            --apiKey "$API_KEY_ID" \
+            --apiIssuer "$API_ISSUER_ID"
+
+      - name: Upload archive on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: NakedPantree.xcarchive
+          path: build/NakedPantree.xcarchive
+          if-no-files-found: ignore

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -436,10 +436,21 @@ chrome, no "+1 more" affordance for a single image.
 
 - Single iOS app target. `iPad` is added to "Supported Destinations." "Mac
   (Designed for iPad)" is enabled.
-- **Xcode Cloud** runs on every PR (build + tests) and on merges to `main`
-  (TestFlight beta upload, internal group).
-- GitHub Actions is reserved for lint and `swift-format` checks that don't
-  need an Xcode runner.
+- **GitHub Actions** runs every PR (`build-test.yml`: build + tests on the
+  iPhone simulator; `lint.yml`: swift-format + swiftlint) and runs the
+  TestFlight beta upload (`testflight-beta.yml`) on each merge to `main`.
+  All on `macos-26` runners. Single CI surface, single set of logs.
+- TestFlight upload uses the App Store Connect API key for both signing
+  (via `xcodebuild -allowProvisioningUpdates -authenticationKey*` flags)
+  and `xcrun altool --upload-app`. Three repo secrets:
+  `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`,
+  `APP_STORE_CONNECT_API_KEY` (base64-encoded `.p8`). No certificates
+  or provisioning profiles are stored as secrets — Xcode regenerates
+  them via the API key per build.
+- Build number (`CFBundleVersion`) is overridden to `$GITHUB_RUN_NUMBER`
+  at archive time, keeping it monotonic without committing back to the
+  repo. Marketing version (`CFBundleShortVersionString`) is bumped by
+  hand at milestone boundaries.
 - Versioned Core Data model from day one (`Model.xcdatamodeld` with a `v1`
   version inside). Lightweight migration enabled. CloudKit schema changes
   are deployed to Production via the CloudKit Console after the dev schema

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -877,16 +877,43 @@ the adaptive-layout one.
 
 ## 6. Release
 
-> **TODO (Xcode Cloud setup PR):** document the Xcode Cloud workflow names
-> (PR check, TestFlight beta), the TestFlight internal group, and the App
-> Store Connect bundle ID once they exist.
-
 The shape, per `ARCHITECTURE.md` §10:
 
-- Every PR: Xcode Cloud builds and runs the test suites.
-- Merges to `main`: Xcode Cloud builds, tests, archives, uploads to
-  TestFlight (internal group).
-- App Store releases are manual until we have a reason to automate.
+- **PRs:** `build-test.yml` (build + tests on iPhone simulator) +
+  `lint.yml` (swift-format + swiftlint) — both on GitHub Actions
+  `macos-26` runners.
+- **Merges to `main`:** `testflight-beta.yml` archives, exports, and
+  uploads to TestFlight via `xcrun altool`. Same runner.
+- **App Store releases:** manual until there's a reason to automate.
+
+### TestFlight upload secrets
+
+The `testflight-beta.yml` workflow needs three repo secrets, all
+generated from a single App Store Connect API key with **App Manager**
+role:
+
+| Secret | What it is |
+| --- | --- |
+| `APP_STORE_CONNECT_API_KEY_ID` | Short identifier from the API key page (e.g. `ABCD1234EF`). |
+| `APP_STORE_CONNECT_API_ISSUER_ID` | UUID at the top of the **Users and Access → Keys** tab. |
+| `APP_STORE_CONNECT_API_KEY` | The downloaded `.p8` file, base64-encoded. Generate with `base64 -i AuthKey_*.p8 \| pbcopy` and paste as the secret value. |
+
+Code-signing certificates and provisioning profiles are **not** stored
+as secrets — `xcodebuild -allowProvisioningUpdates` regenerates them
+via the API key on every run. The `.p8` itself is decoded into the
+runner's `~/.appstoreconnect/private_keys/` directory at job start
+and disappears with the runner.
+
+### Build numbering
+
+`CFBundleVersion` is overridden to `$GITHUB_RUN_NUMBER` at archive
+time so each upload has a strictly increasing build number without
+needing a commit-back step. Marketing version
+(`CFBundleShortVersionString`) lives in
+`NakedPantreeApp/Resources/Info.plist`; bump it by hand at milestone
+boundaries.
+
+### CloudKit Production deploy
 
 CloudKit schema changes require a deliberate "Deploy to Production" step
 in the CloudKit Console **after** a TestFlight build has exercised every

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,12 +337,17 @@ household-shaped.
 
 **In scope**
 
-- Xcode Cloud workflows: PR check (build + tests) and beta
-  (build + tests + archive + upload).
-- TestFlight internal group provisioned in App Store Connect.
+- GitHub Actions workflows: existing `build-test.yml` (PR check, already
+  lands) and a new `testflight-beta.yml` (archive + TestFlight upload on
+  merge to `main`). One CI surface. See `ARCHITECTURE.md` §10 for the
+  signing / API-key shape.
+- App Store Connect record + TestFlight internal group + default metadata
+  stub (name, bundle id, screenshots).
+- Three repo secrets for the TestFlight upload:
+  `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`,
+  `APP_STORE_CONNECT_API_KEY`.
 - CloudKit schema **deployed to Production** (the gate from
   `DEVELOPMENT.md` §6).
-- App Store Connect metadata stub — name, bundle id, default screenshots.
 - Final manual QA pass against the full checklist
   (`ARCHITECTURE.md` §11).
 - `DEVELOPMENT.md` Release section + Troubleshooting section filled in
@@ -363,25 +368,26 @@ household-shaped.
 
 **Sub-milestones**
 
-Phase 7 is mostly Apple-web-UI work — Xcode Cloud workflows, App Store
-Connect, CloudKit Console — that the agent can't drive directly. The
-**Owner** column is the split: `user` rows happen in Apple's web tools
-(no PR); `agent` rows are doc / config edits that follow once the user
-reports back.
+CI moved from Xcode Cloud to GitHub Actions (single platform, already
+pays for the runner). 7.1 flips from `user`-owned to `agent`-owned —
+workflow YAML lives in the repo. The remaining rows are still
+Apple-web-UI work the agent can't drive: App Store Connect provisioning,
+the production CloudKit schema deploy, and the manual checklist that
+needs two real iCloud accounts. The **Owner** column makes the split
+visible.
 
 | # | Title | Owner | Status |
 | --- | --- | --- | --- |
-| 7.1 | Xcode Cloud workflows: PR check (build + tests) and `main`-merge beta (build + tests + archive + TestFlight upload) | user | ⏳ Pending |
-| 7.2 | App Store Connect record + TestFlight internal group + default metadata stub (name, bundle id, screenshots) | user | ⏳ Pending |
-| 7.3 | First TestFlight beta build that exercises every field of the dev CloudKit schema (gates 7.4) | user | ⏳ Pending |
+| 7.1 | `.github/workflows/testflight-beta.yml` — archive + TestFlight upload via App Store Connect API key on every `main` merge | agent | 🟡 In review |
+| 7.2 | App Store Connect record + TestFlight internal group + default metadata stub (name, bundle id, screenshots) + repo secrets (`APP_STORE_CONNECT_API_KEY_ID`, `..._ISSUER_ID`, `..._API_KEY`) | user | ⏳ Pending |
+| 7.3 | First green TestFlight upload from `main` that exercises every field of the dev CloudKit schema (gates 7.4) | user | ⏳ Pending |
 | 7.4 | CloudKit Production schema deploy via the CloudKit Console — one-way ratchet, must follow 7.3 | user | ⏳ Pending |
 | 7.5 | Manual QA pass against `ARCHITECTURE.md` §11 checklist on iPhone, iPad, and Mac (Designed for iPad) — internal-group install, end-to-end | user | ⏳ Pending |
-| 7.6 | `DEVELOPMENT.md` §6 (Release) and §7 (Troubleshooting) fill-ins — workflow names, real failure modes that surface during 7.1–7.5 | agent | ⏳ Pending |
+| 7.6 | `DEVELOPMENT.md` §6 (Release) and §7 (Troubleshooting) fill-ins — real failure modes that surface during 7.1–7.5 | agent | ⏳ Pending |
 
 > 7.6 lands as a series of small doc PRs threaded through the rest —
-> not a one-shot at the end. The TODO blocks in §6 / §7 come out as
-> the user lands each step and reports what the names / failure modes
-> actually were.
+> not a one-shot at the end. The §6 / §7 TODO blocks come out as the
+> user lands each step and reports back what surfaced.
 
 ---
 


### PR DESCRIPTION
## Summary

Pivots Phase 7 from Xcode Cloud to GitHub Actions for the TestFlight upload. One CI surface across PR-checks, lint, and beta upload — single set of logs, single set of runner billing, no 25 hr/mo free-tier ceiling.

- New: `.github/workflows/testflight-beta.yml`. Triggers on push to `main` and on `workflow_dispatch`. Archives via `xcodebuild`, exports the IPA, uploads via `xcrun altool --upload-app`.
- Auth via App Store Connect API key — same key powers `xcodebuild -allowProvisioningUpdates -authentication*` (so Xcode regenerates signing certs / profiles per build) and `xcrun altool --apiKey` (so the upload step doesn't need a separate credential). **Three repo secrets, no certificates committed.**
- Build number = `$GITHUB_RUN_NUMBER` overridden via `CURRENT_PROJECT_VERSION` at archive time — monotonic without committing back to the repo.
- `concurrency: cancel-in-progress: false` so a second push doesn't kill an in-flight upload mid-stream.

## Doc updates

- `ARCHITECTURE.md` §10 rewritten — replaced the Xcode Cloud paragraph with the GitHub Actions setup; secrets list spelled out alongside the build-numbering scheme.
- `ROADMAP.md` Phase 7 sub-milestones — 7.1 flips from `user`-owned to `agent`-owned (workflow YAML lives in repo). 7.2 absorbs the three required repo secrets so you have one checklist for App Store Connect provisioning.
- `DEVELOPMENT.md` §6 — Xcode Cloud TODO lifted; replaced with the concrete workflow names, secrets table, and build-numbering note.

## What this PR can't do (still on you)

The workflow file lands but **cannot succeed** until **7.2** is done:

- App Store Connect record exists for `cc.mnmlst.nakedpantree`
- TestFlight internal testing group provisioned
- Three repo secrets configured at https://github.com/ellisandy/NakedPantree/settings/secrets/actions :
  - `APP_STORE_CONNECT_API_KEY_ID` — short identifier from the API key page (e.g. `ABCD1234EF`)
  - `APP_STORE_CONNECT_API_ISSUER_ID` — UUID at the top of **Users and Access → Keys**
  - `APP_STORE_CONNECT_API_KEY` — the `.p8` file, base64-encoded (`base64 -i AuthKey_*.p8 | pbcopy`)

Until those exist, every `main` merge will fire the workflow and fail at the archive step with a signing error. That's the expected gating behavior — once 7.2 lands, the next merge auto-uploads.

## Closes

- [apps#62](https://github.com/ellisandy/NakedPantree/pull/62) — the Xcode Cloud post-clone hook is redundant under this CI shape (`build-test.yml` already runs `xcodegen generate` inline). Already closed.

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] YAML parses (commit hook would catch obvious malforms; CI re-validates on push)
- [ ] **Real verification: the user lands 7.2, then the next merge to `main` runs `testflight-beta.yml` end-to-end.** That's the only way to know if `-allowProvisioningUpdates` works against this team's API key, whether `app-store-connect` is the right method name on macos-26's Xcode, and whether `altool` rejects anything about the build. Failure modes flow into 7.6 (`DEVELOPMENT.md §7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)