### PR TITLE
test: reinstate prepareShare-householdNotFound runtime test

### DIFF
--- a/NakedPantreeTests/Persistence/HouseholdSharingServiceTests.swift
+++ b/NakedPantreeTests/Persistence/HouseholdSharingServiceTests.swift
@@ -1,45 +1,79 @@
+import CloudKit
+import CoreData
 import Foundation
 import Testing
 
+@testable import NakedPantreeDomain
 @testable import NakedPantreePersistence
 
-/// Unit-level coverage for the share-preparation path. Phase 3 sharing
-/// shipped without any automated coverage — see `SharingUITests` for
-/// the UI-level smoke test, and `StubHouseholdSharingServiceTests` for
-/// the stub coverage.
+/// Unit-level coverage for the share-preparation path. See
+/// `SharingUITests` for the UI smoke test against
+/// `UICloudSharingController` and `StubHouseholdSharingServiceTests`
+/// for stub-output assertions. These exercise the parts of the
+/// production `CloudHouseholdSharingService` that don't require a
+/// real iCloud account to round-trip — primarily, the lookup branch
+/// of `prepareShare`, which throws before any CloudKit API call.
 ///
-/// **Why this file is intentionally light:** the lookup branch of
-/// `CloudHouseholdSharingService.prepareShare` calls
-/// `NSPersistentCloudKitContainer.performBackgroundTask` which on a
-/// `CODE_SIGNING_ALLOWED=NO` simulator binary (the CI configuration)
-/// hangs the test runner — confirmed by the apps#98 diagnostic run,
-/// which produced `[CK] Significant issue ... missing entitlement`
-/// followed by "Restarting after unexpected exit, crash, or test
-/// timeout." The ~28-second hang is correlated with CloudKit pre-flight
-/// against a binary lacking `com.apple.developer.icloud-services`.
-///
-/// Reinstating the lookup test requires either: (a) refactoring
-/// `CloudHouseholdSharingService.init` to take `NSPersistentContainer`
-/// (parent class) and downcast at the CK call sites, or (b) running the
-/// test against a code-signed simulator binary in CI. Tracked as a
-/// follow-up to #90 — for now, the conformance check below + the
-/// UI test in `SharingUITests` + the stub tests cover the realistic
-/// surface.
+/// History: this file was trimmed to a compile-time conformance
+/// check in apps#99 because the runtime test below hung
+/// `NSPersistentCloudKitContainer.performBackgroundTask` for ~28s on
+/// the unsigned simulator binary (CK pre-flight requires
+/// `com.apple.developer.icloud-services`). apps#101 fixed that by
+/// signing the test binary in CI with the same cert + profile the
+/// TestFlight workflow uses, so the test below runs again.
 @Suite("Household sharing service")
 struct HouseholdSharingServiceTests {
+    /// Build an `NSPersistentCloudKitContainer` backed by a `/dev/null`
+    /// SQLite store *without* a `cloudKitContainerOptions` configured —
+    /// the container then behaves as a plain Core Data store and the
+    /// lookup branch of `prepareShare` runs end-to-end without a real
+    /// iCloud account. (We can't drive `share(_:to:)`'s happy path
+    /// from a unit test even with signing — that needs an iCloud
+    /// account, which CI doesn't have. See DEVELOPMENT.md §6.)
+    private static func makeUnsharedContainer() throws -> NSPersistentCloudKitContainer {
+        let container = NSPersistentCloudKitContainer(
+            name: "NakedPantree",
+            managedObjectModel: CoreDataStack.model
+        )
+        let description = NSPersistentStoreDescription()
+        description.type = NSSQLiteStoreType
+        description.url = URL(fileURLWithPath: "/dev/null")
+        description.shouldAddStoreAsynchronously = false
+        // Explicitly nil — without this the description picks up the
+        // default CloudKit options and a CI runner without iCloud
+        // can fail to load the store.
+        description.cloudKitContainerOptions = nil
+        container.persistentStoreDescriptions = [description]
+        var loadError: Error?
+        container.loadPersistentStores { _, error in loadError = error }
+        if let loadError {
+            throw loadError
+        }
+        container.viewContext.mergePolicy = CoreDataStack.defaultMergePolicy
+        return container
+    }
+
+    @Test("prepareShare throws householdNotFound when row is absent")
+    func householdNotFoundError() async throws {
+        let container = try Self.makeUnsharedContainer()
+        let service = CloudHouseholdSharingService(
+            container: container,
+            cloudKitContainer: CKContainer(identifier: "iCloud.cc.mnmlst.nakedpantree.test")
+        )
+        // Random UUID — guaranteed not in the empty store. The lookup
+        // throws before any CloudKit API call, so this works without
+        // an iCloud account.
+        let unknownID = UUID()
+        await #expect(throws: HouseholdSharingError.householdNotFound) {
+            _ = try await service.prepareShare(for: unknownID)
+        }
+    }
+
     @Test("CloudHouseholdSharingService conforms to HouseholdSharingService")
     func conformance() throws {
-        // No need to load a real container — this test is purely a
-        // compile-time assertion that the protocol seam holds.
-        // Constructing the class would trigger the simulator hang
-        // described in the file-level comment, even without exercising
-        // any methods.
-        func acceptsServiceProtocol(_ service: any HouseholdSharingService) {}
-        // We can't instantiate `CloudHouseholdSharingService` without
-        // a real container — but if the type doesn't conform to
-        // `HouseholdSharingService`, this expression won't compile.
+        // Compile-time assertion — if this fails to type-check the
+        // protocol seam is broken.
         let metatype: any HouseholdSharingService.Type = CloudHouseholdSharingService.self
         _ = metatype
-        _ = acceptsServiceProtocol
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to apps#101. Reinstates the runtime test that was trimmed in apps#99 because of the CK pre-flight hang on unsigned simulator binaries. Now that build-test signs the test binary properly, the test runs end-to-end and exercises the actual code path that hung before.

## What this test catches

\`prepareShare\` must throw \`HouseholdSharingError.householdNotFound\` when the requested household id isn't present. This is the lookup-error branch, which runs before any CloudKit API call — works without an iCloud account.

## What this still doesn't cover

- Real \`share(_:to:)\` happy path → requires real iCloud account; CI doesn't have one
- Real \`fetchShares\` → same
- Round-trip CKShare creation → same

That's the deliberate boundary documented in DEVELOPMENT.md §6 (TODO).

## Test plan

- [x] Lint clean
- [ ] CI: \`HouseholdSharingServiceTests\` passes both \`householdNotFoundError\` and \`conformance\` cases
- [ ] CI: no "Restarting after unexpected exit" in the test session log

🤖 Generated with [Claude Code](https://claude.com/claude-code)