### PR TITLE
sharing: bump #90 trace to .notice + log share-button tap

### DIFF
--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -80,8 +80,11 @@ struct SettingsView: View {
                     // needing to attach a debugger.
                     Color.clear
                         .onAppear {
+                            let householdState = household != nil ? "set" : "nil"
+                            let sharingState = householdSharing != nil ? "set" : "nil"
                             Self.logger.error(
-                                "share sheet presented but if-let failed — household=\(household != nil ? "set" : "nil", privacy: .public) sharing=\(householdSharing != nil ? "set" : "nil", privacy: .public)"
+                                // swiftlint:disable:next line_length
+                                "share sheet presented but if-let failed — household=\(householdState, privacy: .public) sharing=\(sharingState, privacy: .public)"
                             )
                         }
                 }
@@ -112,8 +115,11 @@ struct SettingsView: View {
                     // possible signal that the user actually tapped.
                     // `notice` level so the message is visible in
                     // Console.app without enabling Info messages.
+                    let householdState = household != nil ? "set" : "nil"
+                    let sharingState = householdSharing != nil ? "set" : "nil"
                     Self.logger.notice(
-                        "share button tapped — household=\(household != nil ? "set" : "nil", privacy: .public) sharing=\(householdSharing != nil ? "set" : "nil", privacy: .public)"
+                        // swiftlint:disable:next line_length
+                        "share button tapped — household=\(householdState, privacy: .public) sharing=\(sharingState, privacy: .public)"
                     )
                     isPresentingShareSheet = true
                 } label: {

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import NakedPantreeDomain
 import SwiftUI
+import os
 
 /// User-level Settings screen. Phase 9.3 introduced the reminder-time
 /// picker; Phase 10.1 (issue #60) folds household management in next to
@@ -34,6 +35,18 @@ struct SettingsView: View {
     @State private var household: Household?
     @State private var isPresentingShareSheet = false
 
+    /// Trace for #90 (blank Share Household sheet on TestFlight).
+    /// Same subsystem/category as `CloudSharingControllerView` and
+    /// `CloudHouseholdSharingService` so a single Console.app filter
+    /// — `subsystem:cc.mnmlst.nakedpantree` — captures the full
+    /// share path. `notice` level so messages show without the
+    /// "Include Info Messages" toggle. Lifetime: keep until #90
+    /// is closed, then trim to whatever turns out to be load-bearing.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "sharing"
+    )
+
     var body: some View {
         @Bindable var settings = settings
         NavigationStack {
@@ -58,6 +71,19 @@ struct SettingsView: View {
                         onCompletion: { isPresentingShareSheet = false }
                     )
                     .ignoresSafeArea()
+                } else {
+                    // Diagnostic fallback for #90. If the sheet
+                    // presents but the if-let above fails, the user
+                    // sees a blank sheet — exactly the reported
+                    // symptom. The .onAppear log captures which input
+                    // was nil so the bug surfaces in Console without
+                    // needing to attach a debugger.
+                    Color.clear
+                        .onAppear {
+                            Self.logger.error(
+                                "share sheet presented but if-let failed — household=\(household != nil ? "set" : "nil", privacy: .public) sharing=\(householdSharing != nil ? "set" : "nil", privacy: .public)"
+                            )
+                        }
                 }
             }
             .task { await loadHousehold() }
@@ -82,6 +108,13 @@ struct SettingsView: View {
             // empty in those contexts.
             if householdSharing != nil {
                 Button {
+                    // First log line of the share path — earliest
+                    // possible signal that the user actually tapped.
+                    // `notice` level so the message is visible in
+                    // Console.app without enabling Info messages.
+                    Self.logger.notice(
+                        "share button tapped — household=\(household != nil ? "set" : "nil", privacy: .public) sharing=\(householdSharing != nil ? "set" : "nil", privacy: .public)"
+                    )
                     isPresentingShareSheet = true
                 } label: {
                     Label("Share Household", systemImage: "person.crop.circle.badge.plus")

--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -47,19 +47,19 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
     nonisolated private static let prepareShareTimeout: Duration = .seconds(60)
 
     func makeUIViewController(context: Context) -> UICloudSharingController {
-        Self.logger.info("makeUIViewController: creating UICloudSharingController")
+        Self.logger.notice("makeUIViewController: creating UICloudSharingController")
         let controller = UICloudSharingController { _, completion in
             // The controller calls this on the main queue once it's
             // ready to show participant UI. We race `prepareShare`
             // against a timeout (#90) so a hang surfaces as an error
             // alert instead of a blank sheet.
-            Self.logger.info("preparation handler fired — racing prepareShare against timeout")
+            Self.logger.notice("preparation handler fired — racing prepareShare against timeout")
             Task {
                 let outcome = await runPrepareShareWithTimeout()
                 await MainActor.run {
                     switch outcome {
                     case .success(let payload):
-                        Self.logger.info("preparation handler: completion(share, container, nil)")
+                        Self.logger.notice("preparation handler: completion(share, container, nil)")
                         completion(payload.share, payload.container, nil)
                     case .failure(let error):
                         let description = error.localizedDescription

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
@@ -49,25 +49,25 @@ public final class CloudHouseholdSharingService: @unchecked Sendable {
     public func prepareShare(
         for householdID: Household.ID
     ) async throws -> (CKShare, CKContainer) {
-        Self.logger.info("prepareShare start: \(householdID, privacy: .public)")
+        Self.logger.notice("prepareShare start: \(householdID, privacy: .public)")
         let object = try await householdManagedObject(for: householdID)
-        Self.logger.info("got household managed object")
+        Self.logger.notice("got household managed object")
         let share: CKShare
         if let existing = try existingShare(for: object) {
-            Self.logger.info("returning existing share")
+            Self.logger.notice("returning existing share")
             share = existing
         } else {
-            Self.logger.info("calling NSPersistentCloudKitContainer.share")
+            Self.logger.notice("calling NSPersistentCloudKitContainer.share")
             // `share(_:to:)` returns `(Set<NSManagedObject>, CKShare, CKContainer)`.
             // We only want the share — the modified objects are already
             // persisted by the API, and the container is the same one
             // the caller injected.
             let result = try await container.share([object], to: nil)
-            Self.logger.info("container.share returned a new CKShare")
+            Self.logger.notice("container.share returned a new CKShare")
             share = result.1
         }
         share[CKShare.SystemFieldKey.title] = "Naked Pantree"
-        Self.logger.info("prepareShare complete")
+        Self.logger.notice("prepareShare complete")
         return (share, cloudKitContainer)
     }
 


### PR DESCRIPTION
## Summary

Build-19 capture showed zero \`subsystem:cc.mnmlst.nakedpantree\` entries in Console.app even after the "Include Info Messages" toggle. Two issues stacked on top of each other:

1. **\`Logger.info\` is *info* level — frequently suppressed on iOS device logs.** Promoted every existing call to \`Logger.notice\` (default level, always visible).
2. **The blank sheet's most likely cause is *upstream* of \`CloudSharingControllerView\`.** \`SettingsView\`'s \`.sheet\` body has \`if let household, let sharing = householdSharing { … }\` — if either binding is nil at present time, the sheet renders empty and \`makeUIViewController\` is never called. Added two new logs to catch this:
   - **Button tap** (in \`SettingsView\`) — logs the state of \`household\` and \`householdSharing\` at the moment of tap. Earliest possible signal that the user actually invoked the path.
   - **If-let-failed fallback** — replaced the silent empty branch with a \`Color.clear\`/.onAppear that error-logs which binding was nil.

If both new logs land in Console next time, we know exactly which case is happening on TestFlight.

## Test plan

- [x] Local archive succeeds (verified)
- [ ] After merge: post-merge TestFlight run uploads build 20+
- [ ] Install on iPhone, tap **Share Household**, capture Console with \`subsystem:cc.mnmlst.nakedpantree\` filter
- [ ] Expect at minimum the \"share button tapped\" line; the rest of the trace tells us exactly where the bug lives

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)