### PR TITLE
fix: aps-environment=production in NakedPantree.entitlements

### DIFF
--- a/NakedPantreeApp/Resources/NakedPantree.entitlements
+++ b/NakedPantreeApp/Resources/NakedPantree.entitlements
@@ -2,8 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!--
+        Production push environment. The "Github Publish" provisioning
+        profile authorizes `production` (verified via `security cms -D
+        -i Github_Publish.mobileprovision | plutil -extract Entitlements`),
+        and TestFlight / App Store distribution requires it for APNs
+        delivery to work — `development` would route to the dev APNs
+        server which won't deliver to a production-signed binary.
+        Apple's auto-provisioning was silently fixing this when we
+        used `-allowProvisioningUpdates` (issue #92); manual signing
+        surfaced the latent mismatch. The Debug entitlements file
+        (`NakedPantreeDev.entitlements`) keeps `development` because
+        Xcode-Run debug builds use the dev APNs server.
+    -->
     <key>aps-environment</key>
-    <string>development</string>
+    <string>production</string>
     <key>com.apple.developer.icloud-container-identifiers</key>
     <array>
         <string>iCloud.cc.mnmlst.nakedpantree</string>


### PR DESCRIPTION
## Summary

The "Github Publish" provisioning profile authorizes \`aps-environment=production\`, but the production entitlements file specified \`development\`. With manual signing (issue #92) codesign embeds whatever the entitlements file says, so the TestFlight binary was running with the *development* APNs entitlement.

**Real-world impact:**
- APNs refuses to deliver push tokens to a production-distributed binary running with \`aps-environment=development\` ⇒ no push token ⇒ broken push delivery
- CKShare invitation delivery rides APNs ⇒ share-related ops may hang
- Any future push-notification feature would silently not work on App Store / TestFlight

Apple's auto-provisioning under \`-allowProvisioningUpdates\` had been silently fixing this; manual signing surfaced the latent mismatch.

## Verified

Profile entitlements (\`security cms -D -i Github_Publish.mobileprovision | plutil -extract Entitlements xml1 -o -\`):
\`\`\`
<key>aps-environment</key>
<string>production</string>
\`\`\`

App entitlements file (was):
\`\`\`
<key>aps-environment</key>
<string>development</string>   <!-- mismatch -->
\`\`\`

After this PR, both agree on \`production\`.

## Note on #90

Whether this is the **#90 root cause is not yet confirmed.** Pending \`.notice\`-level Console.app capture from build 21 to see where the share trace dies. Shipped as an independent known-bug fix; if logs show the share path completes and the sheet still renders blank, this is a sidequest rather than a cure. Either way it's a real bug — not safe to leave on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)