### PR TITLE
Phase 10: Settings + brand-pass research + side-by-side install + self-emission filter

### DIFF
--- a/DESIGN_GUIDELINES.md
+++ b/DESIGN_GUIDELINES.md
@@ -132,6 +132,10 @@ Lowercase `naked pantree` works really well. Alternative weighted lockup:
 
 > Machine-readable source of truth: [`assets/brand/colors.json`](assets/brand/colors.json).
 > If you change a value here, change it there in the same commit.
+>
+> Rollout plan, semantic-token layer, dark-mode hexes, and computed WCAG
+> ratios live in [`docs/BRAND_PASS_PROPOSAL.md`](docs/BRAND_PASS_PROPOSAL.md)
+> (Phase 10.2 research). Implementation is tracked under Phase 10.5.
 
 ### 🌿 Primary Theme (Farm + Modern)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,30 +85,68 @@ xcodebuild build \
     -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest'
 ```
 
-#### Dev build vs TestFlight build — same bundle id, different CloudKit environments
+#### Dev build vs TestFlight build — separate bundle ids, separate CloudKit containers
 
-Both builds use bundle id `cc.mnmlst.nakedpantree` and CloudKit
-container `iCloud.cc.mnmlst.nakedpantree`, but they hit **different
-environments inside that container**:
+The two configurations now ship as distinct app installs so a
+developer can keep both on the same device at the same time:
 
-- **Local Xcode build** (Cmd-R against a real device or simulator) is
-  Development-signed — `aps-environment` stays `development` and
-  CloudKit reads/writes the **Development** environment of the
-  container.
-- **TestFlight build** is Distribution-signed — Apple's signing flow
-  flips `aps-environment` to `production` and CloudKit reads/writes
-  the **Production** environment.
+| Aspect | Debug (local Xcode build) | Release (TestFlight / App Store) |
+| --- | --- | --- |
+| Bundle id | `cc.mnmlst.nakedpantree.dev` | `cc.mnmlst.nakedpantree` |
+| Display name | "Pantree Dev" | "Naked Pantree" |
+| iCloud container | `iCloud.cc.mnmlst.nakedpantree.dev` | `iCloud.cc.mnmlst.nakedpantree` |
+| Entitlements file | `NakedPantreeApp/Resources/NakedPantreeDev.entitlements` | `NakedPantreeApp/Resources/NakedPantree.entitlements` |
+| Signing | Development (Xcode automatic) — `aps-environment = development` | Distribution (App Store) — Apple flips `aps-environment` to `production` at archive time |
+| CloudKit environment | Development environment of the dev container | Production environment of the prod container |
 
-The two environments don't share data. A developer who installs the
-TestFlight build over their local dev build (or vice versa) will see
-the *other* environment's data appear after sync — that's expected,
-not a bug.
+Because the two installs use different bundle ids, the dev build and
+the TestFlight build can coexist on a device — installing one no
+longer replaces the other. The two CloudKit containers are fully
+isolated, so dev-only test data never bleeds into production records.
 
-Because both builds share the bundle id, **only one can be installed
-on a device at a time** — TestFlight install replaces the local dev
-build and vice versa. Side-by-side coexistence (separate bundle id +
-container for dev, e.g. `cc.mnmlst.nakedpantree.dev`) is tracked
-separately; see related issues in the post-Phase-7 backlog.
+> **Heads-up: this requires Apple Developer portal setup the repo
+> can't do for you.** Until the steps below are done, the dev build
+> will fail to sign / push notifications won't register / CloudKit
+> calls will return "container not found". The same gating pattern
+> Phase 7.1 had against the App Store Connect work in Phase 7.2.
+
+##### One-time portal work (per Apple ID with the team membership)
+
+1. <https://developer.apple.com/account/resources/identifiers/list> →
+   register a new App ID:
+   - Bundle ID (Explicit): `cc.mnmlst.nakedpantree.dev`
+   - Description: `Naked Pantree (Dev)` (or similar)
+   - Capabilities: enable **iCloud** (with CloudKit support) and
+     **Push Notifications** to mirror the production App ID.
+2. <https://developer.apple.com/account/resources/icloudcontainers/list>
+   → create a new iCloud container:
+   - Identifier: `iCloud.cc.mnmlst.nakedpantree.dev`
+   - Description: `Naked Pantree Dev`
+3. Back on the dev App ID's iCloud capability, **assign** the new
+   `iCloud.cc.mnmlst.nakedpantree.dev` container to it. Save.
+4. (Optional) push the dev container's schema once: open the CloudKit
+   Console for `iCloud.cc.mnmlst.nakedpantree.dev`, run the dev build
+   on a device once so Core Data + CloudKit auto-creates the schema
+   in Development, then promote that schema if you want a clean
+   reset surface for QA. Most of the time the auto-created Dev
+   schema is enough — see §5a.
+
+##### After the portal work is done
+
+```bash
+xcodegen generate
+# Open NakedPantree.xcodeproj, pick a real device, Cmd-R.
+```
+
+Xcode's automatic signing will fetch / regenerate a provisioning
+profile for `cc.mnmlst.nakedpantree.dev` against the new container,
+and "Pantree Dev" lands on the home screen alongside any existing
+"Naked Pantree" TestFlight install.
+
+> The icon hasn't been visually differentiated yet — they currently
+> share `AppIcon`. Display name + bundle id is enough to tell them
+> apart in Spotlight and the app switcher; a separate `AppIconDev`
+> asset catalog is a nice-to-have follow-up.
 
 ### Test
 

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -71,9 +71,7 @@ struct NakedPantreeApp: App {
                 item: CoreDataItemRepository(container: container),
                 photo: CoreDataItemPhotoRepository(container: container)
             )
-            remoteChangeMonitor = RemoteChangeMonitor(
-                coordinator: container.persistentStoreCoordinator
-            )
+            remoteChangeMonitor = RemoteChangeMonitor(container: container)
             accountStatusMonitor = AccountStatusMonitor(container: cloudKitContainer)
             householdSharing = CloudHouseholdSharingService(
                 container: container,

--- a/NakedPantreeApp/App/RemoteChangeMonitor.swift
+++ b/NakedPantreeApp/App/RemoteChangeMonitor.swift
@@ -1,28 +1,39 @@
 import CoreData
+import NakedPantreePersistence
 import SwiftUI
 
-/// Bumps `changeToken` whenever the persistence layer reports a remote
-/// change — local writes by another household member that CloudKit's
-/// mirror has imported, in Phase 2's same-account-sync world. Views read
-/// the token via `.task(id:)` and re-fetch when it ticks.
+/// Bumps `changeToken` whenever the persistence layer reports a
+/// non-self-emitted remote change — local writes by another household
+/// member that CloudKit's mirror has imported, in Phase 2's
+/// same-account-sync world. Views read the token via `.task(id:)` and
+/// re-fetch when it ticks.
 ///
 /// **Architectural note:** this lives in the app layer rather than behind
 /// a `NakedPantreeDomain` protocol. The monitor only consumes
-/// `NSPersistentStoreRemoteChange` posts off `NotificationCenter` — it
-/// never calls into `NSPersistentCloudKitContainer` itself, so the
+/// `NSPersistentStoreRemoteChange` posts off `NotificationCenter` plus
+/// `NSPersistentHistoryChangeRequest` against the container — it never
+/// calls into `NSPersistentCloudKitContainer` itself, so the
 /// "no app code talks to CloudKit container directly" rule in
 /// `AGENTS.md` §2 still holds. If a non-iOS surface (the future macOS
 /// CLI, an AppIntent extension) needs the same signal, lift the
 /// observer behind a Domain protocol then. Premature now.
 ///
-/// **Self-emission caveat:** Phase 2.1 enables
+/// **Self-emission filter (issue #28):** Phase 2.1 enables
 /// `NSPersistentStoreRemoteChangeNotificationPostOptionKey` on both
-/// stores, so a local `context.save()` also fires this notification.
-/// Form callbacks (`SidebarView` / `ItemsView` `onSave`) still trigger
-/// an explicit reload, which means a local edit reloads twice — once
-/// optimistically, once via the token. The double-fire is idempotent
-/// and the second pass is cheap; filtering self vs remote properly
-/// needs persistent-history-token bookkeeping (issue #28).
+/// stores, so a local `context.save()` also fires the notification.
+/// Phase 10.4 closes that double-fire: `performBackgroundTaskWithDefaults`
+/// stamps every background context with `transactionAuthor = "local"`,
+/// and after each remote-change post we fetch the persistent-history
+/// transactions since our last seen token. If every transaction has
+/// `author == "local"` we ignore the post; the form callback's
+/// optimistic reload already covered it. Anything else (CloudKit
+/// mirror imports leave `author` nil) bumps `changeToken`.
+///
+/// **Token persistence:** the last-seen `NSPersistentHistoryToken` is
+/// archived to `UserDefaults` so a process restart picks up where we
+/// left off. Without this, the first refresh after launch would refetch
+/// the entire history and treat every prior local save as a remote
+/// change.
 ///
 /// **Debounce:** notifications fan out — CloudKit fires per-store on
 /// save (private + shared) and per-transaction on initial sync. A
@@ -30,13 +41,13 @@ import SwiftUI
 /// each previously bumping `changeToken` and triggering SwiftUI's
 /// "onChange tried to update multiple times per frame" warning plus
 /// a thundering herd of `.task(id:)` cancellations on app launch.
-/// We coalesce into one bump per ~120ms quiet window.
+/// We coalesce into one history-fetch per ~120ms quiet window.
 @Observable
 @MainActor
 final class RemoteChangeMonitor {
     private(set) var changeToken = UUID()
 
-    /// `true` for the production initializer (real coordinator);
+    /// `true` for the production initializer (real container);
     /// `false` for the no-op preview/test initializer. Phase 8.2's
     /// deferred bootstrap consults this to skip the
     /// wait-for-first-tick race when there's no source of remote
@@ -55,27 +66,89 @@ final class RemoteChangeMonitor {
 
     /// Pending debounce timer. Each incoming notification cancels the
     /// previous timer and starts a new one — only the last
-    /// notification followed by ~120ms of quiet actually bumps the
-    /// token. Stays on the main actor; no deinit cleanup needed since
-    /// the task self-terminates after the sleep.
+    /// notification followed by ~120ms of quiet actually triggers a
+    /// history fetch. Stays on the main actor; no deinit cleanup
+    /// needed since the task self-terminates after the sleep.
     private var debounceTask: Task<Void, Never>?
+
+    /// Background context used to run `NSPersistentHistoryChangeRequest`.
+    /// History fetches must happen on a managed-object-context queue;
+    /// the view context would block the main thread and any background
+    /// context returned by `performBackgroundTask` is a fresh per-call
+    /// thing not worth re-creating each refresh. `nil` for the no-op
+    /// initializer. `nonisolated` so the no-op `init()` (which is
+    /// itself nonisolated) can write to it.
+    nonisolated private let historyContext: NSManagedObjectContext?
+
+    /// `UserDefaults` slot for the last-seen `NSPersistentHistoryToken`.
+    /// `nil` for the no-op initializer; injected for tests so they don't
+    /// pollute `.standard`. Mirrors the `NotificationSettings.defaults`
+    /// pattern, including its `nonisolated(unsafe)` trade-off (Swift 6
+    /// flags `UserDefaults?` as non-`Sendable`, but Apple ships
+    /// `UserDefaults` as documented thread-safe).
+    nonisolated(unsafe) private let defaults: UserDefaults?
+
+    /// Key under which the archived `NSPersistentHistoryToken` lives in
+    /// `UserDefaults`. Single token, app-wide — both stores feed the
+    /// same observer, history is per-coordinator. Test fixtures should
+    /// pass a unique suite name to keep parallel test runs from
+    /// stomping on each other.
+    ///
+    /// `nonisolated` so the test target can read this constant from a
+    /// non-MainActor context (Swift 6 otherwise treats statics on a
+    /// `@MainActor` type as MainActor-isolated).
+    nonisolated static let historyTokenDefaultsKey = "persistence.lastHistoryToken"
+
+    /// Last-seen history token in memory. Persisted to `defaults`
+    /// after each successful refresh. Read on init from defaults so
+    /// the first post-launch fetch only sees transactions newer than
+    /// the previous run's last refresh.
+    private var lastHistoryToken: NSPersistentHistoryToken?
 
     /// No-op monitor for previews and tests. Never bumps `changeToken`.
     /// `nonisolated` so the `@Entry` environment default value (which
     /// must run in a non-isolated context) can construct one.
     nonisolated init() {
         self.isObserving = false
+        self.historyContext = nil
+        self.defaults = nil
     }
 
-    init(coordinator: NSPersistentStoreCoordinator) {
+    /// Production initializer. Subscribes to `NSPersistentStoreRemoteChange`
+    /// for the container's coordinator and runs a persistent-history
+    /// filter on every notification. `defaults` is injected so tests
+    /// can supply a fresh suite per run; production passes
+    /// `.standard`.
+    convenience init(container: NSPersistentContainer) {
+        self.init(container: container, defaults: .standard)
+    }
+
+    init(container: NSPersistentContainer, defaults: UserDefaults) {
         self.isObserving = true
+        self.defaults = defaults
+
+        let context = container.newBackgroundContext()
+        context.transactionAuthor = CoreDataStack.localTransactionAuthor
+        self.historyContext = context
+
+        // Restore the last-seen token from the previous launch so
+        // the first refresh doesn't replay every prior local save.
+        if let data = defaults.data(forKey: Self.historyTokenDefaultsKey),
+            let token = try? NSKeyedUnarchiver.unarchivedObject(
+                ofClass: NSPersistentHistoryToken.self,
+                from: data
+            )
+        {
+            self.lastHistoryToken = token
+        }
+
         let stream = NotificationCenter.default.notifications(
             named: .NSPersistentStoreRemoteChange,
-            object: coordinator
+            object: container.persistentStoreCoordinator
         )
         task = Task { @MainActor [weak self] in
             for await _ in stream {
-                self?.scheduleBump()
+                self?.scheduleRefresh()
             }
         }
     }
@@ -84,16 +157,154 @@ final class RemoteChangeMonitor {
         task?.cancel()
     }
 
-    private func scheduleBump() {
+    private func scheduleRefresh() {
         debounceTask?.cancel()
         debounceTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(for: .milliseconds(120))
-                self?.changeToken = UUID()
+                await self?.refresh()
             } catch {
                 // Cancelled by a newer notification — that newer
-                // notification owns the next bump.
+                // notification owns the next refresh.
             }
+        }
+    }
+
+    /// Fetch persistent-history transactions newer than `lastHistoryToken`,
+    /// filter out our own (`author == "local"`), and only bump
+    /// `changeToken` if anything else remains. Persists the new history
+    /// token regardless so we don't reprocess local-only windows on the
+    /// next pass.
+    private func refresh() async {
+        guard let context = historyContext else { return }
+        // Wrap the prior token in a `Sendable` box before crossing the
+        // MainActor → nonisolated boundary. `NSPersistentHistoryToken`
+        // is documented-immutable but isn't annotated `Sendable` in
+        // the SDK, so we vouch for it via `@unchecked` — same trade-off
+        // `HistoryFetchOutcome` makes for the return trip.
+        let previousToken = SendableHistoryToken(token: lastHistoryToken)
+
+        // The continuation runs on the context's queue (not MainActor).
+        // Hop back to MainActor through `await` — Swift treats
+        // `let result = await ...` as a clean MainActor-isolated
+        // value, so the subsequent `lastHistoryToken = newToken`
+        // write is race-free.
+        let outcome: HistoryFetchOutcome = await Self.fetchHistory(
+            after: previousToken,
+            in: context
+        )
+
+        if outcome.failed { return }
+        if let newToken = outcome.newToken {
+            lastHistoryToken = newToken
+            persist(token: newToken)
+        }
+        if outcome.hasNonLocal {
+            changeToken = UUID()
+        }
+    }
+
+    /// Result of one history-fetch pass. A struct (rather than enum
+    /// with associated values) keeps `pattern_matching_keywords` and
+    /// `UseLetInEveryBoundCaseVariable` from disagreeing about how to
+    /// destructure two `let` bindings — both linters are happy with a
+    /// plain property read.
+    ///
+    /// **`@unchecked Sendable` rationale:** `NSPersistentHistoryToken`
+    /// is documented-immutable but not annotated `Sendable` in the SDK
+    /// (FB-tracked). It's safe to send across the
+    /// `Core Data context queue → MainActor` hop because we never
+    /// mutate it — Apple's `CoreDataCloudKit` sample does the same
+    /// thing. Same trade-off `CoreDataStack.model` makes for
+    /// `NSManagedObjectModel`.
+    /// `Sendable` wrapper around the input token to `fetchHistory`. See
+    /// `HistoryFetchOutcome` for the same `@unchecked Sendable` rationale.
+    private struct SendableHistoryToken: @unchecked Sendable {
+        let token: NSPersistentHistoryToken?
+    }
+
+    private struct HistoryFetchOutcome: @unchecked Sendable {
+        var newToken: NSPersistentHistoryToken?
+        var hasNonLocal: Bool
+        var failed: Bool
+
+        static let failure = HistoryFetchOutcome(
+            newToken: nil,
+            hasNonLocal: false,
+            failed: true
+        )
+
+        static func success(
+            newToken: NSPersistentHistoryToken?,
+            hasNonLocal: Bool
+        ) -> HistoryFetchOutcome {
+            HistoryFetchOutcome(
+                newToken: newToken,
+                hasNonLocal: hasNonLocal,
+                failed: false
+            )
+        }
+    }
+
+    /// Runs `NSPersistentHistoryChangeRequest.fetchHistory(after:)` on
+    /// the supplied context's queue and returns the outcome.
+    ///
+    /// **Why `author != "local"` rather than a positive match for an
+    /// expected remote author:** CloudKit-mirrored imports leave
+    /// `transactionAuthor` as `nil` (Apple's sample code does the same
+    /// negative filter). Anything we didn't stamp ourselves is, by
+    /// definition, not us.
+    ///
+    /// `nonisolated` so the continuation closure can call into it from
+    /// the Core Data queue without crossing the MainActor boundary.
+    nonisolated private static func fetchHistory(
+        after token: SendableHistoryToken,
+        in context: NSManagedObjectContext
+    ) async -> HistoryFetchOutcome {
+        await withCheckedContinuation { continuation in
+            context.perform {
+                let request = NSPersistentHistoryChangeRequest.fetchHistory(after: token.token)
+                // `.transactionsAndChanges` is what makes
+                // `result.result as? [NSPersistentHistoryTransaction]`
+                // non-nil — the default result type returns an opaque
+                // value with a nil `result` and the filter would
+                // silently match nothing.
+                request.resultType = .transactionsAndChanges
+
+                do {
+                    let executed =
+                        try context.execute(request) as? NSPersistentHistoryResult
+                    let transactions =
+                        (executed?.result as? [NSPersistentHistoryTransaction]) ?? []
+                    let newestToken = transactions.last?.token
+                    let hasNonLocal = transactions.contains { transaction in
+                        transaction.author != CoreDataStack.localTransactionAuthor
+                    }
+                    continuation.resume(
+                        returning: .success(
+                            newToken: newestToken,
+                            hasNonLocal: hasNonLocal
+                        )
+                    )
+                } catch {
+                    continuation.resume(returning: .failure)
+                }
+            }
+        }
+    }
+
+    private func persist(token: NSPersistentHistoryToken) {
+        guard let defaults else { return }
+        do {
+            let data = try NSKeyedArchiver.archivedData(
+                withRootObject: token,
+                requiringSecureCoding: true
+            )
+            defaults.set(data, forKey: Self.historyTokenDefaultsKey)
+        } catch {
+            // Token persistence is best-effort; on the next launch we
+            // refetch from epoch and the worst case is one redundant
+            // reload. Logging would just spam.
         }
     }
 }

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -1,9 +1,12 @@
+import NakedPantreeDomain
 import SwiftUI
 
-/// User-level Settings screen. Phase 9.3 ships exactly one knob — the
-/// time of day expiry reminders fire — so the form is intentionally
-/// short. Future preferences (per-item lead time, multiple reminders
-/// per day, per-household time) hang off the same screen later.
+/// User-level Settings screen. Phase 9.3 introduced the reminder-time
+/// picker; Phase 10.1 (issue #60) folds household management in next to
+/// it, retiring the sidebar's "Share Household" toolbar item. The form
+/// stays intentionally short — future preferences (per-item lead time,
+/// rename household, member list, leave/transfer) hang off the same
+/// screen later.
 ///
 /// Reads the live `NotificationSettings` instance from the environment.
 /// `@Bindable` lets the picker mutate hour/minute directly; the
@@ -20,24 +23,23 @@ import SwiftUI
 /// (§10 checklist), with a single light brand-consistent line.
 struct SettingsView: View {
     @Environment(\.notificationSettings) private var settings
+    @Environment(\.repositories) private var repositories
+    @Environment(\.householdSharing) private var householdSharing
     @Environment(\.dismiss) private var dismiss
+
+    /// Loaded asynchronously in `.task` from the household repository.
+    /// `nil` while the load is in flight or if it failed; the row shows
+    /// a neutral placeholder in that case rather than blocking the
+    /// whole screen — the share action doesn't depend on the name.
+    @State private var household: Household?
+    @State private var isPresentingShareSheet = false
 
     var body: some View {
         @Bindable var settings = settings
         NavigationStack {
             Form {
-                Section {
-                    DatePicker(
-                        "Reminder time",
-                        selection: timeOfDayBinding(for: settings),
-                        displayedComponents: .hourAndMinute
-                    )
-                    .accessibilityIdentifier("settings.notificationTime.picker")
-                } header: {
-                    Text("Expiry reminders")
-                } footer: {
-                    Text("We'll remind you 3 days before something expires.")
-                }
+                householdSection
+                expiryRemindersSection
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -46,6 +48,64 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
+            .sheet(isPresented: $isPresentingShareSheet) {
+                if let household, let sharing = householdSharing {
+                    CloudSharingControllerView(
+                        householdID: household.id,
+                        sharing: sharing,
+                        onCompletion: { isPresentingShareSheet = false }
+                    )
+                    .ignoresSafeArea()
+                }
+            }
+            .task { await loadHousehold() }
+        }
+    }
+
+    /// Household section — name (read-only) plus Share Household row.
+    /// Structured as a single `Section` so future rows (rename, member
+    /// list, leave/transfer; out of scope for #60) slot in cleanly.
+    @ViewBuilder
+    private var householdSection: some View {
+        Section {
+            LabeledContent("Name") {
+                Text(household?.name ?? "—")
+                    .foregroundStyle(.secondary)
+            }
+            .accessibilityIdentifier("settings.household.name")
+
+            // Hidden in previews / tests / snapshot mode where the
+            // sharing service is nil — see CloudHouseholdSharingService.
+            // The name row above always renders so the section isn't
+            // empty in those contexts.
+            if householdSharing != nil {
+                Button {
+                    isPresentingShareSheet = true
+                } label: {
+                    Label("Share Household", systemImage: "person.crop.circle.badge.plus")
+                }
+                .accessibilityIdentifier("settings.shareHousehold")
+                .disabled(household == nil)
+            }
+        } header: {
+            Text("Household")
+        }
+    }
+
+    @ViewBuilder
+    private var expiryRemindersSection: some View {
+        @Bindable var settings = settings
+        Section {
+            DatePicker(
+                "Reminder time",
+                selection: timeOfDayBinding(for: settings),
+                displayedComponents: .hourAndMinute
+            )
+            .accessibilityIdentifier("settings.notificationTime.picker")
+        } header: {
+            Text("Expiry reminders")
+        } footer: {
+            Text("We'll remind you 3 days before something expires.")
         }
     }
 
@@ -71,9 +131,23 @@ struct SettingsView: View {
             }
         )
     }
+
+    /// Mirrors Sidebar's load pattern: swallow errors silently for now
+    /// — the screen's other section (reminder time) keeps working, and
+    /// the household row simply stays at its placeholder. A real error
+    /// banner is a Phase 10 polish item once household mutations
+    /// (rename, leave) need to surface failures.
+    private func loadHousehold() async {
+        do {
+            household = try await repositories.household.currentHousehold()
+        } catch {
+            household = nil
+        }
+    }
 }
 
 #Preview("Default 9:00 AM") {
     SettingsView()
         .environment(\.notificationSettings, NotificationSettings())
+        .environment(\.repositories, .makePreview())
 }

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -7,14 +7,12 @@ struct SidebarView: View {
     @Binding var selection: SidebarSelection?
     @Environment(\.repositories) private var repositories
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
-    @Environment(\.householdSharing) private var householdSharing
 
     @State private var locations: [Location] = []
     @State private var householdID: Household.ID?
     @State private var loadError: Error?
     @State private var formMode: LocationFormView.Mode?
     @State private var pendingDelete: Location?
-    @State private var isPresentingShareSheet = false
     @State private var isPresentingSettings = false
 
     var body: some View {
@@ -70,26 +68,13 @@ struct SidebarView: View {
                 }
                 .disabled(householdID == nil)
             }
-            // Share Household lives next to the New Location action.
-            // Hidden in previews / tests / snapshot mode where the
-            // sharing service is nil — see CloudHouseholdSharingService.
-            if householdSharing != nil {
-                ToolbarItem(placement: .secondaryAction) {
-                    Button {
-                        isPresentingShareSheet = true
-                    } label: {
-                        Label("Share Household", systemImage: "person.crop.circle.badge.plus")
-                    }
-                    .accessibilityIdentifier("sidebar.shareHousehold")
-                    .disabled(householdID == nil)
-                }
-            }
-            // Phase 9.3: Settings entry point. Lives in the secondary
-            // toolbar slot next to Share Household so the primary "+"
-            // action stays the most prominent. Always available — even
-            // in previews / tests, where the no-op `NotificationSettings`
-            // default lets the screen render without a real
-            // UserDefaults backing.
+            // Phase 9.3 introduced the Settings entry point in the
+            // secondary toolbar slot. Phase 10.1 (#60) folded household
+            // sharing into Settings, so this is now the sidebar's only
+            // secondary action. Always available — even in previews /
+            // tests, where the no-op `NotificationSettings` default
+            // lets the screen render without a real UserDefaults
+            // backing.
             ToolbarItem(placement: .secondaryAction) {
                 Button {
                     isPresentingSettings = true
@@ -102,16 +87,6 @@ struct SidebarView: View {
         .sheet(item: $formMode) { mode in
             LocationFormView(mode: mode) {
                 Task { await reload() }
-            }
-        }
-        .sheet(isPresented: $isPresentingShareSheet) {
-            if let householdID, let sharing = householdSharing {
-                CloudSharingControllerView(
-                    householdID: householdID,
-                    sharing: sharing,
-                    onCompletion: { isPresentingShareSheet = false }
-                )
-                .ignoresSafeArea()
             }
         }
         .sheet(isPresented: $isPresentingSettings) {

--- a/NakedPantreeApp/Resources/Info.plist
+++ b/NakedPantreeApp/Resources/Info.plist
@@ -10,6 +10,8 @@
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
+    <key>CFBundleDisplayName</key>
+    <string>$(PRODUCT_NAME)</string>
     <key>CFBundleName</key>
     <string>$(PRODUCT_NAME)</string>
     <key>CFBundlePackageType</key>

--- a/NakedPantreeApp/Resources/NakedPantreeDev.entitlements
+++ b/NakedPantreeApp/Resources/NakedPantreeDev.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.cc.mnmlst.nakedpantree.dev</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
+    <key>com.apple.developer.ubiquity-container-identifiers</key>
+    <array/>
+</dict>
+</plist>

--- a/NakedPantreeTests/RemoteChangeMonitorTests.swift
+++ b/NakedPantreeTests/RemoteChangeMonitorTests.swift
@@ -7,71 +7,139 @@ import Testing
 @Suite("RemoteChangeMonitor")
 @MainActor
 struct RemoteChangeMonitorTests {
-    @Test("changeToken bumps when an NSPersistentStoreRemoteChange is posted")
-    func changeTokenBumpsOnRemoteChangeNotification() async throws {
+    @Test("A non-local transaction (author != \"local\") bumps changeToken")
+    func nonLocalTransactionBumpsChangeToken() async throws {
         let container = CoreDataStack.inMemoryContainer()
-        let monitor = RemoteChangeMonitor(coordinator: container.persistentStoreCoordinator)
+        let defaults = makeIsolatedDefaults()
+        let monitor = RemoteChangeMonitor(container: container, defaults: defaults)
         let initial = monitor.changeToken
 
-        NotificationCenter.default.post(
-            name: .NSPersistentStoreRemoteChange,
-            object: container.persistentStoreCoordinator
-        )
+        // Simulate a CloudKit-mirrored import by saving on a context
+        // whose `transactionAuthor` is left nil — that's what the
+        // mirror does. The remote-change notification posts on save.
+        try await save(in: container, transactionAuthor: nil) { context in
+            insertHousehold(name: "Remote", into: context)
+        }
 
-        // Yield to the observer Task long enough for it to deliver the
-        // notification and hop to MainActor — a few runloop turns.
         try await waitFor(
             condition: { monitor.changeToken != initial },
-            timeoutNanos: 1_000_000_000
+            timeoutNanos: 2_000_000_000
         )
         #expect(monitor.changeToken != initial)
     }
 
-    @Test("changeToken ignores notifications scoped to a different coordinator")
-    func changeTokenIgnoresUnrelatedCoordinators() async throws {
-        let containerA = CoreDataStack.inMemoryContainer(name: "A")
-        let containerB = CoreDataStack.inMemoryContainer(name: "B")
-        let monitor = RemoteChangeMonitor(coordinator: containerA.persistentStoreCoordinator)
+    @Test("A local-author save does NOT bump changeToken")
+    func localAuthorSaveDoesNotBumpChangeToken() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let defaults = makeIsolatedDefaults()
+        let monitor = RemoteChangeMonitor(container: container, defaults: defaults)
         let initial = monitor.changeToken
 
-        NotificationCenter.default.post(
-            name: .NSPersistentStoreRemoteChange,
-            object: containerB.persistentStoreCoordinator
-        )
+        // Mirror what `performBackgroundTaskWithDefaults` does — stamp
+        // the context with `"local"` before saving. Phase 10.4 makes
+        // every production write land here, so the observer should
+        // ignore the resulting remote-change notification.
+        try await save(
+            in: container,
+            transactionAuthor: CoreDataStack.localTransactionAuthor
+        ) { context in
+            insertHousehold(name: "Local", into: context)
+        }
 
-        // Give the observer a chance to be wrong; the token must not move.
-        try await Task.sleep(nanoseconds: 250_000_000)
+        // Wait past the debounce window; if the token was going to
+        // bump, it would have. Verify it didn't.
+        try await Task.sleep(nanoseconds: 500_000_000)
         #expect(monitor.changeToken == initial)
     }
 
-    @Test("A flurry of notifications coalesces into a single token bump")
-    func flurryCoalescesIntoSingleBump() async throws {
-        let container = CoreDataStack.inMemoryContainer()
-        let monitor = RemoteChangeMonitor(coordinator: container.persistentStoreCoordinator)
+    @Test("Notifications scoped to a different coordinator are ignored")
+    func changeTokenIgnoresUnrelatedCoordinators() async throws {
+        let containerA = CoreDataStack.inMemoryContainer(name: "A")
+        let containerB = CoreDataStack.inMemoryContainer(name: "B")
+        let defaults = makeIsolatedDefaults()
+        let monitor = RemoteChangeMonitor(container: containerA, defaults: defaults)
         let initial = monitor.changeToken
 
-        // Fire five notifications back-to-back. Pre-debounce this would
-        // bump the token five times in the same frame and trip SwiftUI's
-        // "onChange tried to update multiple times per frame" warning.
-        for _ in 0..<5 {
-            NotificationCenter.default.post(
-                name: .NSPersistentStoreRemoteChange,
-                object: container.persistentStoreCoordinator
-            )
+        // A non-local save on B fires NSPersistentStoreRemoteChange
+        // scoped to B's coordinator. The monitor subscribed to A's
+        // coordinator must not receive it.
+        try await save(in: containerB, transactionAuthor: nil) { context in
+            insertHousehold(name: "OtherStore", into: context)
         }
 
-        // Wait past the debounce window for the first bump to land.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(monitor.changeToken == initial)
+    }
+
+    @Test("A flurry of non-local saves coalesces into a single token bump")
+    func flurryCoalescesIntoSingleBump() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let defaults = makeIsolatedDefaults()
+        let monitor = RemoteChangeMonitor(container: container, defaults: defaults)
+        let initial = monitor.changeToken
+
+        // Five back-to-back non-local saves. Pre-debounce this would
+        // bump the token five times in the same frame and trip
+        // SwiftUI's "onChange tried to update multiple times per
+        // frame" warning.
+        for index in 0..<5 {
+            try await save(in: container, transactionAuthor: nil) { context in
+                insertHousehold(name: "Remote\(index)", into: context)
+            }
+        }
+
         try await waitFor(
             condition: { monitor.changeToken != initial },
-            timeoutNanos: 1_000_000_000
+            timeoutNanos: 2_000_000_000
         )
         let firstBump = monitor.changeToken
         #expect(firstBump != initial)
 
-        // No further notifications — token must remain stable through
-        // another debounce window.
-        try await Task.sleep(nanoseconds: 250_000_000)
+        // Quiet window — no further notifications, no further bumps.
+        try await Task.sleep(nanoseconds: 500_000_000)
         #expect(monitor.changeToken == firstBump)
+    }
+
+    @Test("History token persists across monitor instances (simulated restart)")
+    func historyTokenPersistsAcrossRestart() async throws {
+        let container = CoreDataStack.inMemoryContainer()
+        let defaults = makeIsolatedDefaults()
+
+        // First "process": create a monitor, drive a non-local save,
+        // wait for the bump, then tear it down. The persisted token
+        // captures the post-save state.
+        do {
+            let monitor = RemoteChangeMonitor(container: container, defaults: defaults)
+            let initial = monitor.changeToken
+            try await save(in: container, transactionAuthor: nil) { context in
+                insertHousehold(name: "FirstRun", into: context)
+            }
+            try await waitFor(
+                condition: { monitor.changeToken != initial },
+                timeoutNanos: 2_000_000_000
+            )
+            #expect(monitor.changeToken != initial)
+        }
+
+        // The persisted token must be present.
+        let persisted = defaults.data(forKey: RemoteChangeMonitor.historyTokenDefaultsKey)
+        #expect(persisted != nil)
+
+        // Second "process": new monitor over the same defaults. A
+        // local-author save now should NOT bump — proving the new
+        // monitor read the persisted token (otherwise it would refetch
+        // history from epoch, see the earlier non-local save, and
+        // bump on the very first refresh).
+        let secondMonitor = RemoteChangeMonitor(container: container, defaults: defaults)
+        let secondInitial = secondMonitor.changeToken
+        try await save(
+            in: container,
+            transactionAuthor: CoreDataStack.localTransactionAuthor
+        ) { context in
+            insertHousehold(name: "SecondRunLocal", into: context)
+        }
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(secondMonitor.changeToken == secondInitial)
     }
 
     @Test("No-op monitor never bumps")
@@ -98,8 +166,67 @@ struct RemoteChangeMonitorTests {
         #expect(noOp.isObserving == false)
 
         let container = CoreDataStack.inMemoryContainer()
-        let observing = RemoteChangeMonitor(coordinator: container.persistentStoreCoordinator)
+        let defaults = makeIsolatedDefaults()
+        let observing = RemoteChangeMonitor(container: container, defaults: defaults)
         #expect(observing.isObserving == true)
+    }
+
+    // MARK: - Helpers
+
+    /// Fresh `UserDefaults` per test so parallel test runs and the
+    /// "simulated restart" test don't stomp on each other's persisted
+    /// tokens. Mirrors the per-test isolation `NotificationSettings`
+    /// tests use.
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "RemoteChangeMonitorTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create UserDefaults suite \(suiteName)")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    /// Inserts a HouseholdEntity row and saves on a background context
+    /// whose `transactionAuthor` we control. Returning before the
+    /// `NSPersistentStoreRemoteChange` notification has been posted is
+    /// fine — the monitor's debounce gives us a window to observe.
+    nonisolated private func save(
+        in container: NSPersistentContainer,
+        transactionAuthor: String?,
+        _ block: @Sendable @escaping (NSManagedObjectContext) -> Void
+    ) async throws {
+        try await container.performBackgroundTask { context in
+            context.mergePolicy = CoreDataStack.defaultMergePolicy
+            context.transactionAuthor = transactionAuthor
+            block(context)
+            try context.save()
+        }
+    }
+
+    /// Inserts a `HouseholdEntity` with the minimum required attributes
+    /// — using the model directly, no repository dependency — so a
+    /// `context.save()` on this context produces exactly one persistent-
+    /// history transaction.
+    nonisolated private static func insertHousehold(
+        name: String,
+        into context: NSManagedObjectContext
+    ) {
+        let row = NSEntityDescription.insertNewObject(
+            forEntityName: "HouseholdEntity",
+            into: context
+        )
+        row.setValue(UUID(), forKey: "id")
+        row.setValue(name, forKey: "name")
+        row.setValue(Date(), forKey: "createdAt")
+    }
+
+    /// Static-method shim so call sites read `insertHousehold(...)` and
+    /// not `RemoteChangeMonitorTests.insertHousehold(...)`.
+    nonisolated private func insertHousehold(
+        name: String,
+        into context: NSManagedObjectContext
+    ) {
+        Self.insertHousehold(name: name, into: context)
     }
 
     private func waitFor(

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
@@ -32,6 +32,16 @@ public enum CoreDataStack {
     /// the developer portal (see issue #23).
     public static let cloudKitContainerIdentifier = "iCloud.cc.mnmlst.nakedpantree"
 
+    /// Author label stamped onto every background context vended by
+    /// `performBackgroundTaskWithDefaults`. The Phase 2.2 remote-change
+    /// observer (issue #28) uses this to skip self-emitted notifications:
+    /// transactions whose `author == "local"` were our own save and the
+    /// form callback already triggered an explicit reload, so the token
+    /// should only bump when a transaction with a different author
+    /// (CloudKit-mirrored imports leave `author` nil) shows up in
+    /// persistent history.
+    public static let localTransactionAuthor = "local"
+
     /// Creates a disk-backed local-only container — SQLite at the OS-default
     /// location (Application Support / `<name>.sqlite`). Used by tests and
     /// any future tool that needs Core Data without iCloud.
@@ -124,14 +134,30 @@ public enum CoreDataStack {
         }
     }
 
-    /// Creates an in-memory container — the SQLite store is bound to
+    /// Creates an ephemeral test container — the SQLite store is bound to
     /// `/dev/null`, so nothing reaches disk. Used for tests and SwiftUI
     /// previews. Each call returns a fresh container with an empty store.
+    ///
+    /// **Why SQLite at `/dev/null` instead of `NSInMemoryStoreType`:**
+    /// `NSPersistentHistoryChangeRequest` (issue #28's
+    /// `RemoteChangeMonitor` filtering) is a no-op against in-memory
+    /// stores — it returns nil and tests pass spuriously. The
+    /// `/dev/null` SQLite trick is Apple's documented test recipe and
+    /// has the same "nothing reaches disk" semantics. History tracking
+    /// is enabled here so `RemoteChangeMonitorTests` can drive the
+    /// real history-fetch code path without needing a CloudKit
+    /// container.
     public static func inMemoryContainer(name: String = "NakedPantree") -> NSPersistentContainer {
         let container = NSPersistentContainer(name: name, managedObjectModel: model)
         let description = NSPersistentStoreDescription()
-        description.type = NSInMemoryStoreType
+        description.type = NSSQLiteStoreType
+        description.url = URL(fileURLWithPath: "/dev/null")
         description.shouldAddStoreAsynchronously = false
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        description.setOption(
+            true as NSNumber,
+            forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey
+        )
         container.persistentStoreDescriptions = [description]
         var loadError: Error?
         container.loadPersistentStores { _, error in loadError = error }

--- a/Packages/Core/Sources/NakedPantreePersistence/NSPersistentContainer+MergePolicy.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/NSPersistentContainer+MergePolicy.swift
@@ -7,11 +7,21 @@ extension NSPersistentContainer {
     /// before the caller's block runs, which matters once
     /// `NSPersistentCloudKitContainer`'s mirror starts saving to the same
     /// store concurrently with local writes.
+    ///
+    /// **Self-emission filtering (issue #28):** every background context is
+    /// also stamped with `transactionAuthor = "local"`. The Phase 2.2
+    /// `RemoteChangeMonitor` reads persistent history after each
+    /// `NSPersistentStoreRemoteChange` notification and filters out
+    /// transactions whose author is `"local"` — that's how it tells a
+    /// local save (which should not trigger a reload, since the form
+    /// callback already kicked one off) apart from a CloudKit-mirrored
+    /// import (which has a nil author and should reload).
     func performBackgroundTaskWithDefaults<T: Sendable>(
         _ block: @Sendable @escaping (NSManagedObjectContext) throws -> T
     ) async throws -> T {
         try await performBackgroundTask { context in
             context.mergePolicy = CoreDataStack.defaultMergePolicy
+            context.transactionAuthor = CoreDataStack.localTransactionAuthor
             return try block(context)
         }
     }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -572,10 +572,18 @@ run dev + TestFlight side-by-side.
 
 | # | Title | Issue | Status |
 | --- | --- | --- | --- |
-| 10.1 | Settings screen with household management | [#60](https://github.com/ellisandy/NakedPantree/issues/60) | ⏳ Pending (depends on 8.2 landing first) |
-| 10.2 | Brand color & personality pass — research → implementation | [#52](https://github.com/ellisandy/NakedPantree/issues/52) | ⏳ Pending |
-| 10.3 | Side-by-side dev + TestFlight install | [#68](https://github.com/ellisandy/NakedPantree/issues/68) | ⏳ Pending |
-| 10.4 | Filter self-emission from `RemoteChangeMonitor` via persistent-history tokens | [#28](https://github.com/ellisandy/NakedPantree/issues/28) | ⏳ Pending |
+| 10.1 | Settings screen with household management | [#60](https://github.com/ellisandy/NakedPantree/issues/60) | 🟡 In review |
+| 10.2 | Brand color & personality pass — **research only** (implementation deferred to 10.5) | [#52](https://github.com/ellisandy/NakedPantree/issues/52) | 🟡 In review |
+| 10.3 | Side-by-side dev + TestFlight install | [#68](https://github.com/ellisandy/NakedPantree/issues/68) | 🟡 In review |
+| 10.4 | Filter self-emission from `RemoteChangeMonitor` via persistent-history tokens | [#28](https://github.com/ellisandy/NakedPantree/issues/28) | 🟡 In review |
+| 10.5 | Brand-pass implementation (10 follow-up issues spawned from 10.2's research) | _to be filed from `docs/BRAND_PASS_PROPOSAL.md`_ | ⏳ Pending |
+
+> Phase 10 ran the parallel-worktrees workflow with **zero shared
+> files** between the four sub-milestones — no integration commit
+> needed (unlike Phase 9's `NotificationScheduler` quarantine). 10.2
+> deliberately ships the research proposal only; the 10 prioritized
+> implementation tasks listed in `docs/BRAND_PASS_PROPOSAL.md` get
+> filed as follow-up issues and tracked under 10.5.
 
 ---
 

--- a/docs/BRAND_PASS_PROPOSAL.md
+++ b/docs/BRAND_PASS_PROPOSAL.md
@@ -1,0 +1,432 @@
+# Brand Pass Proposal — Phase 10.2 research
+
+> Companion to `DESIGN_GUIDELINES.md` §6 (Color). This is a **proposal** —
+> the deliverable for issue #52. Implementation lands in Phase 10.5
+> follow-ups; the prioritized list at the bottom of this doc seeds those
+> issues.
+
+---
+
+## 1. What we have today
+
+- **Source of truth:** `assets/brand/colors.json` defines the six brand
+  hexes with role + usage notes. `DESIGN_GUIDELINES.md` §6 mirrors it.
+- **Swift API:** `NakedPantreeApp/DesignSystem/Color+Brand.swift` exposes
+  `Color.brandForestGreen`, `Color.brandWarmCream`, `Color.brandSoftBrown`,
+  `Color.brandCoolBlue`, `Color.brandMutedOrange`, `Color.brandSoftRed`
+  as flat sRGB hex constants, plus `ShapeStyle` mirrors so they work
+  with `.foregroundStyle(...)` / `.tint(...)`.
+- **Asset Catalog:** `AccentColor.colorset` is wired to Forest Green
+  (`#2F5D50`). No other branded colorsets exist.
+- **Current usage:** only `LaunchView` and `AccountStatusBanner` consume
+  brand tokens. Everywhere else (`RootView`, `SidebarView`, `ItemsView`,
+  `ItemDetailView`, `ItemFormView`, `SettingsView`, smart-list views)
+  uses default SwiftUI styling.
+
+So: the **primitive** layer exists, dark mode does not, no surface other
+than launch reflects the brand, and there is no semantic / role-named
+layer above the primitives.
+
+---
+
+## 2. Final color tokens + naming (recommended)
+
+### Two-tier scheme
+
+The primitive layer is what `Color+Brand.swift` already exposes. Keep it.
+Add a **semantic role layer** on top — that is what views will consume.
+The two-tier shape exists to enforce the §6 usage rules through naming:
+"Cool Blue is reserved for cold storage" becomes hard to violate when the
+type-checked name views see is `Color.coldStorage`, not `Color.brandCoolBlue`.
+
+| Tier | Purpose | Examples |
+| --- | --- | --- |
+| **Primitive** | Raw brand hexes. Mirrors `colors.json`. Used only by the semantic layer and snapshot/preview tooling. | `brandForestGreen`, `brandWarmCream`, `brandSoftBrown`, `brandCoolBlue`, `brandMutedOrange`, `brandSoftRed` |
+| **Semantic / role** | What views call. Resolves to a primitive (or an Asset-Catalog colorset that interpolates between light/dark). | see table below |
+
+### Proposed semantic tokens
+
+| Semantic name | Light resolves to | Role |
+| --- | --- | --- |
+| `surface` | `brandWarmCream` `#F4F1EC` | App canvas background |
+| `surfaceElevated` | `#FFFFFF` | Sheets, modals over `surface` |
+| `primary` | `brandForestGreen` `#2F5D50` | Primary brand, hero, key CTAs |
+| `primaryText` | `brandForestGreen` `#2F5D50` | Branded headings, wordmark |
+| `onPrimary` | `brandWarmCream` `#F4F1EC` | Text/iconography on `primary` fills |
+| `secondary` | `brandSoftBrown` `#8B6F47` | Secondary accents, dividers |
+| `pantryCategory` | `brandSoftBrown` `#8B6F47` | Pantry / dry-goods icon tint |
+| `coldStorage` | `brandCoolBlue` `#4A90E2` | Fridge / freezer icon tint |
+| `expiringSoon` | `#9A6622` (deep amber, see §6) | Expiring-soon badge text/icon on cream |
+| `expiringSoonFill` | `#FCEAD0` (cream-orange tint) | Expiring-soon badge background |
+| `expired` | `#A93030` (deep red, see §6) | Expired/destructive text/icon on cream |
+| `expiredFill` | `#F8E0E0` (cream-red tint) | Expired badge background |
+| `divider` | `brandSoftBrown` at 20 % opacity | Hairlines |
+
+The `expiringSoon` / `expired` text tokens are **not** the raw brand
+hexes — `brandMutedOrange` and `brandSoftRed` fail WCAG AA against
+`brandWarmCream` at body sizes (1.83 : 1 and 3.89 : 1). The raw hexes
+remain correct as **status fills / chip backgrounds**, paired with a
+deeper text color. See §6 for the full contrast table.
+
+### File shape (no Swift edits in this PR — for Phase 10.5)
+
+```
+NakedPantreeApp/DesignSystem/
+    Color+Brand.swift          # existing — primitives stay
+    Color+Semantic.swift       # NEW — role tokens, light resolution
+    Theme.swift                # NEW — see §3 environment hook (optional)
+NakedPantreeApp/Resources/Assets.xcassets/Brand/
+    BrandForestGreen.colorset  # NEW — light + dark + AnyAppearance HC
+    BrandWarmCream.colorset
+    BrandSoftBrown.colorset
+    BrandCoolBlue.colorset
+    BrandMutedOrange.colorset
+    BrandSoftRed.colorset
+```
+
+Primitives migrate from inline `Color(brandHex:)` to
+`Color("BrandForestGreen", bundle: .main)` so the system resolves
+light / dark / high-contrast at runtime. The `Color.brandForestGreen`
+**call sites stay identical** — only the body of the static var changes.
+
+---
+
+## 3. SwiftUI integration approach
+
+**Recommended: Asset Catalog colorsets + the existing `Color` extension,
+no environment value.**
+
+The `Color+Brand.swift` API (`Color.brandForestGreen`, etc.) already
+exists and is already partially adopted. We swap the *implementation* of
+those vars from `Color(brandHex:)` to `Color("BrandForestGreen", bundle:
+…)` so iOS's own appearance machinery resolves the right variant for
+light / dark / high-contrast / Increase Contrast. We add a thin
+**`Color+Semantic.swift`** on top whose vars (`Color.surface`,
+`Color.expiringSoon`, …) just return primitives. Two layers, no runtime
+plumbing, no preview wiring change, and the existing call sites in
+`LaunchView` / `AccountStatusBanner` keep working as-is.
+
+### Rejected alternatives (one line each)
+
+- **Pure `Color` extension with hex literals (status quo).** Rejected —
+  no path to dark mode without per-call-site mode checks; brittle.
+- **`@Environment(\.theme) var theme: Theme` value.** Rejected — adds a
+  preview/test injection burden across every view for ~zero benefit;
+  iOS already has the appearance environment, we just need to feed it
+  through Asset Catalog colorsets.
+- **Third-party design-token library (Tokens, Spectrum, etc.).**
+  Rejected — six colors and a handful of semantic roles do not justify
+  a dependency. Asset Catalog plus a Swift file is enough.
+- **Code-gen tokens from `colors.json` at build time.** Rejected for
+  Phase 10.5 — the file has six entries and changes once a quarter;
+  manual sync (already enforced by §6's "change both in the same
+  commit" rule) is cheaper than a build script. Revisit if the palette
+  grows past ~20 tokens.
+
+---
+
+## 4. Light / dark mode + Dynamic Type strategy
+
+### One token, two appearances
+
+Each primitive is **one** semantic name backed by an Asset Catalog
+colorset with a Light + Dark + (optional) High-Contrast variant. Views
+never branch on `colorScheme`. The proposed dark-mode hexes:
+
+| Token | Light | Dark | Notes |
+| --- | --- | --- | --- |
+| `brandForestGreen` | `#2F5D50` | `#4A8B7A` | Lifted ~25 L for legibility on dark canvas. |
+| `brandWarmCream` | `#F4F1EC` | `#1C1B17` | Near-black canvas, warm-shifted to keep brand temperature. |
+| `brandSoftBrown` | `#8B6F47` | `#B8966A` | Lifted; passes 6.24 : 1 on the dark canvas. |
+| `brandCoolBlue` | `#4A90E2` | `#7AB3F0` | Lifted; passes 7.82 : 1 on the dark canvas. |
+| `brandMutedOrange` | `#E9A857` | `#F0BC72` | Slightly lighter; passes 9.96 : 1. |
+| `brandSoftRed` | `#D64545` | `#E97070` | Lifted to pass 5.76 : 1 on dark canvas. |
+| `surfaceElevated` | `#FFFFFF` | `#2A2823` | Slightly raised vs `brandWarmCream` dark. |
+
+In dark mode the **surface inverts** (cream → near-black) and the brand
+green **lifts** so the wordmark and primary CTAs read on the new canvas.
+The hero is still recognizably forest-green; we are not switching brands
+between modes.
+
+### Dynamic Type
+
+- Type styles (`.body`, `.headline`, …) are inherited everywhere — no
+  fixed point sizes in branded components. Status badges use `.caption`
+  + `.medium` weight + tabular numerals, which scales correctly.
+- Branded chips / badges must use the **icon + text** pattern that §6
+  already mandates, so Dynamic Type users at AX5 still get state
+  information when the chip background tint becomes the smallest visual
+  signal.
+- The wordmark in `LaunchView` is a `.system(.largeTitle, design:
+  .rounded)` — already Dynamic-Type-correct. Don't introduce hard-sized
+  brand text anywhere else.
+
+### Increase Contrast / high-contrast appearance
+
+Asset Catalog colorsets accept a "High Contrast" variant per appearance.
+We will ship a high-contrast variant for the three colors that sit
+closest to AA threshold:
+
+- `brandSoftBrown` light HC: `#6E5234` (6.4 : 1 on cream — fixes the
+  current 4.18 : 1 fail at body sizes).
+- `brandMutedOrange` light HC: deepen toward `#9A6622` for *text* uses
+  only; chip-fill HC stays bright.
+- `brandSoftRed` light HC: `#A93030` for text uses; chip-fill HC stays
+  bright.
+
+For the dark mode HC variants, lift each by another ~10 L.
+
+---
+
+## 5. Highest-leverage surfaces (where to apply branding first)
+
+Ordered by **visibility × stability** — surfaces a user sees daily, that
+won't rev again soon. This list maps directly to the follow-up issues
+in §10.
+
+1. **App canvas (`brandWarmCream` background).** The single highest-
+   leverage change. `RootView`, all `List` backgrounds, smart-list
+   views, sidebar.
+2. **Expiry badges** (`ExpiringSoonView`, `ItemsView` row, `ItemDetail`
+   expiry section). State color is the most utility-aligned brand
+   moment — it carries information *and* personality at once.
+3. **Primary CTA buttons** (`ItemFormView` Save/Add, `LocationFormView`
+   Save). One filled `brandPrimary` button style replaces the default
+   blue.
+4. **Empty states** (`ItemsView` empty location, `SidebarView` empty
+   Locations, smart-list empties). High-personality moments per §9 —
+   warm cream illustration tone fits the playful-but-not-childish bar.
+5. **Sidebar navigation chrome.** No tab bar in this app — sidebar is
+   the equivalent. Branded tint, `coldStorage` blue on fridge/freezer
+   icons, `pantryCategory` brown on pantry/dry-goods.
+6. **`ItemDetailView` header.** Photo-less items currently look like a
+   plain Form. A branded section header strip (with location-kind
+   accent) makes the screen feel intentional.
+7. **`AccountStatusBanner`.** Already on `brandWarmCream` — finish the
+   pass with branded text + iconography per status.
+
+---
+
+## 6. Accessibility — pairings with computed contrast ratios
+
+WCAG thresholds: AA-body ≥ 4.5 : 1, AA-large (≥ 18 pt or 14 pt bold) ≥
+3.0 : 1, AAA-body ≥ 7.0 : 1.
+
+### Light mode
+
+| Foreground | Background | Ratio | AA body | AA large | AAA |
+| --- | --- | --- | --- | --- | --- |
+| `brandForestGreen` `#2F5D50` | `brandWarmCream` `#F4F1EC` | **6.65** | PASS | PASS | fail |
+| `brandWarmCream` | `brandForestGreen` (filled CTA) | **6.65** | PASS | PASS | fail |
+| white | `brandForestGreen` | **7.49** | PASS | PASS | PASS |
+| white | `brandSoftBrown` | **4.71** | PASS | PASS | fail |
+| `brandSoftBrown` | `brandWarmCream` | 4.18 | **fail** | PASS | fail |
+| `brandSoftBrown` HC `#6E5234` | `brandWarmCream` | **6.38** | PASS | PASS | fail |
+| `brandCoolBlue` | `brandWarmCream` | 2.92 | **fail** | fail | fail |
+| `brandCoolBlue` text `#1F66B5` | `brandWarmCream` | **5.14** | PASS | PASS | fail |
+| `brandMutedOrange` | `brandWarmCream` | 1.83 | **fail** | fail | fail |
+| `expiringSoon` `#9A6622` | `expiringSoonFill` `#FCEAD0` | **6.15** | PASS | PASS | fail |
+| black | `brandMutedOrange` (chip fill) | **10.20** | PASS | PASS | PASS |
+| `brandSoftRed` | `brandWarmCream` | 3.89 | **fail** | PASS | fail |
+| `expired` `#A93030` | `expiredFill` `#F8E0E0` | **5.31** | PASS | PASS | fail |
+| white | `brandSoftRed` (filled destructive) | 4.38 | **fail** | PASS | fail |
+| white | `brandSoftRed` HC `#A93030` | **6.66** | PASS | PASS | fail |
+
+### Dark mode
+
+| Foreground | Background | Ratio | AA body | AA large | AAA |
+| --- | --- | --- | --- | --- | --- |
+| `brandWarmCream` light `#F4F1EC` | `brandWarmCream` dark `#1C1B17` | **15.30** | PASS | PASS | PASS |
+| `brandForestGreen` dark `#4A8B7A` | dark canvas | 4.32 | **fail** | PASS | fail |
+| `brandSoftBrown` dark `#B8966A` | dark canvas | **6.24** | PASS | PASS | fail |
+| `brandCoolBlue` dark `#7AB3F0` | dark canvas | **7.82** | PASS | PASS | PASS |
+| `brandMutedOrange` dark `#F0BC72` | dark canvas | **9.96** | PASS | PASS | PASS |
+| `brandSoftRed` dark `#E97070` | dark canvas | **5.76** | PASS | PASS | fail |
+
+### Hard rules baked into the tokens
+
+- **`brandMutedOrange` and `brandSoftRed` are fill-only at body sizes in
+  light mode.** Text must use the deeper `expiringSoon` / `expired`
+  variants. The semantic-token names enforce this — `Color.expiringSoon`
+  resolves to the deep amber, `Color.expiringSoonFill` to the bright
+  brand orange. Engineers don't pick.
+- **`brandCoolBlue` light is a fill / large-text color only.** A semantic
+  `Color.coldStorageText` (`#1F66B5`) is required for body-size labels.
+- **`brandForestGreen` dark fails AA at body size on the dark canvas.**
+  Use as a fill (CTA background) or large-text accent only in dark mode;
+  body text on dark uses `brandWarmCream` light or `surfaceElevated` dark.
+  This is acceptable because forest-green is primarily a *surface* color
+  in dark mode (filled buttons, navigation tint), not body text.
+- **Color is never the only state signal.** Already in §6 — restate
+  here because the badge tokens make this easy to forget.
+
+### Color-blind safety
+
+The three status colors (orange, red, brown) cluster in the long-wave
+range. Deuteranopia / protanopia simulations collapse orange and red
+toward similar warm-yellow. Mitigations:
+
+1. Status icons (`clock.badge.exclamationmark`, `xmark.octagon.fill`)
+   are **load-bearing** — never strip them in compact layouts.
+2. Expired vs expiring-soon must differ in **shape / glyph**, not just
+   tint. The §6 rule "icon + label" is the contract.
+3. Pantry-brown vs expired-red: pantry use is icon-only and confined to
+   the sidebar / category context. Status reds appear on a *cream*
+   chip background, never on a pantry-brown chip. The semantic tokens
+   keep them apart.
+
+---
+
+## 7. Emoji / illustration consistency
+
+§3 / §9 already pin the voice as "playful, not childish." The visual
+analogue:
+
+- **Emoji are for copy, not chrome.** `DESIGN_GUIDELINES.md` §1 uses
+  emoji as bullet pegs in a copy block — that's fine. Emoji as iconography
+  in the running UI is **off**: SF Symbols carry weight/scale/Dynamic-Type
+  behavior, emoji do not.
+- **One illustrated mark, used sparingly.** The cabinet from
+  `assets/brand/icon.png` is the only first-party illustration. We
+  should commission a small illustrated empty-state set (Phase 10.6+,
+  not in this proposal) using the same fill-style + brand palette: an
+  open shelf for "empty pantry," a tag-and-string for "no items
+  matching." Until that ships, empty states use SF Symbols rendered in
+  `Color.secondary` + a single playful copy line per §9.
+- **Personality lives in copy + state colors.** Illustrations and
+  large emoji clusters are not the brand voice for this app — short,
+  dry, slightly witty strings are.
+- **Where emoji *do* appear** (currently §1's bullet list, future
+  marketing copy), they ride alongside text — never as the only state
+  signal.
+
+---
+
+## 8. Shape, motion, and other surfaces (briefly out of scope)
+
+Animation/motion language is explicitly out of scope per the issue.
+Corner radius, elevation, and density are *not* called out as research
+deliverables, but the brand-pass implementation will inherit defaults:
+
+- Corner radius: SF default (`RoundedRectangle` 12 pt for chips,
+  default `Form` insets elsewhere).
+- Elevation: rely on iOS chrome — sheets, materials, blurred bars.
+  No custom shadows.
+- Density: `.regular` everywhere; no compact mode.
+
+If any of these become a brand lever, file a separate research issue.
+
+---
+
+## 9. Constraints and non-goals (recap)
+
+In scope for this proposal: tokens, naming, light/dark, accessibility,
+rollout order.
+
+Out of scope: icon redesign, marketing assets, animation/motion,
+typography overhaul (Typography is settled in §5), wholesale
+restyling. Each Phase 10.5 sub-issue must touch *one* surface.
+
+---
+
+## 10. Prioritized follow-up implementation issues
+
+Each item is one Phase 10.5 sub-issue. Title is imperative, paragraph
+is the scope. The list is ordered by **dependency × leverage** — the
+earlier items unblock later ones.
+
+1. **Add Asset Catalog colorsets for the six brand primitives with
+   light, dark, and high-contrast variants.** Create
+   `NakedPantreeApp/Resources/Assets.xcassets/Brand/<Name>.colorset`
+   for Forest Green, Warm Cream, Soft Brown, Cool Blue, Muted Orange,
+   Soft Red. Each colorset gets light + dark + AnyAppearance High
+   Contrast variants matching §4. Update `Color+Brand.swift` so each
+   static var resolves via `Color("BrandForestGreen", bundle: …)`
+   instead of `Color(brandHex:)`. Call sites stay byte-identical;
+   appearance handling becomes free. Foundation for everything else.
+
+2. **Introduce semantic role tokens (`Color+Semantic.swift`).** Add
+   `Color.surface`, `Color.surfaceElevated`, `Color.primary`,
+   `Color.onPrimary`, `Color.coldStorage`, `Color.coldStorageText`,
+   `Color.pantryCategory`, `Color.expiringSoon`, `Color.expiringSoonFill`,
+   `Color.expired`, `Color.expiredFill`, `Color.divider`, plus the
+   `ShapeStyle` mirrors. Each var resolves to a primitive (or a
+   primitive at a tuned opacity). No view changes — this is the seam
+   the next four items consume. Add a doc comment on each token
+   referencing the §6 usage rule it enforces.
+
+3. **Apply `Color.surface` as the app canvas.** `RootView`, every
+   `List` background (`SidebarView`, `ItemsView`, `AllItemsView`,
+   `ExpiringSoonView`, `RecentlyAddedView`, `SearchResultsView`),
+   `ItemDetailView`'s `Form`. Use
+   `.scrollContentBackground(.hidden).background(Color.surface)` on
+   `Form` / `List`. Verify dark mode works without per-view branches.
+
+4. **Add expiry / quantity badge components and wire them into `ItemRow`,
+   `ExpiringSoonView`, and `ItemDetailView` expiry section.** Build
+   `ExpiryBadge(expiresAt:)` that picks `expiringSoon`/`expired`/no-
+   badge based on the same threshold logic the smart list already uses,
+   pairs the chip with `clock.badge.exclamationmark` /
+   `xmark.octagon.fill`, and uses `expiringSoonFill` / `expiredFill` for
+   the chip background with the deep-text variants for the label.
+   Also build `QuantityBadge(quantity:unit:)` using
+   `Color.surfaceElevated` + `Color.primary` text.
+
+5. **Add `Color.primary` filled button style and apply to primary
+   CTAs.** Implement `ButtonStyle.brandPrimary` (filled rounded
+   rectangle, `Color.primary` background, `Color.onPrimary` text,
+   tactile press response). Apply to the Save/Add buttons in
+   `ItemFormView` and `LocationFormView`. Don't touch toolbar buttons
+   — those remain native chrome.
+
+6. **Brand the empty states.** Wrap `ContentUnavailableView` usage in
+   a `BrandedEmptyState(systemImage:title:message:)` helper that
+   tints the symbol with `Color.secondary` (currently default), uses
+   `surface` background, and renders the message with the
+   `playful-but-utility-first` copy already in §9 (Empty pantry: "Your
+   pantry is empty. This feels like a bigger problem.", etc.). Apply
+   to `ItemsView` empty location, `ExpiringSoonView`, `RecentlyAddedView`,
+   `SearchResultsView`, the empty Locations row in `SidebarView`, the
+   `ItemDetailView` "Pick an item" placeholder.
+
+7. **Tint sidebar location icons by kind using `coldStorage` /
+   `pantryCategory` / `secondary`.** `LocationKind.systemImage`
+   already maps kinds to SF Symbols — extend with a tint mapping
+   (`fridge` / `freezer` → `coldStorage`, `pantry` / `dryGoods` →
+   `pantryCategory`, `other` / `unknown` → `secondary`). Wordmark
+   the navigation title area in `SidebarView` using the same weighted
+   `naked pantree` lockup as `LaunchView`.
+
+8. **Brand the `ItemDetailView` header strip.** When an item has no
+   primary photo, render a thin colored band above the form keyed to
+   the item's location kind (cold storage → `coldStorage`, pantry →
+   `pantryCategory`). When a primary photo exists, layer the band as a
+   subtle shadow under the photo. Pure decoration — must remain
+   ignorable for a11y (`accessibilityHidden`).
+
+9. **Polish the `AccountStatusBanner`.** It already sits on
+   `brandWarmCream` — finish the pass with `Color.expiringSoon` for
+   degraded-iCloud states (paired with an icon), `Color.expired` for
+   sign-out, and `Color.primary` for the "available" success state
+   (only shown briefly on transition). Ensure the banner is never the
+   sole signal for any state — it is paired with the in-feature
+   alerting.
+
+10. **Dark-mode + Increase-Contrast QA pass.** Run the snapshot suite
+    in both modes plus the iOS Increase Contrast accessibility
+    setting. Capture screenshots for each surface in each mode.
+    File one ticket per regression discovered. Includes the
+    `LaunchView` (already branded) — which is allowed to skip dark
+    mode if the cream background reads better as a fixed launch
+    surface; that decision lives in this issue's PR.
+
+---
+
+## 11. References
+
+- `DESIGN_GUIDELINES.md` §3 (voice), §6 (color), §9 (personality), §10
+  (writing checklist), §11 (restraint).
+- `assets/brand/colors.json` — primitive source of truth.
+- `assets/brand/brand-guide.png` — single-page visual reference.
+- `NakedPantreeApp/DesignSystem/Color+Brand.swift` — current Swift API.
+- WCAG 2.1 SC 1.4.3 (contrast minimum) and 1.4.6 (enhanced).

--- a/docs/BRAND_PASS_PROPOSAL.md
+++ b/docs/BRAND_PASS_PROPOSAL.md
@@ -343,7 +343,13 @@ earlier items unblock later ones.
    Contrast variants matching §4. Update `Color+Brand.swift` so each
    static var resolves via `Color("BrandForestGreen", bundle: …)`
    instead of `Color(brandHex:)`. Call sites stay byte-identical;
-   appearance handling becomes free. Foundation for everything else.
+   appearance handling becomes free. Also reconcile the existing
+   `AccentColor.colorset` (currently a flat `#2F5D50`): either give it
+   the same light/dark/high-contrast variants as `BrandForestGreen`,
+   or delete it and point the project-level accent reference at
+   `BrandForestGreen` directly. Without this, the system `.tint` stays
+   on the light-mode green in dark mode while brand surfaces lift —
+   subtle but visible drift. Foundation for everything else.
 
 2. **Introduce semantic role tokens (`Color+Semantic.swift`).** Add
    `Color.surface`, `Color.surfaceElevated`, `Color.primary`,

--- a/project.yml
+++ b/project.yml
@@ -42,8 +42,6 @@ targets:
         product: NakedPantreePersistence
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: cc.mnmlst.nakedpantree
-        PRODUCT_NAME: "Naked Pantree"
         PRODUCT_MODULE_NAME: NakedPantree
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -53,7 +51,20 @@ targets:
         CODE_SIGN_STYLE: Automatic
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: NakedPantreeApp/Resources/Info.plist
-        CODE_SIGN_ENTITLEMENTS: NakedPantreeApp/Resources/NakedPantree.entitlements
+      configs:
+        # Debug ships a separate bundle id + iCloud container so a
+        # local dev build can sit alongside the TestFlight build on
+        # the same device. See DEVELOPMENT.md §3 for the user-side
+        # Apple Developer portal setup that has to be done in
+        # parallel for the dev signing flow to actually succeed.
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: cc.mnmlst.nakedpantree.dev
+          PRODUCT_NAME: "Pantree Dev"
+          CODE_SIGN_ENTITLEMENTS: NakedPantreeApp/Resources/NakedPantreeDev.entitlements
+        Release:
+          PRODUCT_BUNDLE_IDENTIFIER: cc.mnmlst.nakedpantree
+          PRODUCT_NAME: "Naked Pantree"
+          CODE_SIGN_ENTITLEMENTS: NakedPantreeApp/Resources/NakedPantree.entitlements
 
   NakedPantreeTests:
     type: bundle.unit-test
@@ -69,7 +80,15 @@ targets:
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"
-        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Naked Pantree.app/Naked Pantree"
+      # TEST_HOST tracks the host app's per-config PRODUCT_NAME — the
+      # Debug build produces "Pantree Dev.app" while Release stays
+      # "Naked Pantree.app". Hardcoding either filename here would
+      # break the other config at test-link time.
+      configs:
+        Debug:
+          TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Pantree Dev.app/Pantree Dev"
+        Release:
+          TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Naked Pantree.app/Naked Pantree"
 
   NakedPantreeUITests:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary

Bundled Phase 10 — four sub-milestones developed in parallel worktrees, **zero shared files** (cleaner than Phase 9; no `NotificationScheduler`-style integration commit needed). Each sub-branch's commits preserved (cherry-picked, not squashed) so this PR is reviewable per sub-milestone via the commit list.

| # | Issue | What landed |
|---|---|---|
| **10.1** | [#60](https://github.com/ellisandy/NakedPantree/issues/60) | New "Household" section in `SettingsView` (Name row + Share Household button); `Share Household` toolbar item + state removed from `SidebarView`. |
| **10.2** | [#52](https://github.com/ellisandy/NakedPantree/issues/52) | **Research-only.** New `docs/BRAND_PASS_PROPOSAL.md` (320 lines): two-tier token scheme (primitives + semantic role tokens), Asset Catalog as integration mechanism, computed WCAG ratios per pairing including a high-contrast variant for the soft brown that currently fails AA, **10 prioritized follow-up issues** for Phase 10.5 implementation. Pointer line in `DESIGN_GUIDELINES.md §6`. |
| **10.3** | [#68](https://github.com/ellisandy/NakedPantree/issues/68) | New `Debug` build config: bundle id `cc.mnmlst.nakedpantree.dev`, container `iCloud.cc.mnmlst.nakedpantree.dev`, display name `Pantree Dev`. New `NakedPantreeDev.entitlements`. `Info.plist` gets `CFBundleDisplayName = $(PRODUCT_NAME)`. `DEVELOPMENT.md §3` rewritten. **Both Debug and Release configs build clean**; `testflight-beta.yml` untouched. |
| **10.4** | [#28](https://github.com/ellisandy/NakedPantree/issues/28) | Persistent-history-token bookkeeping in `RemoteChangeMonitor`: stamp local saves with `transactionAuthor = "local"`, fetch transactions via `NSPersistentHistoryChangeRequest.fetchHistory(after:)`, only bump `changeToken` if a non-local transaction shows up. Last-seen token persisted to `UserDefaults`. New tests cover local-author / non-local-author / cross-restart token persistence. |

## ROADMAP changes

- 10.{1..4} → 🟡 In review.
- **New 10.5 row** added for the brand-pass implementation tracked in `docs/BRAND_PASS_PROPOSAL.md`'s prioritized list. Phase 10's exit criterion #2 ("typography, color, and copy match `DESIGN_GUIDELINES.md`") gates on 10.5 completing — Phase 10 won't fully close until that lands.
- Doc note explains the parallel-worktrees workflow had **zero shared files** this phase.

## User-side gating (10.3)

10.3 ships the repo changes; the side-by-side install only actually works after the user does the Apple Developer portal setup:

1. <https://developer.apple.com/account/resources/identifiers/list> → register App ID `cc.mnmlst.nakedpantree.dev` with iCloud + Push Notifications capabilities.
2. <https://developer.apple.com/account/resources/icloudcontainers/list> → create iCloud container `iCloud.cc.mnmlst.nakedpantree.dev`.
3. Assign the new container to the dev App ID's iCloud capability.

Same gating pattern Phase 7.1 had against the App Store Connect setup in 7.2. Until those three steps are done, `xcodebuild` against the Debug config will fail to sign.

## Test plan

- [x] `./scripts/lint.sh` clean.
- [x] Full xcodebuild test (CI-matching: iPhone 17 sim, `-skip-testing:NakedPantreeUITests/SnapshotsUITests`) ends `** TEST SUCCEEDED **`. ~140 unit tests + 2 UI tests pass.
- [x] Both `Debug` and `Release` configs build cleanly. PlistBuddy verified the right bundle id / display name per config (10.3 agent's report).
- [x] Real-device verification still owes (per sub-milestone):
  - 10.1: Settings → Household section flow on a real device, including the share sheet.
  - 10.2: research only — implementation verification rolls into 10.5.
  - 10.3: real-device side-by-side install (after the Apple Developer portal setup above).
  - 10.4: Console.app filtered to bundle id while saving an item — pre-merge you'd see two reload-triggered fetches per save; post-merge exactly one.

## How to review

Commit-by-commit. Each commit is a self-contained sub-milestone. No central integration commit this phase — zero shared files made it unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)