### PR TITLE
sharing: hand UICloudSharingController the CKContainer share() actually minted in

### DIFF
--- a/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
@@ -53,22 +53,30 @@ public final class CloudHouseholdSharingService: @unchecked Sendable {
         let object = try await householdManagedObject(for: householdID)
         Self.logger.notice("got household managed object")
         let share: CKShare
+        // `share(_:to:)` returns `(Set<NSManagedObject>, CKShare, CKContainer)`.
+        // The third element is the CKContainer the system actually used for
+        // the share — even though it has the same identifier as the one we
+        // pre-built, `UICloudSharingController` reportedly refuses to render
+        // when handed a different `CKContainer` instance than the one the
+        // share was minted in (#90 theory 2). Capture it here and return it
+        // to the caller; only fall back to the injected `cloudKitContainer`
+        // for the existing-share branch where no `share(_:to:)` result is
+        // available.
+        let resolvedContainer: CKContainer
         if let existing = try existingShare(for: object) {
             Self.logger.notice("returning existing share")
             share = existing
+            resolvedContainer = cloudKitContainer
         } else {
             Self.logger.notice("calling NSPersistentCloudKitContainer.share")
-            // `share(_:to:)` returns `(Set<NSManagedObject>, CKShare, CKContainer)`.
-            // We only want the share — the modified objects are already
-            // persisted by the API, and the container is the same one
-            // the caller injected.
             let result = try await container.share([object], to: nil)
             Self.logger.notice("container.share returned a new CKShare")
             share = result.1
+            resolvedContainer = result.2
         }
         share[CKShare.SystemFieldKey.title] = "Naked Pantree"
         Self.logger.notice("prepareShare complete")
-        return (share, cloudKitContainer)
+        return (share, resolvedContainer)
     }
 
     /// Resolves the household domain id to its `NSManagedObject` on a


### PR DESCRIPTION
## Summary

#90 theory 2 (per advisor). \`NSPersistentCloudKitContainer.share(_:to:)\` returns \`(Set<NSManagedObject>, CKShare, CKContainer)\` — and even though that third \`CKContainer\` carries the same identifier as the \`CKContainer(identifier:)\` we pre-built at app init, \`UICloudSharingController\` has been observed in the wild to refuse to render when handed a *different instance* than the share was minted in.

This switches the new-share branch to return \`result.2\`. The existing-share branch keeps the injected container — there's no \`share()\` result there, and a previously-minted share in a prior session likely came from this same container anyway.

## Theory ranking for #90

1. **Production CloudKit schema not deployed** — most likely root cause; user-side check in iCloud Dashboard, no code change.
2. **Wrong CKContainer returned** — fixed in this PR (real bug regardless).
3. **\`aps-environment = development\` in production entitlements** — bug, but blank-sheet symptom probably comes from #1 or #2; deferring.
4. **MainActor.run deadlock in completion handler** — only suspect if logs show prep complete but no \`completion(...)\` line.

## Test plan

- [x] Lint + local archive succeed.
- [ ] After merge: build 21+ uploads. Install. Tap Share Household. Capture Console with \`subsystem:cc.mnmlst.nakedpantree\`.
  - Sheet populates → fixed by this PR. Close #90.
  - Sheet still blank → user verifies CloudKit Dashboard schema deploy state for the next iteration.

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)