### PR TITLE
Phase 9: notifications & quality-of-life polish (parallel-worktree integration)

### DIFF
--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -85,11 +85,15 @@ struct NakedPantreeApp: App {
             // invite. The delegate is instantiated by the system before
             // this init runs, so a static var is the simplest seam.
             NakedPantreeAppDelegate.shareAcceptance = CloudShareAcceptance(container: container)
-            notificationScheduler = NotificationScheduler(center: .current())
-            // Phase 9.3: persisted reminder time. Real `UserDefaults`
-            // here so the picker round-trips across launches; the test
-            // / preview branches above stay on the in-memory no-op.
+            // Phase 9.3: persisted reminder time, constructed before
+            // the scheduler so it can read `settings.hourOfDay` /
+            // `.minute` when scheduling and when bundling same-day
+            // expiries (Phase 9.4 integration).
             notificationSettings = NotificationSettings(defaults: .standard)
+            notificationScheduler = NotificationScheduler(
+                center: .current(),
+                settings: notificationSettings
+            )
         }
         // Phase 4.2: the delegate routes notification taps into this
         // service. Same static-var pattern as `shareAcceptance` —

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -16,6 +16,7 @@ struct NakedPantreeApp: App {
     private let householdSharing: CloudHouseholdSharingService?
     private let notificationScheduler: NotificationScheduler
     private let notificationRouting: NotificationRoutingService
+    private let notificationSettings: NotificationSettings
 
     init() {
         // Phase 4.2: a single routing service across all branches —
@@ -34,6 +35,7 @@ struct NakedPantreeApp: App {
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
             notificationScheduler = NotificationScheduler()
+            notificationSettings = NotificationSettings()
         } else if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
             // UI-test escape hatch: empty in-memory repos that exercise
             // the real bootstrap flow without persisting anything to
@@ -44,6 +46,7 @@ struct NakedPantreeApp: App {
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
             notificationScheduler = NotificationScheduler()
+            notificationSettings = NotificationSettings()
         } else if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             // Unit tests load us via BUNDLE_LOADER, but the simulator has
             // no iCloud account so `cloudKitContainer()` would fail to
@@ -54,6 +57,7 @@ struct NakedPantreeApp: App {
             accountStatusMonitor = AccountStatusMonitor()
             householdSharing = nil
             notificationScheduler = NotificationScheduler()
+            notificationSettings = NotificationSettings()
         } else {
             // Phase 2.1: production stack is CloudKit-mirrored. Phase 3
             // adds the sharing service against the same container.
@@ -82,6 +86,10 @@ struct NakedPantreeApp: App {
             // this init runs, so a static var is the simplest seam.
             NakedPantreeAppDelegate.shareAcceptance = CloudShareAcceptance(container: container)
             notificationScheduler = NotificationScheduler(center: .current())
+            // Phase 9.3: persisted reminder time. Real `UserDefaults`
+            // here so the picker round-trips across launches; the test
+            // / preview branches above stay on the in-memory no-op.
+            notificationSettings = NotificationSettings(defaults: .standard)
         }
         // Phase 4.2: the delegate routes notification taps into this
         // service. Same static-var pattern as `shareAcceptance` —
@@ -99,6 +107,7 @@ struct NakedPantreeApp: App {
                 .environment(\.householdSharing, householdSharing)
                 .environment(\.notificationScheduler, notificationScheduler)
                 .environment(\.notificationRouting, notificationRouting)
+                .environment(\.notificationSettings, notificationSettings)
         }
     }
 }

--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -19,6 +19,7 @@ struct ItemDetailView: View {
     @State private var isSavingPhoto = false
     @State private var photoErrorMessage: String?
     @State private var pagerStartIndex: Int?
+    @State private var quantityModel: QuantityStepperModel?
 
     var body: some View {
         Group {
@@ -104,6 +105,15 @@ struct ItemDetailView: View {
         .task(id: ReloadKey(scope: itemID, token: remoteChangeMonitor.changeToken)) {
             await reload()
         }
+        .onDisappear {
+            // Flush any pending debounced quantity write so leaving
+            // the detail screen never strands the user's last tap.
+            // The captured model holds its own state — fine to
+            // outlive `self` view value here.
+            if let quantityModel {
+                Task { await quantityModel.flush() }
+            }
+        }
     }
 
     private var photoErrorBinding: Binding<Bool> {
@@ -146,7 +156,14 @@ struct ItemDetailView: View {
             }
 
             Section("Quantity") {
-                Text("\(item.quantity) \(item.unit.displayLabel)")
+                if let quantityModel {
+                    QuantityStepperControl(model: quantityModel, unit: item.unit)
+                } else {
+                    // Brief render before `.task` wires the model up —
+                    // fall back to the read-only label so layout
+                    // doesn't pop in.
+                    Text("\(item.quantity) \(item.unit.displayLabel)")
+                }
             }
 
             if let expiresAt = item.expiresAt {
@@ -282,18 +299,72 @@ struct ItemDetailView: View {
         guard let itemID else {
             item = nil
             photos = []
+            quantityModel = nil
             return
         }
         do {
-            item = try await repositories.item.item(id: itemID)
+            let fetched = try await repositories.item.item(id: itemID)
+            item = fetched
             photos = try await repositories.photo.photos(for: itemID)
+            if let fetched {
+                rebindQuantityModel(for: fetched)
+            } else {
+                quantityModel = nil
+            }
         } catch {
             item = nil
             photos = []
+            quantityModel = nil
         }
     }
 
-    private func saveCameraImage(_ image: UIImage, itemID: Item.ID) async {
+    /// Lazily creates the stepper model on first load and afterwards
+    /// just resets its baseline to the freshly-fetched quantity. We
+    /// don't recreate the model on every reload — re-creating it
+    /// would clobber whatever optimistic value the user just tapped
+    /// in if the reload fires mid-debounce.
+    @MainActor
+    private func rebindQuantityModel(for fetched: Item) {
+        if let existing = quantityModel {
+            // If the user is mid-burst and their optimistic value
+            // hasn't drained to the repo yet, keep the in-flight
+            // value — the next debounce will write it. Otherwise
+            // accept the freshly-fetched canonical quantity (e.g.
+            // from a CloudKit push or an edit-form save).
+            if !existing.hasPendingWrite {
+                existing.reset(to: fetched.quantity)
+            }
+        } else {
+            let repository = repositories.item
+            quantityModel = QuantityStepperModel(
+                initialQuantity: fetched.quantity,
+                persist: { newQuantity in
+                    // Re-fetch under the actor so we don't write a
+                    // stale `name` / `expiresAt` if those were
+                    // edited in another window. If the row vanished
+                    // between tap and write, drop the update — the
+                    // detail view's reload will catch up.
+                    guard var current = try await repository.item(id: fetched.id) else {
+                        return
+                    }
+                    current.quantity = newQuantity
+                    try await repository.update(current)
+                },
+                onPersistFailure: {
+                    Task { await reload() }
+                }
+            )
+        }
+    }
+
+}
+
+/// Photo-attachment side-effects. Lives in an extension so the main
+/// struct body stays under SwiftLint's `type_body_length` ceiling —
+/// these are independent of the rest of the detail screen's state and
+/// only touch the photo repository plus a couple of `@State` flags.
+extension ItemDetailView {
+    fileprivate func saveCameraImage(_ image: UIImage, itemID: Item.ID) async {
         isSavingPhoto = true
         defer { isSavingPhoto = false }
         do {
@@ -314,7 +385,7 @@ struct ItemDetailView: View {
     /// the strip resorts by sortOrder ascending — the next photo
     /// (lowest remaining sortOrder) becomes `photos.first` on the
     /// next reload.
-    private func deletePhoto(_ photo: ItemPhoto) async {
+    fileprivate func deletePhoto(_ photo: ItemPhoto) async {
         do {
             try await repositories.photo.delete(id: photo.id)
             await reload()
@@ -326,7 +397,7 @@ struct ItemDetailView: View {
     /// Promotes a non-primary photo to the primary slot. The promote
     /// service writes a single row with `currentMin - 1` so reorder
     /// stays an O(1) write rather than an N-row renumber pass.
-    private func makePrimary(_ photo: ItemPhoto) async {
+    fileprivate func makePrimary(_ photo: ItemPhoto) async {
         do {
             _ = try await makePhotoPrimary(
                 photo,
@@ -339,7 +410,7 @@ struct ItemDetailView: View {
         }
     }
 
-    private func saveLibraryPick(_ selection: PhotosPickerItem, itemID: Item.ID) async {
+    fileprivate func saveLibraryPick(_ selection: PhotosPickerItem, itemID: Item.ID) async {
         isSavingPhoto = true
         defer {
             isSavingPhoto = false

--- a/NakedPantreeApp/Features/Items/QuantityStepperControl.swift
+++ b/NakedPantreeApp/Features/Items/QuantityStepperControl.swift
@@ -1,0 +1,377 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Inline +/- controls used on `ItemDetailView` so users can adjust an
+/// item's quantity in one tap without entering the edit form.
+///
+/// The view is a thin SwiftUI shell over `QuantityStepperModel`; all of
+/// the interesting logic (clamping at the 0...9999 bounds, debouncing
+/// rapid taps, flushing on dismiss, reloading on save error) lives in
+/// the model so it stays unit-testable without instantiating a view
+/// hierarchy.
+struct QuantityStepperControl: View {
+    @Bindable var model: QuantityStepperModel
+    let unit: NakedPantreeDomain.Unit
+
+    var body: some View {
+        HStack(spacing: 12) {
+            stepButton(
+                systemImage: "minus",
+                identifier: "itemDetail.qty.decrement",
+                accessibilityLabel: "Decrease quantity",
+                direction: .decrement,
+                isEnabled: model.canDecrement
+            )
+
+            // Tabular figures keep the digit column from jittering as
+            // the count changes — `DESIGN_GUIDELINES.md` §5.
+            Text("\(model.quantity) \(unit.displayLabel)")
+                .monospacedDigit()
+                .frame(maxWidth: .infinity)
+                .accessibilityIdentifier("itemDetail.qty.value")
+
+            stepButton(
+                systemImage: "plus",
+                identifier: "itemDetail.qty.increment",
+                accessibilityLabel: "Increase quantity",
+                direction: .increment,
+                isEnabled: model.canIncrement
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func stepButton(
+        systemImage: String,
+        identifier: String,
+        accessibilityLabel: String,
+        direction: QuantityStepperModel.PressDirection,
+        isEnabled: Bool
+    ) -> some View {
+        // Fixed 44-pt square hit target — `DESIGN_GUIDELINES.md`
+        // §10 / Apple HIG. We use a plain shape with a press gesture
+        // rather than `Button(action:)` because SwiftUI's `Button`
+        // only fires on release, and we need press-down /
+        // press-release callbacks to drive the long-press repeat
+        // loop in the model.
+        PressableStepButton(
+            isEnabled: isEnabled,
+            onPressBegan: { model.beginPress(direction) },
+            onPressEnded: { model.endPress() }
+        ) {
+            Image(systemName: systemImage)
+                .font(.body.weight(.semibold))
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .accessibilityIdentifier(identifier)
+        .accessibilityLabel(Text(accessibilityLabel))
+        .accessibilityAddTraits(.isButton)
+        // VoiceOver double-tap doesn't fire `DragGesture`, so without
+        // an explicit `.accessibilityAction` the button would
+        // announce as activatable but never increment. Pair
+        // begin/end so a single VO activation triggers exactly one
+        // ±1 step plus the debounced save (same as a sighted tap).
+        .accessibilityAction {
+            guard isEnabled else { return }
+            model.beginPress(direction)
+            model.endPress()
+        }
+    }
+}
+
+/// SwiftUI shim that exposes press-began / press-ended callbacks via a
+/// `DragGesture(minimumDistance: 0)`. `Button` won't do — it only
+/// fires on release, and we need to start a repeat loop the moment
+/// the finger lands on the +/- button. Disabled state suppresses the
+/// gesture entirely so neither callback fires when the model has
+/// already hit a bound.
+private struct PressableStepButton<Label: View>: View {
+    let isEnabled: Bool
+    let onPressBegan: () -> Void
+    let onPressEnded: () -> Void
+    @ViewBuilder let label: () -> Label
+
+    @State private var isPressing = false
+
+    var body: some View {
+        label()
+            .opacity(isEnabled ? (isPressing ? 0.5 : 1) : 0.3)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard isEnabled, !isPressing else { return }
+                        isPressing = true
+                        onPressBegan()
+                    }
+                    .onEnded { _ in
+                        guard isPressing else { return }
+                        isPressing = false
+                        onPressEnded()
+                    },
+                isEnabled: isEnabled
+            )
+    }
+}
+
+/// Drives `QuantityStepperControl`: holds the optimistic in-flight
+/// `quantity`, clamps to 0...9999, and coalesces rapid taps into a
+/// single repository write.
+///
+/// **Persistence model.** Every increment/decrement updates `quantity`
+/// immediately so the UI feels instant; the actual `repositories.item
+/// .update(...)` call is debounced behind ~500 ms of idle. This avoids
+/// hammering Core Data / CloudKit during a long-press repeat. The view
+/// is expected to call `flush()` from `.onDisappear` so any pending
+/// write lands before the detail screen tears down.
+///
+/// **Long-press repeat.** Holding a button calls `beginPress(_:)` and
+/// the model spins a loop that ticks every `repeatInterval`. After
+/// `accelerationThreshold` of held time, each tick advances by
+/// `acceleratedStep` instead of `1` — same idea as a native `Stepper`
+/// but with bigger tap targets and a slightly more aggressive
+/// acceleration so big restocks aren't tedious.
+///
+/// **Error recovery.** If the persist closure throws, the model invokes
+/// `onPersistFailure()` so the view can reload from the repository —
+/// optimistic state gets thrown away and the canonical record wins.
+@MainActor
+@Observable
+final class QuantityStepperModel {
+    /// Lower bound. The issue text reserves quantity = 0 for the
+    /// "Add to grocery list" affordance landing in a follow-up; keep
+    /// the floor here, no negative quantities.
+    static let minimumQuantity: Int32 = 0
+
+    /// Upper bound matches the form's `Stepper` range so the two
+    /// surfaces don't disagree on what's a valid count.
+    static let maximumQuantity: Int32 = 9999
+
+    /// Default debounce window. Long enough to coalesce a long-press
+    /// burst, short enough that release-then-walk-away still saves
+    /// before the user leaves the screen.
+    static let defaultDebounce: Duration = .milliseconds(500)
+
+    /// Default tick rate while a button is held — roughly 8 Hz, in
+    /// line with Apple's native `Stepper`.
+    static let defaultRepeatInterval: Duration = .milliseconds(120)
+
+    /// Default delay before the per-tick step size escalates from
+    /// `1` to `acceleratedStep`. Hold "for about a second" matches
+    /// the issue text.
+    static let defaultAccelerationThreshold: Duration = .seconds(1)
+
+    /// Default escalated step size once the acceleration threshold
+    /// is crossed. Five is a comfortable middle ground — issue text
+    /// suggests 5–10.
+    static let defaultAcceleratedStep: Int32 = 5
+
+    /// Direction passed to `beginPress(_:)`. `+1` for the increment
+    /// button, `-1` for the decrement button.
+    enum PressDirection: Sendable {
+        case increment
+        case decrement
+
+        var sign: Int32 {
+            switch self {
+            case .increment: 1
+            case .decrement: -1
+            }
+        }
+    }
+
+    /// Current displayed quantity. Mutating this directly bypasses the
+    /// debouncer — internal use only; tap handlers should call
+    /// `increment()` / `decrement()` / `set(_:)` instead.
+    private(set) var quantity: Int32
+
+    private var pendingTask: Task<Void, Never>?
+    private var pendingDebounceToken: UUID?
+    private var pressTask: Task<Void, Never>?
+    private var lastPersistedQuantity: Int32
+    private let debounceInterval: Duration
+    private let repeatInterval: Duration
+    private let accelerationThreshold: Duration
+    private let acceleratedStep: Int32
+    private let persist: @Sendable (Int32) async throws -> Void
+    private let onPersistFailure: @MainActor () -> Void
+
+    init(
+        initialQuantity: Int32,
+        debounceInterval: Duration = QuantityStepperModel.defaultDebounce,
+        repeatInterval: Duration = QuantityStepperModel.defaultRepeatInterval,
+        accelerationThreshold: Duration = QuantityStepperModel.defaultAccelerationThreshold,
+        acceleratedStep: Int32 = QuantityStepperModel.defaultAcceleratedStep,
+        persist: @escaping @Sendable (Int32) async throws -> Void,
+        onPersistFailure: @MainActor @escaping () -> Void = {}
+    ) {
+        let clamped = QuantityStepperModel.clamp(initialQuantity)
+        self.quantity = clamped
+        self.lastPersistedQuantity = clamped
+        self.debounceInterval = debounceInterval
+        self.repeatInterval = repeatInterval
+        self.accelerationThreshold = accelerationThreshold
+        self.acceleratedStep = acceleratedStep
+        self.persist = persist
+        self.onPersistFailure = onPersistFailure
+    }
+
+    var canIncrement: Bool { quantity < QuantityStepperModel.maximumQuantity }
+    var canDecrement: Bool { quantity > QuantityStepperModel.minimumQuantity }
+
+    /// True if there's a debounced write pending, an active press
+    /// loop, or the in-memory value disagrees with what we last
+    /// persisted. Lets the view avoid clobbering the user's
+    /// in-flight tap when an unrelated remote change reload happens.
+    var hasPendingWrite: Bool {
+        pendingTask != nil || pressTask != nil || quantity != lastPersistedQuantity
+    }
+
+    func increment() {
+        set(quantity &+ 1)
+    }
+
+    func decrement() {
+        set(quantity &- 1)
+    }
+
+    /// Sets `quantity` (clamped) and schedules a debounced persist. A
+    /// no-op if the clamped value matches what's already on screen,
+    /// since a single +/- tap that hits a bound shouldn't reset the
+    /// debouncer.
+    func set(_ proposed: Int32) {
+        let next = QuantityStepperModel.clamp(proposed)
+        guard next != quantity else { return }
+        quantity = next
+        scheduleSave()
+    }
+
+    /// Cancels any in-flight debounce and writes the current value
+    /// immediately. Also stops a press-loop if one's running — the
+    /// view-disappear path needs to make sure neither task outlives
+    /// the screen.
+    func flush() async {
+        pressTask?.cancel()
+        pressTask = nil
+        pendingTask?.cancel()
+        pendingTask = nil
+        await persistIfChanged()
+    }
+
+    /// Starts the long-press repeat loop. The first tick fires
+    /// immediately so the press feels responsive; subsequent ticks
+    /// fire every `repeatInterval`, and after `accelerationThreshold`
+    /// elapses each tick advances by `acceleratedStep` instead of 1.
+    /// `endPress()` cancels the loop. Calling `beginPress` while
+    /// another press is already running cancels it first.
+    func beginPress(_ direction: PressDirection) {
+        pressTask?.cancel()
+        let interval = repeatInterval
+        let threshold = accelerationThreshold
+        let big = acceleratedStep
+        let sign = direction.sign
+
+        // Fire the first tick *synchronously*. Without this, a
+        // press-then-immediate-release pair (the VoiceOver
+        // activation pattern, or just a very short tap) would
+        // cancel the press Task before its first iteration ever
+        // gets scheduled — the user would tap and nothing would
+        // happen.
+        applyPressTick(sign: sign, accelerated: false)
+        let start = ContinuousClock.now
+
+        pressTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: interval)
+                } catch {
+                    return
+                }
+                if Task.isCancelled { return }
+                guard let self else { return }
+                let elapsed = ContinuousClock.now - start
+                let accelerated = elapsed >= threshold
+                let stepMagnitude: Int32 = accelerated ? big : 1
+                self.applyPressTick(sign: sign, magnitude: stepMagnitude, accelerated: accelerated)
+            }
+        }
+    }
+
+    /// Cancels the press-loop and schedules a debounced save for
+    /// whatever quantity the user landed on. Safe to call even if no
+    /// press is active — used from `.onEnded` of the press gesture.
+    func endPress() {
+        pressTask?.cancel()
+        pressTask = nil
+        // After a press settles, kick off the normal debounced save.
+        // We didn't schedule per-tick during the press to avoid
+        // flooding the actor with `Task` create/cancel pairs at the
+        // tick rate.
+        if quantity != lastPersistedQuantity {
+            scheduleSave()
+        }
+    }
+
+    private func applyPressTick(sign: Int32, magnitude: Int32 = 1, accelerated: Bool) {
+        let proposed = quantity &+ (sign &* magnitude)
+        let next = QuantityStepperModel.clamp(proposed)
+        if next == quantity {
+            // Bounded out — there's no more to do, no point spinning.
+            pressTask?.cancel()
+            pressTask = nil
+            return
+        }
+        quantity = next
+        _ = accelerated  // surfaced for future haptics; not used yet
+    }
+
+    /// External hook for the parent reload path — keeps the model's
+    /// `lastPersistedQuantity` in sync when the underlying record
+    /// changes from outside (e.g. CloudKit push, edit form save).
+    func reset(to quantity: Int32) {
+        let clamped = QuantityStepperModel.clamp(quantity)
+        pendingTask?.cancel()
+        pendingTask = nil
+        self.quantity = clamped
+        lastPersistedQuantity = clamped
+    }
+
+    private func scheduleSave() {
+        pendingTask?.cancel()
+        let interval = debounceInterval
+        let token = UUID()
+        pendingDebounceToken = token
+        pendingTask = Task { [weak self] in
+            try? await Task.sleep(for: interval)
+            guard !Task.isCancelled else { return }
+            await self?.persistIfChanged()
+            await self?.clearPendingTask(matching: token)
+        }
+    }
+
+    private func clearPendingTask(matching token: UUID) {
+        // Only clear `pendingTask` if no newer tap re-armed the
+        // slot. The fresh task will clear itself when it finishes.
+        guard pendingDebounceToken == token else { return }
+        pendingTask = nil
+        pendingDebounceToken = nil
+    }
+
+    private func persistIfChanged() async {
+        let target = quantity
+        guard target != lastPersistedQuantity else { return }
+        do {
+            try await persist(target)
+            // Only mark as persisted if the user hasn't tapped again
+            // mid-flight. If they have, `quantity` will have moved on
+            // and the next debounce cycle will pick up the delta.
+            lastPersistedQuantity = target
+        } catch {
+            onPersistFailure()
+        }
+    }
+
+    private static func clamp(_ value: Int32) -> Int32 {
+        min(max(value, minimumQuantity), maximumQuantity)
+    }
+}

--- a/NakedPantreeApp/Features/Root/LaunchView.swift
+++ b/NakedPantreeApp/Features/Root/LaunchView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// In-app launch surface shown while `RootView` waits on
+/// `bootstrapComplete`. Phase 8.2's bootstrap-defer pushed the worst-case
+/// wait to ~8s on a fresh-install + slow-network cold-start, long enough
+/// that a bare `Color.brandWarmCream` reads as a hung app. This view
+/// gives the user something to look at: the brand wordmark, a thin
+/// native progress indicator, and after a few seconds a calm
+/// "Syncing with iCloud…" line for the slow-bootstrap case.
+///
+/// Voice rules (`DESIGN_GUIDELINES.md` §3 / §9): bootstrap waits aren't
+/// the place for personality — sync messaging stays plain. The word
+/// "Loading" is intentionally avoided.
+///
+/// The view is pure (no environment dependencies) so `#Preview` and
+/// future snapshot tests can render it without injecting repositories.
+struct LaunchView: View {
+    /// Seconds until the secondary "Syncing with iCloud…" line appears.
+    /// Public so tests / previews can override it; production callers
+    /// rely on the default.
+    let slowThreshold: Duration
+
+    @State private var showSlowMessage = false
+
+    init(slowThreshold: Duration = .seconds(3)) {
+        self.slowThreshold = slowThreshold
+    }
+
+    var body: some View {
+        ZStack {
+            Color.brandWarmCream
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                wordmark
+                    .accessibilityHidden(true)
+
+                ProgressView()
+                    .tint(.brandForestGreen)
+                    .controlSize(.regular)
+
+                // Reserve the slow-message slot up front so the
+                // wordmark + spinner don't shift vertically when it
+                // appears — opacity-only fade keeps the layout stable.
+                Text("Syncing with iCloud…")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .opacity(showSlowMessage ? 1 : 0)
+                    .animation(.easeIn(duration: 0.2), value: showSlowMessage)
+                    .accessibilityHidden(!showSlowMessage)
+            }
+            .padding(.horizontal, 32)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier("view.launch")
+        .task {
+            // A short, cancel-safe wait. If bootstrap finishes first,
+            // the parent swaps this view out and the task is cancelled
+            // before the flag flips — no flash of the slow message on
+            // a fast cold-start.
+            try? await Task.sleep(for: slowThreshold)
+            showSlowMessage = true
+        }
+    }
+
+    /// `naked pantree` weighted lockup per `DESIGN_GUIDELINES.md` §5:
+    /// `Naked` light, `Pantree` bold. A weighted mark reads as the
+    /// brand; a plain lowercase label would read as filler text.
+    private var wordmark: some View {
+        HStack(spacing: 6) {
+            Text("naked")
+                .fontWeight(.light)
+            Text("pantree")
+                .fontWeight(.bold)
+        }
+        .font(.system(.largeTitle, design: .rounded))
+        .foregroundStyle(.brandForestGreen)
+        .kerning(-0.5)
+    }
+
+    private var accessibilityLabel: String {
+        showSlowMessage
+            ? "Naked Pantree is starting up. Syncing with iCloud."
+            : "Naked Pantree is starting up."
+    }
+}
+
+#Preview("Launch — fresh") {
+    LaunchView()
+}
+
+#Preview("Launch — slow state") {
+    // Threshold of zero flips the secondary message immediately so
+    // reviewers can eyeball the slow-bootstrap state without waiting.
+    LaunchView(slowThreshold: .zero)
+}

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 /// `AllItemsView`) cache their fetch in `@State` and only refetch on
 /// their own `.task`. To keep first-launch bootstrap from racing those
 /// caches — the original Kitchen-doesn't-appear-on-fresh-install bug —
-/// we gate the whole shell on `bootstrapComplete`. The brief
-/// brand-color splash is acceptable for an in-memory + one-row
-/// Core Data write that completes in single-digit milliseconds.
+/// we gate the whole shell on `bootstrapComplete`. The pre-bootstrap
+/// state shows `LaunchView` (Phase 9.2) so the user sees the wordmark
+/// + a progress indicator instead of a blank cream surface — Phase 8.2
+/// bootstrap-defer made the wait long enough on fresh install + slow
+/// sync that a static color reads as a hung app.
 struct RootView: View {
     // Initial selection is `nil` so iPhone (compact `NavigationSplitView`)
     // lands the user on the sidebar — defaulting to a smart list there
@@ -66,8 +68,7 @@ struct RootView: View {
                     await resyncExpiryNotifications()
                 }
             } else {
-                Color.brandWarmCream
-                    .ignoresSafeArea()
+                LaunchView()
             }
         }
         .task {

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// User-level Settings screen. Phase 9.3 ships exactly one knob — the
+/// time of day expiry reminders fire — so the form is intentionally
+/// short. Future preferences (per-item lead time, multiple reminders
+/// per day, per-household time) hang off the same screen later.
+///
+/// Reads the live `NotificationSettings` instance from the environment.
+/// `@Bindable` lets the picker mutate hour/minute directly; the
+/// `didSet` hooks on `NotificationSettings` handle the UserDefaults
+/// write-through. Reschedule of pending notifications happens at the
+/// scheduler-call sites (the parent's integration commit) — this view
+/// is a pure preference editor.
+///
+/// **Voice:** `DESIGN_GUIDELINES.md` §9 classifies notification
+/// permission requests as off-limits for personality, but the
+/// preference for *when* a granted notification fires is a low-stakes
+/// configuration moment, not a permission flow. Copy stays plain and
+/// useful so users in a hurry can scan it without rolling their eyes
+/// (§10 checklist), with a single light brand-consistent line.
+struct SettingsView: View {
+    @Environment(\.notificationSettings) private var settings
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        @Bindable var settings = settings
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker(
+                        "Reminder time",
+                        selection: timeOfDayBinding(for: settings),
+                        displayedComponents: .hourAndMinute
+                    )
+                    .accessibilityIdentifier("settings.notificationTime.picker")
+                } header: {
+                    Text("Expiry reminders")
+                } footer: {
+                    Text("We'll remind you 3 days before something expires.")
+                }
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    /// `DatePicker(.hourAndMinute)` binds to a `Date`, but the
+    /// preference is two `Int`s. Bridge them through an arbitrary
+    /// reference date — only the hour and minute components survive
+    /// the round-trip, the calendar day is irrelevant.
+    private func timeOfDayBinding(for settings: NotificationSettings) -> Binding<Date> {
+        Binding(
+            get: {
+                var components = DateComponents()
+                components.hour = settings.hourOfDay
+                components.minute = settings.minute
+                return Calendar.current.date(from: components) ?? Date()
+            },
+            set: { newValue in
+                let components = Calendar.current.dateComponents(
+                    [.hour, .minute],
+                    from: newValue
+                )
+                settings.hourOfDay = components.hour ?? NotificationSettings.defaultHourOfDay
+                settings.minute = components.minute ?? NotificationSettings.defaultMinute
+            }
+        )
+    }
+}
+
+#Preview("Default 9:00 AM") {
+    SettingsView()
+        .environment(\.notificationSettings, NotificationSettings())
+}

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -15,6 +15,7 @@ struct SidebarView: View {
     @State private var formMode: LocationFormView.Mode?
     @State private var pendingDelete: Location?
     @State private var isPresentingShareSheet = false
+    @State private var isPresentingSettings = false
 
     var body: some View {
         List(selection: $selection) {
@@ -83,6 +84,20 @@ struct SidebarView: View {
                     .disabled(householdID == nil)
                 }
             }
+            // Phase 9.3: Settings entry point. Lives in the secondary
+            // toolbar slot next to Share Household so the primary "+"
+            // action stays the most prominent. Always available — even
+            // in previews / tests, where the no-op `NotificationSettings`
+            // default lets the screen render without a real
+            // UserDefaults backing.
+            ToolbarItem(placement: .secondaryAction) {
+                Button {
+                    isPresentingSettings = true
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+                .accessibilityIdentifier("settings.toolbar.entry")
+            }
         }
         .sheet(item: $formMode) { mode in
             LocationFormView(mode: mode) {
@@ -98,6 +113,9 @@ struct SidebarView: View {
                 )
                 .ignoresSafeArea()
             }
+        }
+        .sheet(isPresented: $isPresentingSettings) {
+            SettingsView()
         }
         .confirmationDialog(
             deleteConfirmationTitle,

--- a/NakedPantreeApp/Notifications/ExpiryNotificationBundle.swift
+++ b/NakedPantreeApp/Notifications/ExpiryNotificationBundle.swift
@@ -1,0 +1,277 @@
+import Foundation
+import NakedPantreeDomain
+
+/// One scheduled expiry notification, ready for the scheduler to convert
+/// into a `UNNotificationRequest`. May represent a single item or a
+/// rollup of multiple items expiring on the same local calendar day.
+///
+/// Phase 9.4 / issue #56. The pure-data shape lets `bundleSameDayExpiries`
+/// stay testable in isolation — no scheduler, no `UNUserNotificationCenter`,
+/// no I/O. The scheduler integration in `NotificationScheduler.resync` is
+/// the parent's job; this file only owns the bundling logic.
+struct ExpiryNotificationBundle: Sendable, Equatable {
+    /// Stable identifier for `UNNotificationRequest`.
+    ///
+    /// - Single-item bundle: `"item.<uuid>.expiry"` — matches
+    ///   `NotificationScheduler.identifier(for:)` so reschedule keeps
+    ///   working unchanged when a day collapses from N → 1 items.
+    /// - Multi-item bundle: `"day.<yyyyMMdd>.expiry"` — derived from the
+    ///   day-of-expiry key so editing any one item's expiry rescheduling
+    ///   collapses cleanly. The parent's `staleExpiryIdentifiers` sweep
+    ///   needs to learn this pattern (see integration note in the PR
+    ///   description).
+    let identifier: String
+
+    /// When the notification should fire. For future-trigger bundles
+    /// this is the chosen reminder time (e.g. 9am local) on the lead
+    /// day; for past-trigger bundles it's `now + 60s` so the
+    /// notification fires immediately. The scheduler chooses
+    /// `UNCalendarNotificationTrigger` vs `UNTimeIntervalNotificationTrigger`
+    /// based on which range it falls in.
+    let triggerDate: Date
+
+    let title: String
+    let body: String
+
+    /// Items represented by this bundle. Single-item bundles have one
+    /// element; multi-item bundles have N. The notification tap handler
+    /// can deep-link to the first item or surface the expiring-soon list.
+    let itemIDs: [Item.ID]
+
+    /// True when every item in the bundle is already past its expiry
+    /// at scheduling time. Used by the scheduler to pick an immediate
+    /// trigger vs a calendar trigger and surfaced for tests.
+    let firesImmediately: Bool
+}
+
+/// Groups items by the local-calendar day of their `expiresAt` and
+/// returns one `ExpiryNotificationBundle` per day. Pure function over
+/// `(items, reminder time, lead, calendar, now)` — same shape as
+/// `itemsRecentlyAdded` / `itemsExpiringSoon`. Tests pin `calendar` and
+/// `now` to lock behavior across timezones and DST boundaries.
+///
+/// **Bundling rules:**
+/// - Items with `expiresAt == nil` are dropped (same as
+///   `itemsExpiringSoon`).
+/// - Items grouped by the local calendar day of `expiresAt`, using the
+///   *injected* calendar — not `Calendar.current`. Items at 11pm and
+///   1am local in adjacent days are different days even when their
+///   absolute timestamps are an hour apart.
+/// - For each day's group:
+///   - 1 item → single-item bundle, copy unchanged from per-item path
+///     (`item.name` title, `expiryNotificationBodyCopy(...)` body),
+///     identifier matches `NotificationScheduler.identifier(for:)`.
+///   - N ≥ 2 items → rollup bundle. Lead name is the alphabetically-first
+///     name (deterministic, testable). Title and body follow the §3 +
+///     §10 voice rules: useful, short, no humor (notifications are
+///     mid-stakes).
+/// - Items whose computed lead trigger has already passed (either the
+///   item is past expiry, or it's expiring within the lead window
+///   already) get an immediate trigger of `now + 60s`. The 60-second
+///   pad keeps `UNTimeIntervalNotificationTrigger`'s ≥1s requirement
+///   well-clear of any "fire while still scheduling" race. Past-expiry
+///   items use past-tense copy ("have expired"); items expiring inside
+///   the lead window use future-tense copy ("expires tomorrow") — both
+///   still fire immediately because the user wants to know now.
+///
+/// The function is sort-deterministic: bundles are returned ordered by
+/// `triggerDate` ascending, ties broken by identifier.
+///
+/// - Parameters:
+///   - items: Items to consider. `expiresAt == nil` filtered out.
+///   - reminderHour: Hour-of-day (local) the future-trigger bundles
+///     fire. Phase 9.3 will inject this from settings; default 9 matches
+///     the existing per-item path.
+///   - reminderMinute: Minute-of-hour, default 0.
+///   - leadDays: How far ahead of expiry to fire. Default 3 matches
+///     §8 of `ARCHITECTURE.md` and the existing per-item path.
+///   - calendar: Calendar used for day-grouping and trigger
+///     construction. Inject in tests.
+///   - now: Reference "now" for past-trigger detection and immediate-
+///     trigger date. Inject in tests.
+/// - Returns: One bundle per occupied day, ordered by trigger date.
+func bundleSameDayExpiries(
+    _ items: [Item],
+    reminderHour: Int = 9,
+    reminderMinute: Int = 0,
+    leadDays: Int = 3,
+    calendar: Calendar = .current,
+    now: Date = Date()
+) -> [ExpiryNotificationBundle] {
+    // Filter to items with a real expiry, then group by the local
+    // calendar day of that expiry. Using the injected calendar's
+    // `startOfDay(for:)` yields a `Date` that's stable across the same
+    // local day and so works as a dictionary key — DST transitions
+    // don't break grouping because `startOfDay` accounts for them.
+    let withExpiry = items.compactMap { item -> (Item, Date)? in
+        guard let expiresAt = item.expiresAt else { return nil }
+        return (item, expiresAt)
+    }
+
+    let grouped = Dictionary(grouping: withExpiry) { _, expiresAt in
+        calendar.startOfDay(for: expiresAt)
+    }
+
+    let bundles = grouped.compactMap { dayStart, pairs -> ExpiryNotificationBundle? in
+        // Items in a day's group may not all share the same
+        // `expiresAt` instant — pick the soonest as the canonical
+        // expiry for body-copy purposes. (For multi-item bundles we
+        // don't show the time anyway; for single-item it's the actual
+        // expiry of that item.)
+        let sortedByExpiry = pairs.sorted { $0.1 < $1.1 }
+        let canonicalExpiresAt = sortedByExpiry[0].1
+        let dayItems = sortedByExpiry.map(\.0)
+
+        // Compute the future trigger date: lead-day's reminder time
+        // in the injected calendar. If we can't form it, fall through
+        // to immediate.
+        let leadDay = calendar.date(byAdding: .day, value: -leadDays, to: dayStart)
+        let futureTrigger = leadDay.flatMap {
+            calendar.date(bySettingHour: reminderHour, minute: reminderMinute, second: 0, of: $0)
+        }
+
+        // Choose trigger: future if it's still ahead of `now`, else
+        // immediate (60s pad past `now`). Also detect "already past
+        // expiry" for past-tense copy.
+        let isAllPastExpiry = sortedByExpiry.allSatisfy { $0.1 <= now }
+        let firesImmediately: Bool
+        let triggerDate: Date
+        if let future = futureTrigger, future > now {
+            firesImmediately = false
+            triggerDate = future
+        } else {
+            firesImmediately = true
+            triggerDate = now.addingTimeInterval(60)
+        }
+
+        let identifier = bundleIdentifier(
+            dayItems: dayItems,
+            dayStart: dayStart,
+            calendar: calendar
+        )
+
+        let (title, body) = bundleCopy(
+            items: dayItems,
+            canonicalExpiresAt: canonicalExpiresAt,
+            triggerDate: triggerDate,
+            isAllPastExpiry: isAllPastExpiry
+        )
+
+        return ExpiryNotificationBundle(
+            identifier: identifier,
+            triggerDate: triggerDate,
+            title: title,
+            body: body,
+            itemIDs: dayItems.map(\.id),
+            firesImmediately: firesImmediately
+        )
+    }
+
+    return bundles.sorted { lhs, rhs in
+        if lhs.triggerDate != rhs.triggerDate {
+            return lhs.triggerDate < rhs.triggerDate
+        }
+        return lhs.identifier < rhs.identifier
+    }
+}
+
+/// Builds the stable identifier for a bundle. Single-item bundles match
+/// `NotificationScheduler.identifier(for:)` exactly — that's load-bearing
+/// for the resync path: when a day collapses from N items to 1, the
+/// rollup identifier disappears and the per-item identifier returns,
+/// and the scheduler's existing `removePendingNotificationRequests`
+/// sweep handles it without special-casing.
+///
+/// Multi-item identifiers use `yyyyMMdd` of the day key, formed from
+/// calendar components (not `DateFormatter`) so the result is stable
+/// across locales and timezones.
+private func bundleIdentifier(
+    dayItems: [Item],
+    dayStart: Date,
+    calendar: Calendar
+) -> String {
+    if dayItems.count == 1, let only = dayItems.first {
+        return "item.\(only.id.uuidString).expiry"
+    }
+    let components = calendar.dateComponents([.year, .month, .day], from: dayStart)
+    let year = components.year ?? 0
+    let month = components.month ?? 0
+    let day = components.day ?? 0
+    let stamp = String(format: "%04d%02d%02d", year, month, day)
+    return "day.\(stamp).expiry"
+}
+
+/// Builds title + body for a bundle. Single-item copy matches the
+/// existing per-item path; multi-item copy follows the §3 voice rules
+/// (useful, short, no humor at mid-stakes notifications).
+///
+/// **Variants** (N = item count, lead = alphabetically-first name):
+/// - Single, future: title `item.name`, body `expiryNotificationBodyCopy(...)`.
+/// - Single, past: title `item.name`, body `"\(item.name) has expired."`.
+/// - N≥2, future: title `"\(N) items expiring soon"`,
+///   body `"\(lead) + \(N-1) other(s) expire(s) \(relative)."`
+/// - N≥2, past: title `"\(N) items expired"`,
+///   body `"\(lead) + \(N-1) other(s) ha(s/ve) expired."`
+///
+/// Subject-verb agreement on `expires`/`expire` and `has`/`have` is
+/// driven by the count of "others" — singular for 1, plural for 2+ —
+/// not the total item count. Title agrees with body voice: future
+/// rollups read "expiring soon"; past rollups read "expired" so the
+/// banner doesn't claim something is upcoming when it isn't.
+private func bundleCopy(
+    items: [Item],
+    canonicalExpiresAt: Date,
+    triggerDate: Date,
+    isAllPastExpiry: Bool
+) -> (title: String, body: String) {
+    if items.count == 1, let only = items.first {
+        let title = only.name
+        let body: String
+        if isAllPastExpiry {
+            body = "\(only.name) has expired."
+        } else {
+            body = expiryNotificationBodyCopy(
+                expiresAt: canonicalExpiresAt,
+                relativeTo: triggerDate
+            )
+        }
+        return (title, body)
+    }
+
+    // Multi-item: pick the alphabetically-first name as the lead so
+    // the copy is deterministic regardless of input order. Test
+    // fixtures should make this rule visible.
+    let names = items.map(\.name).sorted {
+        $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+    }
+    let lead = names[0]
+    let othersCount = names.count - 1
+    let othersWord = othersCount == 1 ? "other" : "others"
+
+    let title: String
+    let body: String
+    if isAllPastExpiry {
+        // Title must agree with body — "expiring soon" reads false
+        // when the items have already expired (§10 checklist item 1).
+        title = "\(items.count) items expired"
+        let verb = othersCount == 1 ? "has" : "have"
+        body = "\(lead) + \(othersCount) \(othersWord) \(verb) expired."
+    } else {
+        title = "\(items.count) items expiring soon"
+        let verb = othersCount == 1 ? "expires" : "expire"
+        let relative = relativeExpiryPhrase(expiresAt: canonicalExpiresAt, relativeTo: triggerDate)
+        body = "\(lead) + \(othersCount) \(othersWord) \(verb) \(relative)."
+    }
+    return (title, body)
+}
+
+/// Same `RelativeDateTimeFormatter` shape as `expiryNotificationBodyCopy`,
+/// returning just the relative phrase (no `"Expires "` prefix, no
+/// trailing period). The multi-item body composes its own sentence so
+/// it doesn't double up on punctuation.
+private func relativeExpiryPhrase(expiresAt: Date, relativeTo reference: Date) -> String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .full
+    formatter.dateTimeStyle = .named
+    return formatter.localizedString(for: expiresAt, relativeTo: reference)
+}

--- a/NakedPantreeApp/Notifications/NotificationScheduler.swift
+++ b/NakedPantreeApp/Notifications/NotificationScheduler.swift
@@ -33,13 +33,19 @@ func expiryNotificationBodyCopy(expiresAt: Date, relativeTo reference: Date) -> 
 /// closed; the UI still shows the expiry itself).
 ///
 /// Lead time matches `ARCHITECTURE.md` §8: 3 days before `expiresAt`,
-/// fired at 9:00 in the user's local calendar. DST boundaries are
-/// handled by `Calendar.date(bySettingHour:minute:second:of:)`, which
-/// resolves to the wall-clock hour rather than a fixed UTC offset.
+/// fired at the user's chosen reminder time (Phase 9.3 — wall-clock
+/// hour and minute) in the local calendar. DST boundaries are handled
+/// by `Calendar.date(bySettingHour:minute:second:of:)`, which resolves
+/// to the wall-clock hour rather than a fixed UTC offset.
+///
+/// Phase 9.3 added the `minute` parameter so users can pick non-on-the-
+/// hour reminder times like 7:30 PM. Pre-existing callers default to
+/// `minute: 0`, matching the previous hardcoded behavior.
 func expiryNotificationTriggerDate(
     expiresAt: Date,
     leadDays: Int = 3,
     hourOfDay: Int = 9,
+    minute: Int = 0,
     calendar: Calendar = .current,
     now: Date = .now
 ) -> Date? {
@@ -49,7 +55,7 @@ func expiryNotificationTriggerDate(
     guard
         let target = calendar.date(
             bySettingHour: hourOfDay,
-            minute: 0,
+            minute: minute,
             second: 0,
             of: leadDay
         )
@@ -57,6 +63,42 @@ func expiryNotificationTriggerDate(
         return nil
     }
     return target > now ? target : nil
+}
+
+/// Recognizes a notification identifier as one this scheduler owns —
+/// either the per-item shape (`item.<uuid>.expiry`) or the Phase 9.4
+/// rollup shape (`day.<yyyyMMdd>.expiry`). The bundle-aware resync
+/// sweep uses this to filter out third-party identifiers (future
+/// low-stock alerts, share-related notifications) before computing
+/// "stale relative to the expected set."
+///
+/// Pure free function so it stays unit-testable without standing up
+/// `UNUserNotificationCenter`.
+func isExpiryNotificationIdentifier(_ identifier: String) -> Bool {
+    let parts = identifier.split(separator: ".", omittingEmptySubsequences: false)
+    guard parts.count == 3, parts[2] == "expiry" else { return false }
+    if parts[0] == "item" {
+        return UUID(uuidString: String(parts[1])) != nil
+    }
+    if parts[0] == "day" {
+        return parts[1].count == 8 && parts[1].allSatisfy(\.isNumber)
+    }
+    return false
+}
+
+/// Bundle-aware stale-identifier sweep used by `resync(currentItems:)`
+/// after Phase 9.4. Returns pending identifiers that look like ours
+/// (per `isExpiryNotificationIdentifier`) but aren't in the expected
+/// set produced by `bundleSameDayExpiries`. Identifiers we don't
+/// recognize pass through untouched, same as the per-item-only
+/// `staleExpiryIdentifiers` did.
+func staleBundleIdentifiers(
+    pending: [String],
+    expected: Set<String>
+) -> [String] {
+    pending.filter { identifier in
+        isExpiryNotificationIdentifier(identifier) && !expected.contains(identifier)
+    }
 }
 
 /// Parses the item UUID out of a notification identifier produced by
@@ -137,6 +179,13 @@ final class NotificationScheduler {
     /// the relaxation, not the underlying API.
     nonisolated(unsafe) private let center: UNUserNotificationCenter?
 
+    /// Phase 9.3: optional reference to the user's notification
+    /// preferences. Drives the wall-clock reminder time. `nil` for
+    /// previews / tests / EMPTY_STORE / unit-test host paths, where
+    /// the default 9:00 AM (matching the pre-9.3 hardcoded value)
+    /// preserves existing behavior.
+    private let settings: NotificationSettings?
+
     /// No-op scheduler for previews and tests. `nonisolated` so the
     /// `@Entry` default value (built in a non-isolated context) can
     /// call it. The trick is similar in spirit to
@@ -145,10 +194,30 @@ final class NotificationScheduler {
     /// settable from a non-isolated init.
     nonisolated init() {
         self.center = nil
+        self.settings = nil
     }
 
-    init(center: UNUserNotificationCenter) {
+    /// Production initializer. `settings` is optional so callers that
+    /// want the previous hardcoded 9:00 AM behavior (e.g. tests that
+    /// don't care about the picker) can still construct without one.
+    /// `NakedPantreeApp` always passes a real one in production.
+    init(center: UNUserNotificationCenter, settings: NotificationSettings? = nil) {
         self.center = center
+        self.settings = settings
+    }
+
+    /// Reads the current reminder hour from settings, falling back to
+    /// the pre-9.3 hardcoded value when no settings store is wired.
+    /// `@MainActor`-isolated like the class itself, since
+    /// `NotificationSettings` is `@Observable @MainActor`.
+    private var reminderHour: Int {
+        settings?.hourOfDay ?? NotificationSettings.defaultHourOfDay
+    }
+
+    /// Reads the current reminder minute. Same fallback shape as
+    /// `reminderHour`.
+    private var reminderMinute: Int {
+        settings?.minute ?? NotificationSettings.defaultMinute
     }
 
     /// Idempotent. Re-running with the same item replaces any pending
@@ -163,7 +232,13 @@ final class NotificationScheduler {
             return
         }
 
-        guard let triggerDate = expiryNotificationTriggerDate(expiresAt: expiresAt) else {
+        guard
+            let triggerDate = expiryNotificationTriggerDate(
+                expiresAt: expiresAt,
+                hourOfDay: reminderHour,
+                minute: reminderMinute
+            )
+        else {
             // Lead-time window has passed. Drop any older request that
             // might still be pending from a previous expiry value.
             center.removePendingNotificationRequests(withIdentifiers: [id])
@@ -211,30 +286,29 @@ final class NotificationScheduler {
     /// Brings pending expiry notifications into agreement with the
     /// current set of items.
     ///
-    /// Drives:
-    /// - re-schedule each existing item via `scheduleIfNeeded` (idempotent
-    ///   — replaces the pending request when expiry changed, removes it
-    ///   when expiry was cleared, no-ops when nothing changed)
-    /// - cancel pending expiry requests whose underlying item no longer
-    ///   exists (remote delete from another household member)
+    /// Phase 9.4: items are bundled by local-calendar day before
+    /// scheduling. A day with N items produces one rollup notification
+    /// (`day.<yyyyMMdd>.expiry`) instead of N per-item banners; a day
+    /// with one item still produces a single-item notification using
+    /// the same `item.<uuid>.expiry` identifier `scheduleIfNeeded`
+    /// produces, so a day collapsing N → 1 hands off cleanly without
+    /// a special case. The form-save fast-path (`scheduleIfNeeded`
+    /// direct) still emits per-item; the next remote-change tick's
+    /// resync converges to the bundled shape, cancelling the now-
+    /// stale per-item request via the `staleBundleIdentifiers` sweep.
     ///
     /// Called from `RootView` on every `RemoteChangeMonitor.changeToken`
     /// tick. The first tick fires at cold launch — that's intentional:
     /// it backfills "user reinstalled," "user re-granted notification
     /// permission," and "remote changes happened while backgrounded
-    /// for weeks." The cost is O(items) + O(pending requests) per pass;
-    /// fine for typical pantry sizes. The reschedule loop is serial:
-    /// each `scheduleIfNeeded` awaits a settings check then `add`, and
-    /// `TaskGroup`-style fan-out would race the `.notDetermined` path.
-    /// After the gate below fires, the per-item path is fast.
+    /// for weeks." The cost is O(bundles) + O(pending) per pass.
     ///
     /// **Permission gate.** A blanket `.notDetermined` bail at the top
     /// keeps this background sweep from triggering the permission
-    /// prompt — a cold launch with seeded items would otherwise call
-    /// `scheduleIfNeeded` → `ensureAuthorization` → `requestAuthorization`,
-    /// breaking Phase 4.1's "lazy. We never prompt at launch" contract.
-    /// The explicit form-save path (`scheduleIfNeeded` direct) keeps
-    /// its prompt because that's the contextual moment.
+    /// prompt — a cold launch with seeded items would otherwise hit
+    /// `requestAuthorization` and break Phase 4.1's "lazy. We never
+    /// prompt at launch" contract. The form-save path keeps its
+    /// prompt because that's the contextual moment.
     func resync(currentItems: [Item]) async {
         guard let center else { return }
         let settings = await center.notificationSettings()
@@ -248,14 +322,77 @@ final class NotificationScheduler {
         @unknown default:
             return
         }
-        for item in currentItems {
-            await scheduleIfNeeded(for: item)
+
+        let bundles = bundleSameDayExpiries(
+            currentItems,
+            reminderHour: reminderHour,
+            reminderMinute: reminderMinute
+        )
+        for bundle in bundles {
+            await scheduleBundle(bundle, on: center)
         }
+
         let pending = await center.pendingNotificationRequests().map(\.identifier)
-        let currentIDs = Set(currentItems.map(\.id))
-        let stale = staleExpiryIdentifiers(pending: pending, currentItemIDs: currentIDs)
+        let expected = Set(bundles.map(\.identifier))
+        let stale = staleBundleIdentifiers(pending: pending, expected: expected)
         if !stale.isEmpty {
             center.removePendingNotificationRequests(withIdentifiers: stale)
+        }
+    }
+
+    /// Converts a bundle into a `UNNotificationRequest` and registers
+    /// it. Bundles whose computed lead trigger has already passed
+    /// (`firesImmediately`) use a short `UNTimeIntervalNotificationTrigger`;
+    /// future bundles use `UNCalendarNotificationTrigger` so the system
+    /// fires at the wall-clock minute the user chose, even if the
+    /// device is off then.
+    ///
+    /// `userInfo` carries the first item's id so the existing tap-routing
+    /// (`NotificationRoutingService`) keeps working — multi-item bundles
+    /// land on the first item's detail; single-item bundles land on
+    /// that item, same as before.
+    private func scheduleBundle(
+        _ bundle: ExpiryNotificationBundle,
+        on center: UNUserNotificationCenter
+    ) async {
+        guard await ensureAuthorization(center: center) else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = bundle.title
+        content.body = bundle.body
+        content.sound = .default
+        if let leadID = bundle.itemIDs.first {
+            content.userInfo = ["itemID": leadID.uuidString]
+        }
+
+        let trigger: UNNotificationTrigger
+        if bundle.firesImmediately {
+            // `UNTimeIntervalNotificationTrigger` requires ≥1s; the
+            // bundling function already pads to `now + 60s` so this
+            // is comfortable.
+            let interval = max(1.0, bundle.triggerDate.timeIntervalSinceNow)
+            trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+        } else {
+            let components = Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute],
+                from: bundle.triggerDate
+            )
+            trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: false)
+        }
+
+        let request = UNNotificationRequest(
+            identifier: bundle.identifier,
+            content: content,
+            trigger: trigger
+        )
+
+        do {
+            try await center.add(request)
+        } catch {
+            // No remediation path — `.add` rejects only on system
+            // throttling or denied authorization that flipped between
+            // our check and the call. Silent skip; user has expiry in
+            // the UI either way.
         }
     }
 

--- a/NakedPantreeApp/Notifications/NotificationSettings.swift
+++ b/NakedPantreeApp/Notifications/NotificationSettings.swift
@@ -1,0 +1,110 @@
+import Foundation
+import SwiftUI
+
+/// User-level preferences that drive how expiry notifications fire. The
+/// only knob today is the wall-clock time of day — Phase 9.3 lets users
+/// pick when reminders land instead of the previously hardcoded 9:00 AM
+/// (`NotificationScheduler.expiryNotificationTriggerDate` default).
+///
+/// **Storage:** UserDefaults, single household-wide preference. v1
+/// intentionally per-device — cross-device sync of the preference (via
+/// `NSUbiquitousKeyValueStore` or CloudKit) is deferred per the issue
+/// scope. The default values match the previous hardcoded behavior so
+/// existing TestFlight users see zero observable change until the
+/// integration commit wires this into the scheduler.
+///
+/// **Architectural placement:** app layer, alongside `NotificationScheduler`
+/// and `NotificationRoutingService`. Same trade-off as
+/// `RemoteChangeMonitor` / `AccountStatusMonitor`: lift behind a Domain
+/// protocol when a non-iOS surface needs the same signal. UserDefaults
+/// is iOS-friendly but the abstraction would be cheap if the future
+/// macOS CLI grows a notion of "schedule a reminder."
+///
+/// **`@Observable` shape:** matches `RemoteChangeMonitor` /
+/// `AccountStatusMonitor` so the SwiftUI environment hookup is the same
+/// pattern. The `nonisolated init()` form requires mutable defaults to
+/// live inline on the property declaration — same trick
+/// `AccountStatusMonitor.status` uses — because the `@Observable` macro
+/// makes stored properties `@MainActor`-isolated and a `nonisolated`
+/// initializer body can't write to them.
+@Observable
+@MainActor
+final class NotificationSettings {
+    /// Wall-clock hour (0–23) when expiry reminders fire. Defaults to 9
+    /// to match the previous hardcoded value at
+    /// `NotificationScheduler.expiryNotificationTriggerDate(hourOfDay:)`.
+    var hourOfDay: Int = 9 {
+        didSet {
+            defaults?.set(hourOfDay, forKey: Self.hourKey)
+        }
+    }
+
+    /// Wall-clock minute (0–59) when expiry reminders fire. Defaults to
+    /// 0 — same as the previous hardcoded `minute: 0` baked into the
+    /// scheduler.
+    var minute: Int = 0 {
+        didSet {
+            defaults?.set(minute, forKey: Self.minuteKey)
+        }
+    }
+
+    /// `nil` for the preview/test no-op initializer; the real
+    /// `UserDefaults` for the production initializer. The `nil` case
+    /// keeps `didSet` from writing to `.standard` from a preview /
+    /// snapshot context, where we want a fresh default each time.
+    nonisolated(unsafe) private let defaults: UserDefaults?
+
+    /// `nonisolated` so the static constants are reachable from
+    /// non-isolated test contexts and the inline property defaults
+    /// above. Without this, Swift 6 strict concurrency treats statics
+    /// on a `@MainActor` type as MainActor-isolated.
+    nonisolated static let hourKey = "settings.notifications.reminderHour"
+    nonisolated static let minuteKey = "settings.notifications.reminderMinute"
+
+    /// Hardcoded default that mirrors the value the scheduler was using
+    /// before this preference existed. Migration is implicitly a no-op:
+    /// users who never opened the new Settings screen keep their 9:00 AM
+    /// reminder.
+    nonisolated static let defaultHourOfDay = 9
+    nonisolated static let defaultMinute = 0
+
+    /// No-op settings store for previews and snapshot tests. Holds the
+    /// values in memory only (the `nil` `defaults` short-circuits the
+    /// write-throughs above) so #Preview blocks render with the
+    /// hardcoded defaults and don't leak between runs.
+    ///
+    /// `nonisolated` so the `@Entry` environment default — built in a
+    /// non-isolated context — can construct one. Mirrors
+    /// `RemoteChangeMonitor.init()` and `AccountStatusMonitor.init()`.
+    /// The body intentionally only sets the `nonisolated(unsafe)`
+    /// `defaults` field; mutable property defaults are inline above so
+    /// a nonisolated body never touches MainActor-isolated storage.
+    nonisolated init() {
+        self.defaults = nil
+    }
+
+    /// Production initializer. Reads the persisted values on launch,
+    /// falling back to the hardcoded defaults when nothing is stored.
+    /// Tests inject a `UserDefaults(suiteName:)` to round-trip values
+    /// without touching the standard store.
+    ///
+    /// The two property writes below trip `didSet` and write back what
+    /// we just read — idempotent, two `UserDefaults.set` calls per
+    /// launch. Cheap; not worth a guard flag.
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+        // `object(forKey:)` returns nil when nothing's stored, which
+        // distinguishes "user has never opened settings" from "user
+        // explicitly chose 0" — `integer(forKey:)` would conflate them.
+        if defaults.object(forKey: Self.hourKey) != nil {
+            self.hourOfDay = defaults.integer(forKey: Self.hourKey)
+        }
+        if defaults.object(forKey: Self.minuteKey) != nil {
+            self.minute = defaults.integer(forKey: Self.minuteKey)
+        }
+    }
+}
+
+extension EnvironmentValues {
+    @Entry var notificationSettings = NotificationSettings()
+}

--- a/NakedPantreeTests/ExpiryNotificationBundleTests.swift
+++ b/NakedPantreeTests/ExpiryNotificationBundleTests.swift
@@ -1,0 +1,432 @@
+import Foundation
+import NakedPantreeDomain
+import Testing
+@testable import NakedPantree
+
+/// Shared helpers for the bundling test suites. Pulled into a namespace
+/// so the @Suite types stay short enough for `type_body_length`.
+enum BundleFixtures {
+    /// Pinned to a fixed timezone + Gregorian calendar so day-grouping,
+    /// trigger dates, and identifier stamps match across CI runners and
+    /// developer machines. `Calendar.current` would otherwise drift
+    /// with the host locale.
+    static func laCalendar() throws -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        let zone = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        cal.timeZone = zone
+        return cal
+    }
+
+    static func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        _ hour: Int = 12,
+        _ minute: Int = 0,
+        in calendar: Calendar
+    ) throws -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return try #require(calendar.date(from: components))
+    }
+
+    static func makeItem(name: String, expiresAt: Date?) -> Item {
+        Item(locationID: UUID(), name: name, expiresAt: expiresAt)
+    }
+}
+
+@Suite("Bundling: empty / nil-expiry inputs")
+struct ExpiryBundleEmptyInputTests {
+    @Test("Empty input returns empty output")
+    func emptyInputProducesNoBundles() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 1, 12, 0, in: calendar)
+        let bundles = bundleSameDayExpiries([], calendar: calendar, now: now)
+        #expect(bundles.isEmpty)
+    }
+
+    @Test("Items without an expiry are dropped before bundling")
+    func nilExpiryItemsAreDropped() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 1, 12, 0, in: calendar)
+        let nilItem = BundleFixtures.makeItem(name: "Pasta", expiresAt: nil)
+        let bundles = bundleSameDayExpiries([nilItem], calendar: calendar, now: now)
+        #expect(bundles.isEmpty)
+    }
+
+    @Test("All-nil-expiry input returns empty output")
+    func allNilExpiryProducesNoBundles() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 1, 12, 0, in: calendar)
+        let items = [
+            BundleFixtures.makeItem(name: "A", expiresAt: nil),
+            BundleFixtures.makeItem(name: "B", expiresAt: nil),
+        ]
+        let bundles = bundleSameDayExpiries(items, calendar: calendar, now: now)
+        #expect(bundles.isEmpty)
+    }
+}
+
+@Suite("Bundling: single-item days")
+struct ExpiryBundleSingleItemTests {
+    @Test("Single item on its own day produces a single-item bundle")
+    func singleItemProducesSingleBundle() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let expiresAt = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries([item], calendar: calendar, now: now)
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(bundle.itemIDs == [item.id])
+        #expect(bundle.title == "Milk")
+        // Body shape matches the existing per-item path.
+        #expect(bundle.body.hasPrefix("Expires "))
+        #expect(bundle.body.hasSuffix("."))
+        #expect(bundle.firesImmediately == false)
+    }
+
+    @Test("Single-item identifier matches the existing per-item scheme")
+    func singleItemIdentifierMatchesPerItemScheme() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let expiresAt = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries([item], calendar: calendar, now: now)
+
+        let bundle = try #require(bundles.first)
+        // Load-bearing: scheduler reschedule path keys on this exact
+        // shape. If a day collapses from N items to 1, the rollup id
+        // disappears and the per-item id returns — no special casing.
+        #expect(bundle.identifier == "item.\(item.id.uuidString).expiry")
+        #expect(bundle.identifier == NotificationScheduler.identifier(for: item.id))
+    }
+
+    @Test("Single-item trigger fires at the configured reminder time on lead-day")
+    func singleItemTriggerHonoursReminderTime() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let expiresAt = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries(
+            [item],
+            reminderHour: 14,
+            reminderMinute: 30,
+            calendar: calendar,
+            now: now
+        )
+
+        let bundle = try #require(bundles.first)
+        // 3 days before March 25 = March 22; reminder at 14:30 local.
+        let expected = try BundleFixtures.date(2026, 3, 22, 14, 30, in: calendar)
+        #expect(bundle.triggerDate == expected)
+    }
+}
+
+@Suite("Bundling: multi-item rollups")
+struct ExpiryBundleMultiItemTests {
+    @Test("Two items same day → single rollup with N=2 copy")
+    func twoItemsSameDayProducesSingularOtherCopy() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        // Names chosen so the alphabetically-first lead is "Cucumber".
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: day)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: day)
+
+        let bundles = bundleSameDayExpiries([yogurt, cucumber], calendar: calendar, now: now)
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(Set(bundle.itemIDs) == Set([cucumber.id, yogurt.id]))
+        #expect(bundle.title == "2 items expiring soon")
+        // Singular "other" + singular verb "expires".
+        #expect(bundle.body.hasPrefix("Cucumber + 1 other expires "))
+        #expect(bundle.body.hasSuffix("."))
+        #expect(bundle.firesImmediately == false)
+    }
+
+    @Test("Three items same day → rollup with plural N≥3 copy")
+    func threeItemsSameDayProducesPluralOthersCopy() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: day)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: day)
+        let milk = BundleFixtures.makeItem(name: "Milk", expiresAt: day)
+
+        let bundles = bundleSameDayExpiries(
+            [yogurt, cucumber, milk],
+            calendar: calendar,
+            now: now
+        )
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(bundle.itemIDs.count == 3)
+        #expect(bundle.title == "3 items expiring soon")
+        // Plural "others" + plural verb "expire".
+        #expect(bundle.body.hasPrefix("Cucumber + 2 others expire "))
+        #expect(bundle.body.hasSuffix("."))
+    }
+
+    @Test("Multi-item identifier uses yyyyMMdd of the local day")
+    func multiItemIdentifierHasDayStamp() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: day)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: day)
+
+        let bundles = bundleSameDayExpiries([yogurt, cucumber], calendar: calendar, now: now)
+
+        let bundle = try #require(bundles.first)
+        #expect(bundle.identifier == "day.20260325.expiry")
+    }
+
+    @Test("Lead name is alphabetically-first regardless of input order")
+    func leadNameIsAlphabeticallyFirst() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let zucchini = BundleFixtures.makeItem(name: "Zucchini", expiresAt: day)
+        let apricot = BundleFixtures.makeItem(name: "Apricot", expiresAt: day)
+        let mango = BundleFixtures.makeItem(name: "Mango", expiresAt: day)
+
+        // Try multiple input orderings — lead must always be the
+        // alphabetically-first name.
+        for permutation in [
+            [zucchini, apricot, mango],
+            [mango, apricot, zucchini],
+            [apricot, mango, zucchini],
+            [mango, zucchini, apricot],
+        ] {
+            let bundles = bundleSameDayExpiries(permutation, calendar: calendar, now: now)
+            let bundle = try #require(bundles.first)
+            #expect(bundle.body.hasPrefix("Apricot + 2 others expire "))
+        }
+    }
+}
+
+@Suite("Bundling: past-expiry / immediate-trigger paths")
+struct ExpiryBundlePastExpiryTests {
+    @Test("Already-past single-item expiry uses past-tense copy + immediate trigger")
+    func pastExpirySingleItemUsesPastTense() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        // Expired three days ago.
+        let expiresAt = try BundleFixtures.date(2026, 3, 12, 9, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries([item], calendar: calendar, now: now)
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(bundle.title == "Milk")
+        #expect(bundle.body == "Milk has expired.")
+        #expect(bundle.firesImmediately == true)
+        // Immediate trigger sits 60 seconds past `now`.
+        #expect(bundle.triggerDate == now.addingTimeInterval(60))
+    }
+
+    @Test("Already-past multi-item expiry uses past-tense copy + immediate trigger")
+    func pastExpiryMultiItemUsesPastTense() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 12, 9, 0, in: calendar)
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: day)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: day)
+        let milk = BundleFixtures.makeItem(name: "Milk", expiresAt: day)
+
+        let bundles = bundleSameDayExpiries(
+            [yogurt, cucumber, milk],
+            calendar: calendar,
+            now: now
+        )
+
+        let bundle = try #require(bundles.first)
+        // Title agrees with past-tense body — "expiring soon" would
+        // be a lie when items have already expired.
+        #expect(bundle.title == "3 items expired")
+        // N=3: plural verb "have".
+        #expect(bundle.body == "Cucumber + 2 others have expired.")
+        #expect(bundle.firesImmediately == true)
+        #expect(bundle.triggerDate == now.addingTimeInterval(60))
+    }
+
+    @Test("Two past-expired items use singular has + singular other")
+    func pastExpiryTwoItemsUsesSingularHas() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day = try BundleFixtures.date(2026, 3, 12, 9, 0, in: calendar)
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: day)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: day)
+
+        let bundles = bundleSameDayExpiries([yogurt, cucumber], calendar: calendar, now: now)
+
+        let bundle = try #require(bundles.first)
+        #expect(bundle.title == "2 items expired")
+        #expect(bundle.body == "Cucumber + 1 other has expired.")
+    }
+
+    @Test("Lead-window-already-closed item bundles with immediate trigger and future copy")
+    func leadWindowClosedFiresImmediatelyWithFutureCopy() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        // Expires tomorrow — 3-day lead is already in the past, but
+        // the item itself isn't expired yet. The permissive read:
+        // still bundle, fire immediately, future-tense copy.
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let expiresAt = try BundleFixtures.date(2026, 3, 16, 9, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries([item], calendar: calendar, now: now)
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(bundle.firesImmediately == true)
+        #expect(bundle.triggerDate == now.addingTimeInterval(60))
+        // Future-tense — the item hasn't expired yet.
+        #expect(bundle.body.hasPrefix("Expires "))
+        #expect(bundle.body.hasSuffix("."))
+        // Sanity: not the past-tense copy.
+        #expect(bundle.body != "Milk has expired.")
+    }
+}
+
+@Suite("Bundling: mixed days, DST, and timezone independence")
+struct ExpiryBundleMixedAndBoundaryTests {
+    @Test("Items expiring on different days produce separate bundles, ordered by trigger")
+    func mixedDaysProduceMultipleBundlesOrdered() throws {
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 15, 12, 0, in: calendar)
+        let day1 = try BundleFixtures.date(2026, 3, 22, 9, 0, in: calendar)
+        let day2 = try BundleFixtures.date(2026, 3, 25, 9, 0, in: calendar)
+        let day3 = try BundleFixtures.date(2026, 3, 30, 9, 0, in: calendar)
+        let alpha = BundleFixtures.makeItem(name: "Alpha", expiresAt: day1)
+        let beta1 = BundleFixtures.makeItem(name: "Beta", expiresAt: day2)
+        let beta2 = BundleFixtures.makeItem(name: "Bravo", expiresAt: day2)
+        let gamma = BundleFixtures.makeItem(name: "Gamma", expiresAt: day3)
+
+        let bundles = bundleSameDayExpiries(
+            [gamma, beta2, alpha, beta1],
+            calendar: calendar,
+            now: now
+        )
+
+        #expect(bundles.count == 3)
+        // Ordered by trigger date ascending.
+        #expect(bundles[0].triggerDate < bundles[1].triggerDate)
+        #expect(bundles[1].triggerDate < bundles[2].triggerDate)
+        // First bundle is single-item (Alpha alone on day1).
+        #expect(bundles[0].itemIDs == [alpha.id])
+        // Middle bundle is the rollup.
+        #expect(bundles[1].itemIDs.count == 2)
+        #expect(bundles[1].title == "2 items expiring soon")
+        // Last bundle is single-item (Gamma alone on day3).
+        #expect(bundles[2].itemIDs == [gamma.id])
+    }
+
+    @Test("DST spring-forward day groups items into the same local day")
+    func dstSpringForwardKeepsSameLocalDayGrouping() throws {
+        // US spring-forward 2026: clocks jump 02:00 → 03:00 on Sunday
+        // March 8. Two items both expire on March 8 (one in the
+        // morning, one in the evening) — they must group into one
+        // bundle because they share the local calendar day.
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 1, 12, 0, in: calendar)
+        let morning = try BundleFixtures.date(2026, 3, 8, 9, 0, in: calendar)
+        let evening = try BundleFixtures.date(2026, 3, 8, 22, 0, in: calendar)
+        let cucumber = BundleFixtures.makeItem(name: "Cucumber", expiresAt: morning)
+        let yogurt = BundleFixtures.makeItem(name: "Yogurt", expiresAt: evening)
+
+        let bundles = bundleSameDayExpiries([cucumber, yogurt], calendar: calendar, now: now)
+
+        #expect(bundles.count == 1)
+        let bundle = try #require(bundles.first)
+        #expect(bundle.itemIDs.count == 2)
+        #expect(bundle.identifier == "day.20260308.expiry")
+    }
+
+    @Test("DST spring-forward day's lead trigger lands at 9am wall-clock")
+    func dstSpringForwardTriggerLandsAtNineAMWallClock() throws {
+        // Item expires Wed March 11 — 3-day lead is Sunday March 8,
+        // the spring-forward day. Trigger should resolve to 9am wall
+        // clock, not 8am.
+        let calendar = try BundleFixtures.laCalendar()
+        let now = try BundleFixtures.date(2026, 3, 1, 12, 0, in: calendar)
+        let expiresAt = try BundleFixtures.date(2026, 3, 11, 12, 0, in: calendar)
+        let item = BundleFixtures.makeItem(name: "Milk", expiresAt: expiresAt)
+
+        let bundles = bundleSameDayExpiries([item], calendar: calendar, now: now)
+
+        let bundle = try #require(bundles.first)
+        let components = calendar.dateComponents([.hour, .minute], from: bundle.triggerDate)
+        #expect(components.hour == 9)
+        #expect(components.minute == 0)
+        let expected = try BundleFixtures.date(2026, 3, 8, 9, 0, in: calendar)
+        #expect(bundle.triggerDate == expected)
+    }
+
+    @Test("Day-grouping uses the injected calendar's timezone, not the host's")
+    func dayGroupingHonoursInjectedTimezone() throws {
+        // Same UTC instants, two timezones: New York vs Tokyo. The
+        // bundling key is the *local* calendar day, so the same two
+        // items will or won't group depending on which timezone the
+        // injected calendar uses. This pins the contract.
+        var ny = Calendar(identifier: .gregorian)
+        ny.timeZone = try #require(TimeZone(identifier: "America/New_York"))
+        var tokyo = Calendar(identifier: .gregorian)
+        tokyo.timeZone = try #require(TimeZone(identifier: "Asia/Tokyo"))
+
+        // Construct two `Date` instants such that, in NY, both fall
+        // on March 25; but in Tokyo, one falls on March 25 and the
+        // other on March 26.
+        // 2026-03-25 23:00 NY = 2026-03-26 12:00 Tokyo (next day).
+        // 2026-03-25 09:00 NY = 2026-03-25 22:00 Tokyo (same day).
+        var nyLate = DateComponents()
+        nyLate.year = 2026
+        nyLate.month = 3
+        nyLate.day = 25
+        nyLate.hour = 23
+        let nyLateDate = try #require(ny.date(from: nyLate))
+
+        var nyEarly = DateComponents()
+        nyEarly.year = 2026
+        nyEarly.month = 3
+        nyEarly.day = 25
+        nyEarly.hour = 9
+        let nyEarlyDate = try #require(ny.date(from: nyEarly))
+
+        let cucumber = Item(locationID: UUID(), name: "Cucumber", expiresAt: nyLateDate)
+        let yogurt = Item(locationID: UUID(), name: "Yogurt", expiresAt: nyEarlyDate)
+
+        let nyNow = try BundleFixtures.date(2026, 3, 1, 12, 0, in: ny)
+        let nyBundles = bundleSameDayExpiries(
+            [cucumber, yogurt],
+            calendar: ny,
+            now: nyNow
+        )
+        // NY: same local day, one bundle.
+        #expect(nyBundles.count == 1)
+
+        let tokyoNow = try BundleFixtures.date(2026, 3, 1, 12, 0, in: tokyo)
+        let tokyoBundles = bundleSameDayExpiries(
+            [cucumber, yogurt],
+            calendar: tokyo,
+            now: tokyoNow
+        )
+        // Tokyo: different local days (March 25 vs March 26), two
+        // single-item bundles.
+        #expect(tokyoBundles.count == 2)
+        #expect(tokyoBundles[0].itemIDs.count == 1)
+        #expect(tokyoBundles[1].itemIDs.count == 1)
+    }
+}

--- a/NakedPantreeTests/NotificationSettingsTests.swift
+++ b/NakedPantreeTests/NotificationSettingsTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+
+/// Persistence + default-value tests for `NotificationSettings`.
+///
+/// Each test stands up a fresh `UserDefaults(suiteName:)` and clears
+/// it on construction so values don't leak between cases. The suite
+/// name is randomized per test to keep parallel test runs isolated;
+/// `removePersistentDomain` ensures no stale state survives.
+@Suite("NotificationSettings")
+@MainActor
+struct NotificationSettingsTests {
+    private static func freshDefaults() throws -> UserDefaults {
+        let suite = "NotificationSettingsTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    @Test("Defaults to 9:00 AM when nothing is stored")
+    func defaultsTo9AMWhenEmpty() throws {
+        let defaults = try Self.freshDefaults()
+        let settings = NotificationSettings(defaults: defaults)
+
+        #expect(settings.hourOfDay == 9)
+        #expect(settings.minute == 0)
+    }
+
+    @Test("Default constants match the previous hardcoded scheduler value")
+    func defaultConstantsMatchHardcoded() {
+        // Pin the migration contract: existing TestFlight users must
+        // see exactly the same time-of-day until they explicitly change
+        // it. If a future commit drifts the default, this fails loudly.
+        #expect(NotificationSettings.defaultHourOfDay == 9)
+        #expect(NotificationSettings.defaultMinute == 0)
+    }
+
+    @Test("Round-trips a stored hour through a new instance")
+    func roundTripsHour() throws {
+        let defaults = try Self.freshDefaults()
+        let writer = NotificationSettings(defaults: defaults)
+        writer.hourOfDay = 18
+        writer.minute = 30
+
+        // A fresh instance over the same defaults sees the persisted
+        // values — proves the `didSet` write-through reaches storage
+        // and the production initializer reads it back.
+        let reader = NotificationSettings(defaults: defaults)
+        #expect(reader.hourOfDay == 18)
+        #expect(reader.minute == 30)
+    }
+
+    @Test("Explicit zero hour is distinguished from missing key")
+    func zeroHourPersists() throws {
+        // `integer(forKey:)` returns 0 for both "user picked midnight"
+        // and "nothing stored." The implementation guards with
+        // `object(forKey:)` to keep them distinct — pin that here so
+        // a future "simplification" doesn't conflate the cases.
+        let defaults = try Self.freshDefaults()
+        let writer = NotificationSettings(defaults: defaults)
+        writer.hourOfDay = 0
+        writer.minute = 0
+
+        let reader = NotificationSettings(defaults: defaults)
+        #expect(reader.hourOfDay == 0)
+        #expect(reader.minute == 0)
+    }
+
+    @Test("No-op initializer holds defaults in memory only")
+    func noOpInitDoesNotPersist() throws {
+        // The `nonisolated init()` is what the `@Entry` environment
+        // default uses for previews / tests. It must not leak into
+        // `.standard` UserDefaults — we just verify it constructs with
+        // the documented defaults.
+        let settings = NotificationSettings()
+        #expect(settings.hourOfDay == 9)
+        #expect(settings.minute == 0)
+
+        // Mutating the no-op instance shouldn't crash even though
+        // there's no backing defaults.
+        settings.hourOfDay = 20
+        #expect(settings.hourOfDay == 20)
+    }
+
+    @Test("Storage keys are stable")
+    func storageKeysStable() {
+        // The keys are part of the on-disk contract for any user who
+        // already saved a preference. Re-naming them is a migration,
+        // not a refactor — pin the strings.
+        #expect(NotificationSettings.hourKey == "settings.notifications.reminderHour")
+        #expect(NotificationSettings.minuteKey == "settings.notifications.reminderMinute")
+    }
+}

--- a/NakedPantreeTests/QuantityStepperModelTests.swift
+++ b/NakedPantreeTests/QuantityStepperModelTests.swift
@@ -1,0 +1,352 @@
+import Foundation
+import NakedPantreeDomain
+import Testing
+
+@testable import NakedPantree
+
+/// Tests for the model that backs `QuantityStepperControl` on
+/// `ItemDetailView`. The view itself is intentionally trivial; the
+/// behaviors that need pinning (clamping, debouncing, flush-on-dismiss,
+/// error-triggered reload) all live on the model so they're driveable
+/// from `swift-testing` without spinning up a SwiftUI host.
+@Suite("QuantityStepperModel")
+@MainActor
+struct QuantityStepperModelTests {
+    /// Test fixture that records every persist call. Uses an actor
+    /// internally so concurrent debounced writes don't race the
+    /// recorder; the public API stays simple.
+    final class PersistRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _values: [Int32] = []
+        var shouldThrow = false
+
+        var values: [Int32] {
+            lock.lock()
+            defer { lock.unlock() }
+            return _values
+        }
+
+        var callCount: Int { values.count }
+
+        func record(_ value: Int32) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            if shouldThrow {
+                throw PersistRecorderError.injected
+            }
+            _values.append(value)
+        }
+    }
+
+    enum PersistRecorderError: Error { case injected }
+
+    // MARK: Clamping
+
+    @Test("Initial quantity below 0 clamps to 0")
+    func initialClampsBelowZero() {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: -5,
+            persist: { try recorder.record($0) }
+        )
+        #expect(model.quantity == 0)
+    }
+
+    @Test("Initial quantity above 9999 clamps to 9999")
+    func initialClampsAboveMax() {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 12_345,
+            persist: { try recorder.record($0) }
+        )
+        #expect(model.quantity == 9999)
+    }
+
+    @Test("Decrement at 0 stays at 0 and does not schedule a write")
+    func decrementAtZeroIsNoOp() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 0,
+            debounceInterval: .milliseconds(20),
+            persist: { try recorder.record($0) }
+        )
+        model.decrement()
+        #expect(model.quantity == 0)
+        #expect(model.canDecrement == false)
+        // Wait long enough to confirm no debounced write fires.
+        try? await Task.sleep(for: .milliseconds(80))
+        #expect(recorder.callCount == 0)
+    }
+
+    @Test("Increment at 9999 stays at 9999 and does not schedule a write")
+    func incrementAtMaxIsNoOp() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 9999,
+            debounceInterval: .milliseconds(20),
+            persist: { try recorder.record($0) }
+        )
+        model.increment()
+        #expect(model.quantity == 9999)
+        #expect(model.canIncrement == false)
+        try? await Task.sleep(for: .milliseconds(80))
+        #expect(recorder.callCount == 0)
+    }
+
+    // MARK: Debouncing
+
+    @Test("Multiple rapid increments coalesce into a single persist call")
+    func rapidIncrementsCoalesce() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .milliseconds(40),
+            persist: { try recorder.record($0) }
+        )
+
+        for _ in 0..<5 {
+            model.increment()
+        }
+        #expect(model.quantity == 6)
+        #expect(recorder.callCount == 0)  // still pending
+
+        // Wait past the debounce window plus a margin for scheduling.
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(recorder.callCount == 1)
+        #expect(recorder.values == [6])
+    }
+
+    @Test("Each tap resets the debounce window")
+    func tapsResetDebounce() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .milliseconds(60),
+            persist: { try recorder.record($0) }
+        )
+
+        model.increment()
+        try? await Task.sleep(for: .milliseconds(30))
+        model.increment()
+        try? await Task.sleep(for: .milliseconds(30))
+        model.increment()
+        // Less time has passed than `60ms` since the last tap, so
+        // the persist hasn't fired yet.
+        #expect(recorder.callCount == 0)
+
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(recorder.values == [4])
+    }
+
+    // MARK: Flush
+
+    @Test("flush() writes the pending value immediately")
+    func flushWritesPending() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .seconds(10),  // long enough to never fire
+            persist: { try recorder.record($0) }
+        )
+
+        model.increment()
+        model.increment()
+        #expect(recorder.callCount == 0)
+
+        await model.flush()
+        #expect(recorder.values == [3])
+    }
+
+    @Test("flush() with no pending change does nothing")
+    func flushWithoutPendingChangeIsNoOp() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 5,
+            persist: { try recorder.record($0) }
+        )
+        await model.flush()
+        #expect(recorder.callCount == 0)
+    }
+
+    // MARK: Error path
+
+    @Test("Persist failure invokes onPersistFailure")
+    func persistFailureTriggersReload() async {
+        let recorder = PersistRecorder()
+        recorder.shouldThrow = true
+
+        let failureCount = FailureCounter()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .milliseconds(20),
+            persist: { try recorder.record($0) },
+            onPersistFailure: { failureCount.bump() }
+        )
+
+        model.increment()
+        try? await Task.sleep(for: .milliseconds(120))
+        #expect(failureCount.count == 1)
+    }
+
+    // MARK: Reset
+
+    @Test("reset(to:) updates quantity and clears pending state")
+    func resetClearsPending() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .seconds(10),
+            persist: { try recorder.record($0) }
+        )
+
+        model.increment()
+        model.increment()
+        #expect(model.hasPendingWrite == true)
+
+        model.reset(to: 7)
+        #expect(model.quantity == 7)
+        #expect(model.hasPendingWrite == false)
+
+        // The cancelled debounced task must not fire after the reset.
+        try? await Task.sleep(for: .milliseconds(80))
+        #expect(recorder.callCount == 0)
+    }
+
+    @Test("hasPendingWrite is true between tap and persist completion")
+    func hasPendingWriteWhilePending() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .milliseconds(40),
+            persist: { try recorder.record($0) }
+        )
+
+        model.increment()
+        #expect(model.hasPendingWrite == true)
+
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(model.hasPendingWrite == false)
+    }
+
+    // MARK: Long-press repeat
+
+    @Test("beginPress repeats while held — every tick advances by 1 before acceleration")
+    func longPressRepeatsBeforeAcceleration() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 0,
+            debounceInterval: .seconds(10),  // never fires during the test
+            repeatInterval: .milliseconds(40),
+            accelerationThreshold: .seconds(10),  // never escalates here
+            acceleratedStep: 5,
+            persist: { try recorder.record($0) }
+        )
+
+        model.beginPress(.increment)
+        // First tick is immediate, then ticks every 40 ms. After
+        // ~200 ms we expect ≥4 ticks (5 immediate + repeats), but
+        // we only assert a lower bound so CI scheduler jitter
+        // doesn't flake.
+        try? await Task.sleep(for: .milliseconds(200))
+        model.endPress()
+
+        #expect(model.quantity >= 3)
+        // No persist yet — the long debounce interval keeps writes
+        // batched for after the press loop ends.
+        #expect(recorder.callCount == 0)
+    }
+
+    @Test("Long press escalates step size after acceleration threshold")
+    func longPressEscalates() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 0,
+            debounceInterval: .seconds(10),
+            repeatInterval: .milliseconds(40),
+            accelerationThreshold: .milliseconds(150),
+            acceleratedStep: 10,
+            persist: { try recorder.record($0) }
+        )
+
+        model.beginPress(.increment)
+        try? await Task.sleep(for: .milliseconds(400))
+        model.endPress()
+
+        // Without acceleration, ~400 ms / 40 ms ≈ 10 ticks → q ≈ 10.
+        // With escalation to +10 after 150 ms, we expect q to be
+        // well above the linear bound. Use a conservative floor.
+        #expect(model.quantity > 15)
+    }
+
+    @Test("beginPress on a bounded direction does not loop forever")
+    func longPressStopsAtBound() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 9998,
+            debounceInterval: .seconds(10),
+            repeatInterval: .milliseconds(20),
+            persist: { try recorder.record($0) }
+        )
+
+        model.beginPress(.increment)
+        try? await Task.sleep(for: .milliseconds(150))
+        // Loop should have self-cancelled once it hit 9999. Verify
+        // we don't keep ticking past the bound and that
+        // `hasPendingWrite` reflects the now-idle press loop.
+        #expect(model.quantity == 9999)
+        model.endPress()
+    }
+
+    @Test("beginPress + immediate endPress acts like a single tap (VoiceOver activation)")
+    func voiceOverActivationActsLikeTap() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 1,
+            debounceInterval: .milliseconds(40),
+            persist: { try recorder.record($0) }
+        )
+
+        model.beginPress(.increment)
+        model.endPress()
+
+        // The first tick is synchronous, so the optimistic value
+        // updates immediately even though endPress fires before
+        // any sleep window has elapsed.
+        #expect(model.quantity == 2)
+
+        // After the debounce window, the persisted value catches up.
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(recorder.values == [2])
+    }
+
+    @Test("flush() during a press cancels the press loop")
+    func flushCancelsActivePress() async {
+        let recorder = PersistRecorder()
+        let model = QuantityStepperModel(
+            initialQuantity: 0,
+            debounceInterval: .milliseconds(20),
+            repeatInterval: .milliseconds(30),
+            persist: { try recorder.record($0) }
+        )
+
+        model.beginPress(.increment)
+        try? await Task.sleep(for: .milliseconds(80))
+        let snapshot = model.quantity
+        await model.flush()
+
+        // After flush, no further ticks land — wait and verify the
+        // quantity stays put.
+        try? await Task.sleep(for: .milliseconds(120))
+        #expect(model.quantity == snapshot)
+        // Flush wrote the snapshot value to the recorder.
+        #expect(recorder.values == [snapshot])
+    }
+}
+
+/// MainActor-isolated, mutable tally — `Int` plus a closure capture
+/// can't escape the closure cleanly under strict concurrency.
+@MainActor
+final class FailureCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -515,10 +515,18 @@ become useful instead of annoying.
 
 | # | Title | Issue | Status |
 | --- | --- | --- | --- |
-| 9.1 | Quantity inc / dec controls on `ItemDetailView` | [#51](https://github.com/ellisandy/NakedPantree/issues/51) | ⏳ Pending |
-| 9.2 | Launch / loading feedback during cold-start bootstrap | [#53](https://github.com/ellisandy/NakedPantree/issues/53) | ⏳ Pending |
-| 9.3 | Expiry-reminder time-of-day picker | [#55](https://github.com/ellisandy/NakedPantree/issues/55) | ⏳ Pending |
-| 9.4 | Roll up same-day expiries into a single summary notification | [#56](https://github.com/ellisandy/NakedPantree/issues/56) | ⏳ Pending |
+| 9.1 | Quantity inc / dec controls on `ItemDetailView` | [#51](https://github.com/ellisandy/NakedPantree/issues/51) | 🟡 In review |
+| 9.2 | Launch / loading feedback during cold-start bootstrap | [#53](https://github.com/ellisandy/NakedPantree/issues/53) | 🟡 In review |
+| 9.3 | Expiry-reminder time-of-day picker | [#55](https://github.com/ellisandy/NakedPantree/issues/55) | 🟡 In review |
+| 9.4 | Roll up same-day expiries into a single summary notification | [#56](https://github.com/ellisandy/NakedPantree/issues/56) | 🟡 In review |
+
+> Phase 9 ran the parallel-worktrees workflow: four agents in
+> isolated worktrees, no per-sub-milestone PRs, integrated locally
+> into a single PR. The shared file (`NotificationScheduler.swift`)
+> was quarantined from the agents and wired centrally in the
+> integration commit so 9.3's settings + 9.4's bundling both flow
+> through one place. Each sub-branch's commit is preserved (cherry-
+> picked, not squashed) so the PR is reviewable per sub-milestone.
 
 ---
 


### PR DESCRIPTION
## Summary

Bundled Phase 9 — four sub-milestones developed in parallel worktrees, no per-sub-milestone PRs, integrated locally into one CI run. Each sub-branch's single commit is preserved (cherry-picked, not squashed) so this PR is reviewable per sub-milestone via the commit list.

| # | Issue | Branch | What landed |
|---|---|---|---|
| 9.1 | [#51](https://github.com/ellisandy/NakedPantree/issues/51) | `claude/phase-9.1-qty-controls` | Inline `+`/`−` on `ItemDetailView`. Hold-to-repeat ~8 Hz, escalates to ±5 after ~1s. Writes coalesce into one Core Data update 500ms after release. Clamped at 0 / 9999. 16 new Swift Testing cases. |
| 9.2 | [#53](https://github.com/ellisandy/NakedPantree/issues/53) | `claude/phase-9.2-launch-feedback` | New `LaunchView` replaces the blank `Color.brandWarmCream` while `bootstrapComplete == false`. Brand-cream canvas + weighted wordmark + `ProgressView`. After 3s, a "Syncing with iCloud…" line fades in. Pure standalone view (no env deps). |
| 9.3 | [#55](https://github.com/ellisandy/NakedPantree/issues/55) | `claude/phase-9.3-notification-time` | New `NotificationSettings` (`@Observable @MainActor` UserDefaults wrapper, mirrors `RemoteChangeMonitor` shape). New `SettingsView` with `DatePicker(.hourAndMinute)`. Reachable from the sidebar via a new gear toolbar entry next to Share Household. 6 new tests. |
| 9.4 | [#56](https://github.com/ellisandy/NakedPantree/issues/56) | `claude/phase-9.4-notification-bundle` | Pure `bundleSameDayExpiries(...)` function + `ExpiryNotificationBundle` value type — no scheduler I/O. 18 tests across 5 suites covering DST, timezone, past-expiry, N=2/N≥3 copy variants. Single-item identifier matches `NotificationScheduler.identifier(for:)` byte-for-byte so day-collapse N → 1 needs no scheduler special case. |

## Integration

`NotificationScheduler.swift` was deliberately quarantined from all four agents — that's the only file 9.3 and 9.4 would have collided on. The integration commit (`c38da7a`) wires both at once:

- **9.3 → scheduler:** `NotificationScheduler` gains an optional `settings: NotificationSettings` injected at init. `scheduleIfNeeded(for:)` reads `reminderHour` / `reminderMinute` from settings (with the pre-9.3 hardcoded `9:00 AM` as fallback) when computing the trigger date. `expiryNotificationTriggerDate` gains a `minute:` parameter (default `0`).
- **9.4 → scheduler:** `resync(currentItems:)` now calls `bundleSameDayExpiries(...)` and emits one notification per bundle. Bundles flagged `firesImmediately` use a `UNTimeIntervalNotificationTrigger` (≥1s); future bundles use `UNCalendarNotificationTrigger` so the system fires at the chosen wall-clock minute. New `staleBundleIdentifiers(pending:expected:)` + `isExpiryNotificationIdentifier(_:)` free functions handle the bundle-aware sweep that recognizes both `item.<uuid>.expiry` and `day.<yyyyMMdd>.expiry` shapes.
- **`NakedPantreeApp.swift`** reorders construction so `notificationSettings` precedes `notificationScheduler`, then passes it to the scheduler init.

## Test plan

- [x] `./scripts/lint.sh` clean.
- [x] Full xcodebuild test (the CI-matching command, iPhone 17 sim, `-skip-testing:NakedPantreeUITests/SnapshotsUITests`) ends `** TEST SUCCEEDED **`. ~140 unit tests across the new sub-milestones + the existing suite all pass.
- [ ] Real-device verification still owes (per-sub-milestone):
  - 9.1: tap-and-hold UX feel on a real device (the simulator approximates the 8 Hz repeat well but trackpad ≠ touchscreen).
  - 9.2: cold-start visual on a real device — the splash should be visible for the entire bootstrap window.
  - 9.3: round-trip a chosen reminder time, restart, confirm persistence; schedule an item, verify the notification fires at the new time.
  - 9.4: add 3+ items expiring same day, confirm one rollup banner instead of three on the trigger date. (Phase 8 verification + this overlaps — same multi-item fixture exercises both.)

## How to review

The cleanest path is commit-by-commit via the file tree on the GitHub PR — each commit is a self-contained sub-milestone, and the integration commit (`c38da7a`) is the only place the four meet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)