### PR TITLE
testflight-beta: harden API-key decode + clearer setup docs

### DIFF
--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -42,16 +42,49 @@ jobs:
       # path lets `xcodebuild -authenticationKeyPath` and
       # `xcrun altool --apiKey` find it without surfacing the secret
       # in command lines.
+      #
+      # The secret can be either the PEM text directly (starts with
+      # `-----BEGIN PRIVATE KEY-----`) or its base64 encoding. The
+      # PEM-direct path forgives the most common user mistake: pasting
+      # the `.p8` file contents into the secret value box instead of
+      # running `base64 -i AuthKey_*.p8 | pbcopy`. After writing, we
+      # sanity-check the file before letting xcodebuild's much-less-
+      # informative `keyPathInvalid` surface.
       - name: Decode App Store Connect API key
         env:
-          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          API_KEY_RAW: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         run: |
           set -euo pipefail
           mkdir -p ~/.appstoreconnect/private_keys
           KEY_PATH=~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8
-          printf '%s' "$API_KEY_BASE64" | base64 -d > "$KEY_PATH"
+
+          if printf '%s' "$API_KEY_RAW" | head -c 32 | grep -q -- '-----BEGIN'; then
+            echo "▸ Secret looks like raw PEM — writing as-is"
+            printf '%s' "$API_KEY_RAW" > "$KEY_PATH"
+          else
+            echo "▸ Secret looks like base64 — decoding"
+            printf '%s' "$API_KEY_RAW" | base64 -d > "$KEY_PATH"
+          fi
           chmod 600 "$KEY_PATH"
+
+          SIZE=$(wc -c < "$KEY_PATH" | tr -d ' ')
+          FIRST_LINE=$(head -n 1 "$KEY_PATH")
+          LAST_LINE=$(tail -n 1 "$KEY_PATH" | tr -d '\r')
+          echo "▸ Key file: $SIZE bytes, first line: $FIRST_LINE"
+
+          if [ "$SIZE" -lt 200 ]; then
+            echo "::error::Decoded key is only $SIZE bytes — expected ~250+ for an App Store Connect .p8. Re-check APP_STORE_CONNECT_API_KEY."
+            exit 1
+          fi
+          if [ "$FIRST_LINE" != "-----BEGIN PRIVATE KEY-----" ]; then
+            echo "::error::Decoded key doesn't start with PEM header. Got: $FIRST_LINE"
+            echo "::error::Re-check APP_STORE_CONNECT_API_KEY — paste either the .p8 contents directly or its base64 encoding (see DEVELOPMENT.md §6)."
+            exit 1
+          fi
+          if [ "$LAST_LINE" != "-----END PRIVATE KEY-----" ]; then
+            echo "::warning::Decoded key tail is '$LAST_LINE' (expected '-----END PRIVATE KEY-----'). xcodebuild may still accept it; surfacing for visibility."
+          fi
 
       # `CURRENT_PROJECT_VERSION` overrides `CFBundleVersion` (build
       # number) at archive time. TestFlight requires a strictly

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -896,7 +896,15 @@ role:
 | --- | --- |
 | `APP_STORE_CONNECT_API_KEY_ID` | Short identifier from the API key page (e.g. `ABCD1234EF`). |
 | `APP_STORE_CONNECT_API_ISSUER_ID` | UUID at the top of the **Users and Access → Keys** tab. |
-| `APP_STORE_CONNECT_API_KEY` | The downloaded `.p8` file, base64-encoded. Generate with `base64 -i AuthKey_*.p8 \| pbcopy` and paste as the secret value. |
+| `APP_STORE_CONNECT_API_KEY` | The downloaded `.p8` file. Either paste the file contents directly (`pbpaste < AuthKey_*.p8`) or its base64 encoding (`base64 -i AuthKey_*.p8 \| pbcopy`) — the workflow detects which one and acts accordingly. |
+
+> **Wrong key type is the #1 setup gotcha.** Apple has multiple `.p8`
+> formats: APNs keys, in-app purchase keys, App Store Connect API
+> keys. They look identical (PEM-formatted EC private keys, ~250
+> bytes) but only the **App Store Connect API key** signs JWTs for
+> TestFlight upload. Generate it at
+> https://appstoreconnect.apple.com/access/api with the
+> **App Manager** role.
 
 Code-signing certificates and provisioning profiles are **not** stored
 as secrets — `xcodebuild -allowProvisioningUpdates` regenerates them


### PR DESCRIPTION
## Summary

First merge of [apps#63](https://github.com/ellisandy/NakedPantree/pull/63) triggered `testflight-beta.yml` on `main` ([run 25011075095](https://github.com/ellisandy/NakedPantree/actions/runs/25011075095)). It failed at the archive step with:

```
xcodebuild: error: Invalid authentication key credential specified
(DVTFoundation.JWT.Error.keyPathInvalid("/.../.appstoreconnect/private_keys/AuthKey_***.p8"))
```

The decode step itself ran clean — so the secret was *valid base64* — but what `base64 -d` produced isn't a parseable EC private key. The error fires on the local JWT parse, not against Apple, so the issue is the file's contents.

## What this PR changes

**Workflow:** the decode step now (a) detects whether the secret already starts with `-----BEGIN PRIVATE KEY-----` and writes it as-is, otherwise base64-decodes as before; (b) sanity-checks the resulting file (size > 200 bytes, first line matches the PEM header) and bails with a clear `::error::` annotation if either fails; (c) logs the file size and first line so subsequent runs make the cause obvious without re-reading the workflow.

The accept-both-formats path forgives the most common user mis-step: pasting the `.p8` file contents directly into the secret box instead of running `base64 -i ...` first.

**Docs:** `DEVELOPMENT.md §6` now (a) says either format works (matches workflow), and (b) calls out the #1 gotcha — Apple has multiple `.p8` types (APNs, in-app purchase, App Store Connect API). They're visually identical PEM-formatted EC private keys; only the App Store Connect API key (App Manager role) signs TestFlight JWTs. Includes the URL.

## What this PR doesn't fix

If the user's secret is the **wrong .p8 type** (e.g., an APNs key), the file *will* pass the new sanity-checks (it's a valid PEM private key, ~250 bytes) but xcodebuild will still reject it with `keyPathInvalid` because the JWT signing algorithm or key-curve doesn't match what the App Store Connect API expects. In that case the next step is to regenerate the key as App Store Connect API at https://appstoreconnect.apple.com/access/api .

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] YAML has no tabs (caught at a basic syntax level)
- [x] **Real verification: merge this PR. The next push to `main` re-runs the workflow.** Either the new diagnostic surfaces a clear cause (file too small / wrong header) and the user fixes the secret, or the file passes sanity-checks and we have new information about why xcodebuild rejects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)