### PR TITLE
ci: thread build number through Info.plist; gate altool on ERROR

### DIFF
--- a/.github/workflows/testflight-beta.yml
+++ b/.github/workflows/testflight-beta.yml
@@ -243,6 +243,14 @@ jobs:
             -exportOptionsPlist build/exportOptions.plist \
             OTHER_CODE_SIGN_FLAGS="--keychain=$KEYCHAIN_PATH"
 
+      # `xcrun altool` exits 0 on Apple-side rejection (e.g. duplicate
+      # bundle version) — it logs `ERROR:` to stdout but the shell
+      # sees green. Two TestFlight uploads silently no-op'd this way
+      # before this guard was added. We tee output to a file and
+      # explicitly fail the step if any line begins with `ERROR:`.
+      # `set -o pipefail` would propagate altool's exit code through
+      # tee, but altool's exit 0 makes that insufficient — the grep
+      # is the actual gate.
       - name: Upload to TestFlight
         env:
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -251,11 +259,18 @@ jobs:
           set -euo pipefail
           IPA=$(find build/export -name '*.ipa' | head -n1)
           [ -n "$IPA" ] || { echo "No .ipa produced"; exit 1; }
+          ALTOOL_LOG=$(mktemp)
           xcrun altool --upload-app \
             --type ios \
             --file "$IPA" \
             --apiKey "$API_KEY_ID" \
-            --apiIssuer "$API_ISSUER_ID"
+            --apiIssuer "$API_ISSUER_ID" 2>&1 | tee "$ALTOOL_LOG"
+          if grep -q '^[[:space:]]*[0-9-]\+\s\+[0-9:.]\+\s\+ERROR:' "$ALTOOL_LOG" \
+             || grep -q 'Failed to upload' "$ALTOOL_LOG"; then
+            echo "::error::altool reported an upload failure — Apple did NOT accept the build."
+            echo "::error::Check the log above for details (common causes: duplicate cfBundleVersion, missing entitlements, expired profile)."
+            exit 1
+          fi
 
       - name: Upload archive on failure
         if: failure()

--- a/NakedPantreeApp/Resources/Info.plist
+++ b/NakedPantreeApp/Resources/Info.plist
@@ -18,8 +18,18 @@
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
     <string>0.1.0</string>
+    <!-- Build number flows from `CURRENT_PROJECT_VERSION` so CI can
+         override per-run (`GITHUB_RUN_NUMBER` in
+         `.github/workflows/testflight-beta.yml`). Hardcoding a literal
+         here is what caused two silent TestFlight rejections in
+         issue #92's wake — every upload landed as build "1", which
+         was lower than the build "10" already on file. Local builds
+         get `CURRENT_PROJECT_VERSION = 1` from Xcode defaults; CI
+         gets the run number. Marketing version
+         (`CFBundleShortVersionString`) above stays a literal; bump it
+         by hand on milestone changes. -->
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <!--
         Standard export-compliance exemption: Naked Pantree uses only
         Apple-provided system encryption (HTTPS via URLSession,


### PR DESCRIPTION
## Summary

Two silent TestFlight rejections after #92 merged — the manual-signing fix worked, but the build never actually reached Apple's beta channel:

1. **\`Info.plist\` hardcoded \`CFBundleVersion = 1\`.** Xcode's \`CURRENT_PROJECT_VERSION=\$GITHUB_RUN_NUMBER\` cmdline override only propagates to plist values that use \`\$(CURRENT_PROJECT_VERSION)\` substitution, not literal strings. Every CI archive baked in build "1", which Apple rejected as ≤ the existing build "10" already on file.
2. **\`xcrun altool\` exits 0 on Apple-side rejection.** Logs \`ERROR:\` lines but doesn't propagate via exit code, so \`set -euo pipefail\` didn't catch it. The step showed green in GitHub Actions.

Net effect: zero TestFlight builds since #92 merged, despite four "successful" runs.

## Fixes

- **\`Info.plist\`** — \`CFBundleVersion\` now \`\$(CURRENT_PROJECT_VERSION)\`. Verified locally with \`xcodebuild ... CURRENT_PROJECT_VERSION=99 archive\` and \`plutil\` on the produced \`.app\` — output \`"CFBundleVersion" => "99"\`. Local Debug builds without the override get \`1\` from Xcode defaults (unchanged daily-dev behaviour).
- **\`testflight-beta.yml\` upload step** — tees altool output, greps for \`ERROR:\` / \`Failed to upload\`, exits 1 with a GitHub Actions \`::error::\` annotation. Apple rejections now fail loudly.

## Test plan

- [x] Local archive: \`xcodebuild ... CURRENT_PROJECT_VERSION=99 archive\` → produced .app's Info.plist shows \`CFBundleVersion = 99\`.
- [ ] After merge: workflow_dispatch on \`main\` → run lands a build on TestFlight with \`CFBundleVersion\` matching \`GITHUB_RUN_NUMBER\` (will be 19+).
- [ ] (Negative test, optional later) Re-run the same workflow without changing anything else → second run rejected by Apple, step now FAILS instead of going green.

Refs #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)