### PR TITLE
#90: instrument Share Household path to diagnose blank-sheet bug

### DIFF
--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -3,6 +3,7 @@ import NakedPantreeDomain
 import NakedPantreePersistence
 import SwiftUI
 import UIKit
+import os
 
 /// `UIViewControllerRepresentable` over `UICloudSharingController`. iOS
 /// 26 still doesn't have a SwiftUI-native participant manager — the
@@ -21,20 +22,50 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
     /// caller drops the sheet binding and may want to refresh state.
     let onCompletion: () -> Void
 
+    /// Trace for #90 (blank Share Household sheet on TestFlight).
+    /// Visible via Console.app filtered by subsystem
+    /// `cc.mnmlst.nakedpantree`, category `sharing`. Same lifetime
+    /// note as `CloudHouseholdSharingService.logger` — keep until #90
+    /// is fully closed.
+    ///
+    /// `nonisolated` because `UIViewControllerRepresentable` infers
+    /// `@MainActor` on the struct, but the `Task` in the preparation
+    /// handler runs off-main and reads `Self.logger` from there.
+    nonisolated private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "sharing"
+    )
+
+    /// Cap on how long we wait for `prepareShare` before surfacing a
+    /// timeout error to the controller. 60s is generous — first-time
+    /// share creation can legitimately spend many seconds in
+    /// `NSPersistentCloudKitContainer.share(_:to:)` while CloudKit
+    /// lazy-creates the shared zone — but it's tight enough that a
+    /// genuine hang produces an alert instead of an indefinitely
+    /// blank sheet (the symptom in #90). Same `nonisolated` rationale
+    /// as `logger`.
+    nonisolated private static let prepareShareTimeout: Duration = .seconds(60)
+
     func makeUIViewController(context: Context) -> UICloudSharingController {
+        Self.logger.info("makeUIViewController: creating UICloudSharingController")
         let controller = UICloudSharingController { _, completion in
             // The controller calls this on the main queue once it's
-            // ready to show participant UI. We hop to a Task to use the
-            // async sharing API, then bounce results back via the
-            // synchronous completion closure.
+            // ready to show participant UI. We race `prepareShare`
+            // against a timeout (#90) so a hang surfaces as an error
+            // alert instead of a blank sheet.
+            Self.logger.info("preparation handler fired — racing prepareShare against timeout")
             Task {
-                do {
-                    let (share, container) = try await sharing.prepareShare(for: householdID)
-                    await MainActor.run {
-                        completion(share, container, nil)
-                    }
-                } catch {
-                    await MainActor.run {
+                let outcome = await runPrepareShareWithTimeout()
+                await MainActor.run {
+                    switch outcome {
+                    case .success(let payload):
+                        Self.logger.info("preparation handler: completion(share, container, nil)")
+                        completion(payload.share, payload.container, nil)
+                    case .failure(let error):
+                        let description = error.localizedDescription
+                        Self.logger.error(
+                            "preparation handler: completion(nil, nil, \(description, privacy: .public))"
+                        )
                         completion(nil, nil, error)
                     }
                 }
@@ -42,6 +73,54 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
         }
         controller.delegate = context.coordinator
         return controller
+    }
+
+    /// Runs `prepareShare(for:)` on the actor-isolated service, racing
+    /// it against `prepareShareTimeout`. Whichever wins wins; the
+    /// loser is cancelled. Returns the outcome as a value so the
+    /// caller can dispatch onto MainActor in one place.
+    private func runPrepareShareWithTimeout() async -> Result<SharePayload, Error> {
+        let timeout = Self.prepareShareTimeout
+        let householdID = householdID
+        let sharing = sharing
+        return await withTaskGroup(of: Result<SharePayload, Error>.self) { group in
+            group.addTask {
+                do {
+                    let (share, container) = try await sharing.prepareShare(for: householdID)
+                    return .success(SharePayload(share: share, container: container))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                Self.logger.error(
+                    "prepareShare timed out after \(timeout, privacy: .public)"
+                )
+                return .failure(SharingTimeoutError())
+            }
+            let first = await group.next() ?? .failure(SharingTimeoutError())
+            group.cancelAll()
+            return first
+        }
+    }
+
+    /// Tuple-shaped payload kept as a struct so the `Result.success`
+    /// destructure at the call site is a single binding (sidesteps the
+    /// swift-format / swiftlint disagreement on multi-bound `let` /
+    /// `case let` forms).
+    private struct SharePayload {
+        let share: CKShare
+        let container: CKContainer
+    }
+
+    private struct SharingTimeoutError: LocalizedError {
+        var errorDescription: String? {
+            // Surfaced to the user by `UICloudSharingController`'s own
+            // alert — keep terse and actionable.
+            "Couldn't reach iCloud to prepare the share. Try again — "
+                + "if it keeps happening, check the iCloud account in Settings."
+        }
     }
 
     func updateUIViewController(_ controller: UICloudSharingController, context: Context) {

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
@@ -1,6 +1,7 @@
 import CloudKit
 import CoreData
 import NakedPantreeDomain
+import os
 
 /// Vends a `CKShare` rooted at a `Household` row, plus the `CKContainer`
 /// that owns it — exactly what `UICloudSharingController(preparationHandler:)`
@@ -16,6 +17,17 @@ import NakedPantreeDomain
 public final class CloudHouseholdSharingService: @unchecked Sendable {
     private let container: NSPersistentCloudKitContainer
     private let cloudKitContainer: CKContainer
+
+    /// Step-by-step trace of `prepareShare` — visible via Console.app
+    /// filtered by subsystem `cc.mnmlst.nakedpantree`, category
+    /// `sharing`. Added while diagnosing #90 (blank Share Household
+    /// sheet on TestFlight). Keep until that issue is fully closed
+    /// and the failure mode is documented in DEVELOPMENT.md §7; then
+    /// trim back to whatever turned out to be load-bearing.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "sharing"
+    )
 
     public init(
         container: NSPersistentCloudKitContainer,
@@ -37,19 +49,25 @@ public final class CloudHouseholdSharingService: @unchecked Sendable {
     public func prepareShare(
         for householdID: Household.ID
     ) async throws -> (CKShare, CKContainer) {
+        Self.logger.info("prepareShare start: \(householdID, privacy: .public)")
         let object = try await householdManagedObject(for: householdID)
+        Self.logger.info("got household managed object")
         let share: CKShare
         if let existing = try existingShare(for: object) {
+            Self.logger.info("returning existing share")
             share = existing
         } else {
+            Self.logger.info("calling NSPersistentCloudKitContainer.share")
             // `share(_:to:)` returns `(Set<NSManagedObject>, CKShare, CKContainer)`.
             // We only want the share — the modified objects are already
             // persisted by the API, and the container is the same one
             // the caller injected.
             let result = try await container.share([object], to: nil)
+            Self.logger.info("container.share returned a new CKShare")
             share = result.1
         }
         share[CKShare.SystemFieldKey.title] = "Naked Pantree"
+        Self.logger.info("prepareShare complete")
         return (share, cloudKitContainer)
     }
 


### PR DESCRIPTION
Diagnostic build for [#90](https://github.com/ellisandy/NakedPantree/issues/90). The Share Household sheet renders blank on TestFlight despite CloudKit private sync being healthy on the same device — and the existing share path emits zero `os_log` traffic, so a device-side log capture surfaces nothing actionable.

This adds a step-by-step trace plus a 60s timeout that converts a hang into a surfaced error alert.

## What you'll get on next reproduction

After merging + building TestFlight, reproduce the bug, then in **Console.app** filter by:

```
subsystem:cc.mnmlst.nakedpantree
```

You'll see one of three outcome shapes:

1. **`makeUIViewController` only, no `preparation handler fired`.** The controller never asked for a share — likely an iOS 26 issue with `UICloudSharingController(preparationHandler:)` (it's deprecated; see deprecation note below).
2. **`preparation handler fired` but no `prepareShare start`.** The Task ran but `CloudHouseholdSharingService` is broken in some way the trace doesn't expose.
3. **`prepareShare start` then a stop somewhere mid-flow.** The most useful outcome — tells us *which step* hangs or throws (managed object lookup / existing-share fetch / `container.share`).

If `prepareShare` hangs entirely, the 60s timeout fires → `UICloudSharingController` shows its built-in error alert with a real message ("Couldn't reach iCloud to prepare the share. Try again — if it keeps happening, check the iCloud account in Settings."), instead of staying blank indefinitely.

## Deprecation note (worth tracking)

`UICloudSharingController(preparationHandler:)` emits an iOS 17 deprecation warning at this call site:

> Use `UIActivityViewController initWithActivityItemsConfiguration:` and pass it a `UIActivityItemsConfigurationReading`-conforming object with an `NSItemProvider` and registered preparation handler.

Apple's own CloudKit Sharing samples still use the deprecated init — it's the documented path. But on iOS 26, the deprecated init may have visual regressions. That's worth **ruling in or out as the root cause** once the trace lands. If outcome shape #1 above shows up consistently, this is almost certainly it.

## Test plan

- [x] `./scripts/lint.sh` clean.
- [x] `xcodebuild build` succeeds.
- [x] `swift test` on `Packages/Core` passes (12/12).
- [ ] User reproduces on next TestFlight build, captures Console.app logs filtered by subsystem `cc.mnmlst.nakedpantree`.
- [ ] Trace narrows the bug to one of the three outcome shapes above; root-cause PR follows.

Diagnostic-only — no production behavior changes other than the timeout converting a hang into an alert. Once #90 is root-caused and closed, the verbose logging trims back to whatever turns out to be load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)