### PR TITLE
Phase 7 close

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,6 +85,31 @@ xcodebuild build \
     -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
 ```
 
+#### Dev build vs TestFlight build — same bundle id, different CloudKit environments
+
+Both builds use bundle id `cc.mnmlst.nakedpantree` and CloudKit
+container `iCloud.cc.mnmlst.nakedpantree`, but they hit **different
+environments inside that container**:
+
+- **Local Xcode build** (Cmd-R against a real device or simulator) is
+  Development-signed — `aps-environment` stays `development` and
+  CloudKit reads/writes the **Development** environment of the
+  container.
+- **TestFlight build** is Distribution-signed — Apple's signing flow
+  flips `aps-environment` to `production` and CloudKit reads/writes
+  the **Production** environment.
+
+The two environments don't share data. A developer who installs the
+TestFlight build over their local dev build (or vice versa) will see
+the *other* environment's data appear after sync — that's expected,
+not a bug.
+
+Because both builds share the bundle id, **only one can be installed
+on a device at a time** — TestFlight install replaces the local dev
+build and vice versa. Side-by-side coexistence (separate bundle id +
+container for dev, e.g. `cc.mnmlst.nakedpantree.dev`) is tracked
+separately; see related issues in the post-Phase-7 backlog.
+
 ### Test
 
 In Xcode: `Cmd+U` runs the app-target test bundles. Headless:
@@ -1030,3 +1055,38 @@ re-uploading (though if Apple's flow forces a key reissue,
 On the next run, `-allowProvisioningUpdates` will mint the profile
 on the fly and the Export IPA + Upload to TestFlight steps both
 succeed.
+
+### CloudKit Console shows two `CD_HouseholdEntity` rows after a fresh install on a second device
+
+**Symptom.** After installing the TestFlight build on a second
+device tied to the same iCloud account, the private zone in
+CloudKit Console contains two `CD_HouseholdEntity` records — both
+named "My Pantry" but with different `CD_id` UUIDs, created several
+seconds apart. Items added on the second device immediately after
+launch may disappear from the UI once sync settles.
+
+**Root cause.** Bootstrap (`BootstrapService.bootstrapIfNeeded()`,
+called from `RootView.runBootstrap()`) runs at app launch and
+checks the local Core Data store for an existing household. On a
+fresh install, the local store is empty *because CloudKit sync
+hasn't replicated the existing household yet* — bootstrap can't
+distinguish that from "genuinely first launch" and creates a new
+household. Sync then brings down the original household, and now
+two exist for the same user. `fetchHouseholdRow` sorts by
+`createdAt ASC` so both devices eventually pick the older
+household, leaving the newer one orphaned. Items added during the
+gap go into the orphaned household and become invisible after
+re-binding.
+
+**Fix.** Tracked as
+[#67](https://github.com/ellisandy/NakedPantree/issues/67) — needs
+real engineering (defer bootstrap until first remote-change tick
+or bounded timeout, with offline-first-launch handling). Until
+fixed, the workaround for testing is: on a fresh install of a
+second device, **wait ~30s after first launch before adding
+items** so CloudKit sync has time to replicate the existing
+household before bootstrap commits. Cleaning up orphan households
+from CloudKit Console requires manually deleting the extra
+`CD_HouseholdEntity` rows (and their associated `CD_LocationEntity`
+"Kitchen" rows) per zone — Core Data's CloudKit mirror doesn't
+cascade-delete from the dashboard side.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -376,6 +376,11 @@ internal-group install round-trips against production CloudKit.
   arrives. Eventually-consistent (`fetchHouseholdRow` sorts oldest-first
   so devices converge) but items added during the gap orphan. Must fix
   before App Store release.
+- [#68](https://github.com/ellisandy/NakedPantree/issues/68) — local
+  dev build and TestFlight build share bundle id `cc.mnmlst.nakedpantree`
+  so they can't be installed side-by-side on the same device. Affects
+  developer ergonomics only; no user-visible bug. Nice-to-have for
+  post-Phase-7.
 
 **Sub-milestones**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -331,7 +331,10 @@ household-shaped.
 
 ---
 
-## Phase 7 — Pre-TestFlight hardening
+## Phase 7 — Pre-TestFlight hardening ✅
+
+**Status:** Complete. CI ships every `main` merge to TestFlight; the
+internal-group install round-trips against production CloudKit.
 
 **Goal:** ship a build to TestFlight internal testers.
 
@@ -360,11 +363,19 @@ household-shaped.
 
 **Exit criteria**
 
-- [ ] An internal tester can install the build from TestFlight and use
+- [x] An internal tester can install the build from TestFlight and use
       it end-to-end (add household, share, get an expiry notification,
       attach a photo).
-- [ ] The full manual checklist passes on iPhone, iPad, and Mac.
-- [ ] CloudKit Production schema matches Development schema exactly.
+- [x] The full manual checklist passes on iPhone, iPad, and Mac.
+- [x] CloudKit Production schema matches Development schema exactly.
+
+**Known issues at close** (filed against post-Phase-7 work):
+
+- [#67](https://github.com/ellisandy/NakedPantree/issues/67) — bootstrap
+  creates a duplicate household on fresh install before CloudKit sync
+  arrives. Eventually-consistent (`fetchHouseholdRow` sorts oldest-first
+  so devices converge) but items added during the gap orphan. Must fix
+  before App Store release.
 
 **Sub-milestones**
 


### PR DESCRIPTION
## Summary

Closes Phase 7. CI ships every \`main\` merge to TestFlight; the internal-group install round-trips end-to-end against production CloudKit. All three exit criteria ticked.

## What changed

- **\`DEVELOPMENT.md §7\`** gains a troubleshooting entry for [#67](https://github.com/ellisandy/NakedPantree/issues/67) (bootstrap-races-sync) so anyone hitting the duplicate-\`CD_HouseholdEntity\` symptom can confirm it's the known issue. Workaround documented.
- **\`DEVELOPMENT.md §3 → Build\`** gains a sub-section explaining that local Xcode builds and TestFlight builds share the bundle id but hit different CloudKit *environments* inside the same container — this caused real confusion during 7.3 verification when the same iCloud account showed different data depending on which build was installed. Also notes that side-by-side coexistence requires separate bundle ids ([#68](https://github.com/ellisandy/NakedPantree/issues/68)).
- **\`ROADMAP.md\`** marks Phase 7 ✅ Complete with a "Status: Complete" line. All three exit criteria ticked. Adds a "Known issues at close" sub-section pointing at #67 and #68 so the doc honestly reflects state-as-of-merge.

## Phase 7 final state

| # | Title | Owner | Status |
| --- | --- | --- | --- |
| 7.1 | TestFlight upload workflow | agent | ✅ Merged |
| 7.2 | App Store Connect provisioning + secrets | user | ✅ Complete |
| 7.3 | First green TestFlight upload exercising every dev-schema field | user | ✅ Verified |
| 7.4 | CloudKit Production schema deploy | user | ✅ (auto-populated by TestFlight writes) |
| 7.5 | Manual QA against \`§11\` checklist | user | ✅ |
| 7.6 | \`DEVELOPMENT.md §6 / §7\` fill-ins | agent | ✅ (across [apps#63](https://github.com/ellisandy/NakedPantree/pull/63), [apps#66](https://github.com/ellisandy/NakedPantree/pull/66), and this PR) |

## Known issues filed

- [#67](https://github.com/ellisandy/NakedPantree/issues/67) — bootstrap-races-sync. Eventually-consistent failure mode but real data loss for items added during the gap on a freshly-installed second device. **Must fix before App Store release.**
- [#68](https://github.com/ellisandy/NakedPantree/issues/68) — side-by-side dev + TestFlight installs. Developer-ergonomics nice-to-have; no user-visible bug.

## After merge

Tag \`phase-7\` on the merge commit per the milestone-tagging convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)