### PR TITLE
Phase 11.1d: ship PrivacyInfo.xcprivacy manifest

### DIFF
--- a/NakedPantreeApp/Resources/PrivacyInfo.xcprivacy
+++ b/NakedPantreeApp/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        Naked Pantree privacy manifest.
+
+        Source-of-truth rationale for every key here is in
+        docs/app-store-privacy.md (§5 covers the required-reason API
+        accounting; §3 covers the App Privacy questionnaire). Keep
+        this file in sync with that document — if a new third-party
+        SDK, analytics pipeline, or required-reason API ever lands in
+        the codebase, both this manifest and that doc need updating.
+    -->
+
+    <!-- §3 Q1 / §3 Q17 / §4: zero tracking, zero data collection. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+
+    <!--
+        §5: required-reason API declarations. The only category we
+        currently use is UserDefaults, via
+        NakedPantreeApp/Notifications/NotificationSettings.swift —
+        the per-device notification reminder time is read and
+        written under the `settings.notifications.reminderHour` /
+        `settings.notifications.reminderMinute` keys. Reason code
+        CA92.1 ("Access info from same app") matches that usage
+        exactly: the data is strictly first-party and accessible
+        only to this app.
+    -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -643,9 +643,10 @@ upload without drafts.
 | 11.1a | App Store listing copy — name, subtitle, description, keywords, age rating, category (`docs/app-store-listing.md`) | agent | ✅ Merged ([apps#78](https://github.com/ellisandy/NakedPantree/pull/78)) |
 | 11.1b | App Privacy questionnaire answers + `PrivacyInfo.xcprivacy` plist plan (`docs/app-store-privacy.md`) | agent | ✅ Merged ([apps#78](https://github.com/ellisandy/NakedPantree/pull/78)) |
 | 11.1c | App Store screenshots per device family (run / extend the existing `SnapshotsUITests` pipeline to produce App-Store-spec sizes) | agent | ⏳ Deferred — produced near submission time when the human is doing the App Store Connect upload anyway |
+| 11.1d | Ship `PrivacyInfo.xcprivacy` manifest (the code-side follow-up flagged in 11.1b §5 / §8) — `UserDefaults` reason `CA92.1`, empty `NSPrivacyCollectedDataTypes`, `NSPrivacyTracking=false` | agent | 🟡 In review |
 | 11.2 | App Store Connect record setup — paste 11.1a metadata, fill 11.1b privacy answers, upload 11.1c screenshots, set age rating / category / regions, choose pricing (free, all countries) | user | ⏳ Pending |
 | 11.3 | Final manual QA pass against `ARCHITECTURE.md §11` — two iCloud accounts, two devices, real iPhone + iPad + Mac (Designed for iPad). Sweeps up the still-pending real-device verification owed by Phases 8.2 / 8.3 / 9.{1..4} / 10.{1..4} | user | ⏳ Pending |
-| 11.4 | App Store submission + review iteration — ship the `PrivacyInfo.xcprivacy` flagged in 11.1b, submit, respond to Apple Review feedback, ship code-side fixes if Apple flags anything | hybrid | ⏳ Pending |
+| 11.4 | App Store submission + review iteration — submit, respond to Apple Review feedback, ship code-side fixes if Apple flags anything (privacy manifest already shipped in 11.1d) | hybrid | ⏳ Pending |
 | 11.5 | Release docs + retrospective — `DEVELOPMENT.md §6 / §7` final fills, ROADMAP close, tag `phase-11`, README version bump | agent | ⏳ Pending |
 
 > 11.1's three sub-pieces ran in parallel agent worktrees alongside

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,7 @@ targets:
           - "**/*.md"
     resources:
       - path: NakedPantreeApp/Resources/Assets.xcassets
+      - path: NakedPantreeApp/Resources/PrivacyInfo.xcprivacy
     dependencies:
       - package: Core
         product: NakedPantreeDomain


### PR DESCRIPTION
## Summary

- Adds `NakedPantreeApp/Resources/PrivacyInfo.xcprivacy` declaring `UserDefaults` reason `CA92.1`, plus the affirmative `NSPrivacyTracking=false` / empty `NSPrivacyCollectedDataTypes` / empty `NSPrivacyTrackingDomains` keys that mirror our \"Data Collected = NO\" answer from 11.1b.
- Wires the manifest into the `NakedPantree` target's `resources:` list in `project.yml` (xcodegen regenerates the pbxproj reference automatically — no checked-in `.xcodeproj` churn).
- Updates `ROADMAP.md`: adds row **11.1d** under Phase 11.1; removes the rider on row 11.4 that referenced \"ship the `PrivacyInfo.xcprivacy` flagged in 11.1b\" since that's now landed here.

## Why now

Apple has required a `PrivacyInfo.xcprivacy` manifest for any app that uses a [\"required reason\" API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) since May 2024. App Store Connect bounces uploads that lack one. We use exactly one reason-required API today — `UserDefaults` via `NakedPantreeApp/Notifications/NotificationSettings.swift` for the per-device reminder time — so the manifest needed to land before Phase 11.4 (App Store submission). Source-of-truth rationale for every key value is in `docs/app-store-privacy.md` §5; the plist comments point readers at that doc.

## Test plan

- [x] `./scripts/lint.sh` clean.
- [x] Full `xcodebuild test` matching `.github/workflows/build-test.yml`: 136 unit tests + 2 UI tests, 0 failures.
- [x] Manifest is bundled into the built `.app` at the app root: `Pantree Dev.app/PrivacyInfo.xcprivacy` (where Apple's tooling expects it).
- [ ] CI \"Build & Test\" green (post-push).
- [ ] CI \"Lint\" green (post-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)