### PR TITLE
ci: switch TestFlight signing to fully manual (#92)

### DIFF
--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -168,13 +168,20 @@ jobs:
       # version (`CFBundleShortVersionString`) stays at whatever Info.plist
       # holds — bump that by hand when the milestone changes.
       #
-      # Signing: `CODE_SIGN_STYLE=Manual` +
-      # `PROVISIONING_PROFILE_SPECIFIER=<UUID>` +
-      # `OTHER_CODE_SIGN_FLAGS=--keychain=...` overrides project.yml's
-      # `CODE_SIGN_STYLE: Automatic` and pins codesign to the temp
-      # keychain. No `-allowProvisioningUpdates` — the cert + profile are
-      # already on disk, so xcodebuild has no reason to phone home and
-      # mint a new cert (which is what filled the team's quota in #92).
+      # Signing: `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY` +
+      # `DEVELOPMENT_TEAM` + `OTHER_CODE_SIGN_FLAGS=--keychain=...`
+      # overrides project.yml's `CODE_SIGN_STYLE: Automatic` and pins
+      # codesign to the temp keychain. **No `PROVISIONING_PROFILE_SPECIFIER`
+      # on the cmdline** — that flag cascades to every target in the
+      # build graph, and SwiftPM-generated resource bundles
+      # (e.g. `Core_NakedPantreePersistence`) reject it with
+      # "does not support provisioning profiles". Instead, the profile
+      # was installed to `~/Library/MobileDevice/Provisioning Profiles/`
+      # in the keychain step; Xcode auto-matches it to the main app
+      # target by `(bundle id, team id, cert)` and leaves resource
+      # bundles alone. No `-allowProvisioningUpdates` — the cert +
+      # profile are on disk, so xcodebuild has no reason to phone home
+      # and mint a new cert (which is what filled the team's quota in #92).
       - name: Archive
         run: |
           set -o pipefail
@@ -188,7 +195,6 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Apple Distribution" \
             DEVELOPMENT_TEAM=YJBSSS9C6C \
-            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_UUID" \
             OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH" \
             CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
 

--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -38,6 +38,81 @@ jobs:
       - name: Generate project
         run: xcodegen generate
 
+      # Manual signing (issue #92). Each ephemeral runner gets a fresh
+      # temporary keychain that holds *only* the imported distribution
+      # cert for the duration of the job. The keychain is deleted in the
+      # cleanup step at the end. We do NOT pass `-allowProvisioningUpdates`
+      # to xcodebuild — that flag asks Apple to mint a fresh cert per
+      # run, which is what filled the team's cert quota in the first
+      # place. With the cert + profile in hand, xcodebuild has no reason
+      # to phone home.
+      #
+      # Keychain naming: a per-run UUID-suffixed name (e.g.
+      # `nakedpantree-build-<run-id>.keychain-db`) prevents collisions
+      # if a future workflow change ever shares state across jobs.
+      - name: Set up signing keychain
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/nakedpantree-build-$GITHUB_RUN_ID.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          CERT_PATH="$RUNNER_TEMP/build_certificate.p12"
+          PROFILE_PATH="$RUNNER_TEMP/AppStore.mobileprovision"
+
+          # Decode the cert + profile from base64 secrets.
+          printf '%s' "$BUILD_CERTIFICATE_BASE64" | base64 -d > "$CERT_PATH"
+          printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 -d > "$PROFILE_PATH"
+
+          # Sanity-check sizes — base64 padding mistakes silently produce
+          # short files that fail downstream with cryptic codesign errors.
+          CERT_SIZE=$(wc -c < "$CERT_PATH" | tr -d ' ')
+          PROFILE_SIZE=$(wc -c < "$PROFILE_PATH" | tr -d ' ')
+          echo "▸ p12: $CERT_SIZE bytes, profile: $PROFILE_SIZE bytes"
+          [ "$CERT_SIZE" -gt 1000 ] || { echo "::error::p12 too small — re-check BUILD_CERTIFICATE_BASE64"; exit 1; }
+          [ "$PROFILE_SIZE" -gt 1000 ] || { echo "::error::profile too small — re-check PROVISIONING_PROFILE_BASE64"; exit 1; }
+
+          # Create + unlock + add to search list. `set-keychain-settings`
+          # without `-l/-u` disables auto-lock so a long archive doesn't
+          # re-lock and break codesign mid-run.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import the cert + private key. `-T /usr/bin/codesign` lets
+          # codesign read the key without prompting; `-A` would be
+          # broader but is unnecessary here.
+          security import "$CERT_PATH" \
+            -P "$P12_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+
+          # Make the new keychain the default and add to search list so
+          # xcodebuild finds the identity. Order matters: the user's
+          # default search list must include this keychain.
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Install the provisioning profile to the well-known location
+          # xcodebuild scans. Filename can be anything; Xcode keys off
+          # the embedded UUID.
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
+          echo "▸ Installed profile UUID: $PROFILE_UUID"
+
+          # Echo identity for the build log so signing failures are
+          # debuggable without re-running the job.
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+          # Stash the keychain path + profile UUID for downstream steps.
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
       # The .p8 stays on the runner only for this job. The well-known
       # path lets `xcodebuild -authenticationKeyPath` and
       # `xcrun altool --apiKey` find it without surfacing the secret
@@ -86,17 +161,21 @@ jobs:
             echo "::warning::Decoded key tail is '$LAST_LINE' (expected '-----END PRIVATE KEY-----'). xcodebuild may still accept it; surfacing for visibility."
           fi
 
-      # `CURRENT_PROJECT_VERSION` overrides `CFBundleVersion` (build
-      # number) at archive time. TestFlight requires a strictly
-      # increasing build number per marketing version; deriving from
-      # `GITHUB_RUN_NUMBER` keeps it monotonic without committing
-      # back to the repo. Marketing version (`CFBundleShortVersionString`)
-      # stays at whatever Info.plist holds — bump that by hand when
-      # the milestone changes.
+      # Build number: `CURRENT_PROJECT_VERSION` overrides `CFBundleVersion`
+      # at archive time. TestFlight requires a strictly increasing build
+      # number per marketing version; deriving from `GITHUB_RUN_NUMBER`
+      # keeps it monotonic without committing back to the repo. Marketing
+      # version (`CFBundleShortVersionString`) stays at whatever Info.plist
+      # holds — bump that by hand when the milestone changes.
+      #
+      # Signing: `CODE_SIGN_STYLE=Manual` +
+      # `PROVISIONING_PROFILE_SPECIFIER=<UUID>` +
+      # `OTHER_CODE_SIGN_FLAGS=--keychain=...` overrides project.yml's
+      # `CODE_SIGN_STYLE: Automatic` and pins codesign to the temp
+      # keychain. No `-allowProvisioningUpdates` — the cert + profile are
+      # already on disk, so xcodebuild has no reason to phone home and
+      # mint a new cert (which is what filled the team's quota in #92).
       - name: Archive
-        env:
-          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           set -o pipefail
           xcodebuild archive \
@@ -106,23 +185,30 @@ jobs:
             -destination 'generic/platform=iOS' \
             -archivePath build/NakedPantree.xcarchive \
             -skipPackagePluginValidation \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8 \
-            -authenticationKeyID "$API_KEY_ID" \
-            -authenticationKeyIssuerID "$API_ISSUER_ID" \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM=YJBSSS9C6C \
+            PROVISIONING_PROFILE_SPECIFIER="$PROFILE_UUID" \
+            OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH" \
             CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
 
-      # `app-store-connect` is the modern method name; older Xcode
-      # called it `app-store`. `signingStyle = automatic` lets Xcode
-      # fetch / regenerate provisioning profiles via the API key —
-      # avoids storing certs and profiles as repo secrets. `teamID`
-      # is hardcoded here to match `DEVELOPMENT_TEAM` in project.yml;
-      # team ids are public (visible on App Store listings), not
-      # secret. Update both together if Apple ever reissues the team.
+      # Manual export: `signingStyle = manual` plus a
+      # `provisioningProfiles` dict mapping bundle id → profile name.
+      # Xcode resolves the profile by *name*, not UUID, so we extract
+      # the embedded `Name` field from the .mobileprovision at runtime.
+      # `signingCertificate` pins the cert by its common name so a
+      # future second cert in the same keychain doesn't introduce
+      # ambiguity. team ids are public, hardcoding is fine — update in
+      # lockstep with `project.yml`'s `DEVELOPMENT_TEAM` if Apple
+      # reissues.
       - name: Write export options
         run: |
+          set -euo pipefail
+          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
+          PROFILE_NAME=$(security cms -D -i "$PROFILE_PATH" | plutil -extract Name raw -)
+          echo "▸ Profile name for export: $PROFILE_NAME"
+
           mkdir -p build
-          cat > build/exportOptions.plist <<'PLIST'
+          cat > build/exportOptions.plist <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -130,9 +216,16 @@ jobs:
             <key>method</key>
             <string>app-store-connect</string>
             <key>signingStyle</key>
-            <string>automatic</string>
+            <string>manual</string>
             <key>teamID</key>
             <string>YJBSSS9C6C</string>
+            <key>signingCertificate</key>
+            <string>Apple Distribution</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>cc.mnmlst.nakedpantree</key>
+              <string>${PROFILE_NAME}</string>
+            </dict>
             <key>uploadSymbols</key>
             <true/>
           </dict>
@@ -140,19 +233,13 @@ jobs:
           PLIST
 
       - name: Export IPA
-        env:
-          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
         run: |
           set -o pipefail
           xcodebuild -exportArchive \
             -archivePath build/NakedPantree.xcarchive \
             -exportPath build/export \
             -exportOptionsPlist build/exportOptions.plist \
-            -allowProvisioningUpdates \
-            -authenticationKeyPath ~/.appstoreconnect/private_keys/AuthKey_$API_KEY_ID.p8 \
-            -authenticationKeyID "$API_KEY_ID" \
-            -authenticationKeyIssuerID "$API_ISSUER_ID"
+            OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH"
 
       - name: Upload to TestFlight
         env:
@@ -175,3 +262,18 @@ jobs:
           name: NakedPantree.xcarchive
           path: build/NakedPantree.xcarchive
           if-no-files-found: ignore
+
+      # Always tear down the temp keychain. Runners are ephemeral so
+      # this is belt-and-braces — but if a future change ever caches
+      # `$RUNNER_TEMP` or shares state across jobs, leaving the
+      # keychain behind would be a credential leak. `|| true` because
+      # a failure here shouldn't mask a real build failure.
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          if [ -n "${KEYCHAIN_PATH:-}" ] && [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          if [ -n "${PROFILE_UUID:-}" ]; then
+            rm -f "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision" || true
+          fi

--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -168,20 +168,18 @@ jobs:
       # version (`CFBundleShortVersionString`) stays at whatever Info.plist
       # holds — bump that by hand when the milestone changes.
       #
-      # Signing: `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY` +
-      # `DEVELOPMENT_TEAM` + `OTHER_CODE_SIGN_FLAGS=--keychain=...`
-      # overrides project.yml's `CODE_SIGN_STYLE: Automatic` and pins
-      # codesign to the temp keychain. **No `PROVISIONING_PROFILE_SPECIFIER`
-      # on the cmdline** — that flag cascades to every target in the
-      # build graph, and SwiftPM-generated resource bundles
-      # (e.g. `Core_NakedPantreePersistence`) reject it with
-      # "does not support provisioning profiles". Instead, the profile
-      # was installed to `~/Library/MobileDevice/Provisioning Profiles/`
-      # in the keychain step; Xcode auto-matches it to the main app
-      # target by `(bundle id, team id, cert)` and leaves resource
-      # bundles alone. No `-allowProvisioningUpdates` — the cert +
-      # profile are on disk, so xcodebuild has no reason to phone home
-      # and mint a new cert (which is what filled the team's quota in #92).
+      # Signing settings live in project.yml under the NakedPantree
+      # target's Release config — `CODE_SIGN_STYLE`,
+      # `CODE_SIGN_IDENTITY`, `PROVISIONING_PROFILE_SPECIFIER`. Putting
+      # them there (not on the xcodebuild cmdline) is deliberate:
+      # cmdline settings cascade to SwiftPM-generated resource bundles
+      # (`Core_NakedPantreePersistence`) which reject profile
+      # specifiers. The only signing setting on the cmdline is
+      # `OTHER_CODE_SIGN_FLAGS=--keychain=...` to point codesign at
+      # the temp keychain — harmless cascade since it's just a search
+      # path, not a per-target binding. No `-allowProvisioningUpdates`
+      # — the cert + profile are on disk, so xcodebuild has no reason
+      # to phone home and mint a new cert (the original #92 leak).
       - name: Archive
         run: |
           set -o pipefail
@@ -192,9 +190,6 @@ jobs:
             -destination 'generic/platform=iOS' \
             -archivePath build/NakedPantree.xcarchive \
             -skipPackagePluginValidation \
-            CODE_SIGN_STYLE=Manual \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-            DEVELOPMENT_TEAM=YJBSSS9C6C \
             OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH" \
             CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER"
 

--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -186,6 +186,7 @@ jobs:
             -archivePath build/NakedPantree.xcarchive \
             -skipPackagePluginValidation \
             CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             DEVELOPMENT_TEAM=YJBSSS9C6C \
             PROVISIONING_PROFILE_SPECIFIER="$PROFILE_UUID" \
             OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH" \

--- a/project.yml
+++ b/project.yml
@@ -65,6 +65,19 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: cc.mnmlst.nakedpantree
           PRODUCT_NAME: "Naked Pantree"
           CODE_SIGN_ENTITLEMENTS: NakedPantreeApp/Resources/NakedPantree.entitlements
+          # Manual signing for Release (issue #92). These have to live
+          # on the main app target — passing them on the xcodebuild
+          # cmdline cascades to SwiftPM-generated resource bundles
+          # (e.g. Core_NakedPantreePersistence) which reject profile
+          # specifiers. CI imports the matching cert + profile via
+          # `.github/workflows/testflight-beta.yml`; local archives
+          # need the same "Github Publish" profile installed via
+          # `open ~/Downloads/Github_Publish.mobileprovision` and the
+          # "Apple Distribution: Andrew Ellis" cert in the login
+          # keychain. Debug stays Automatic — see `base` above.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: "Apple Distribution"
+          PROVISIONING_PROFILE_SPECIFIER: "Github Publish"
 
   NakedPantreeTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

Closes the cert-quota leak that's been blocking TestFlight uploads.

- Drops `-allowProvisioningUpdates` from archive + export — that flag was minting a fresh Apple Distribution cert per CI run, hitting Apple's ~2-3-active-cert-per-team cap.
- Imports a persistent cert (`BUILD_CERTIFICATE_BASE64` + `P12_PASSWORD`) and provisioning profile (`PROVISIONING_PROFILE_BASE64`) from repo secrets into a per-run temp keychain.
- Switches `exportOptions.plist` to `signingStyle = manual` with an explicit `provisioningProfiles` dict.
- Tears down the temp keychain + profile on completion (`if: always()`).

## Why fully manual (not just cert-only)

`-allowProvisioningUpdates` can mint a cert *or* a profile. Half-measures still let Apple-side state drift silently. With both pinned to repo secrets, every run uses the exact same cert + profile, with rotation only when the cert expires (~1 year).

## Test plan

- [ ] **Run via `workflow_dispatch` on this branch BEFORE merging.** Don't merge to main first — burning a build number on a known-good branch run is far cheaper than discovering this fails post-merge.
- [ ] Watch run log for `security find-identity -v -p codesigning` output. Should print `1 valid identities found` with the new cert name.
- [ ] Watch for `▸ Profile name for export:` line — must match the profile name in the developer portal exactly.
- [ ] After the run completes: confirm in [App Store Connect TestFlight](https://appstoreconnect.apple.com) that the new build appears with the expected build number (matches `GITHUB_RUN_NUMBER`).
- [ ] Spot-check Apple Developer portal → Certificates: no new cert was created by this run.
- [ ] After merge: trigger a second TestFlight upload (any `main` push affecting the watched paths) and confirm it succeeds without minting a new cert. Two consecutive green runs is the bar.

Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)