### PR TITLE
test: cover withTaskGroup timeout race in CloudSharingControllerView

### DIFF
--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -76,11 +76,18 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
     }
 
     /// Runs `prepareShare(for:)` on the actor-isolated service, racing
-    /// it against `prepareShareTimeout`. Whichever wins wins; the
-    /// loser is cancelled. Returns the outcome as a value so the
-    /// caller can dispatch onto MainActor in one place.
-    private func runPrepareShareWithTimeout() async -> Result<SharePayload, Error> {
-        let timeout = Self.prepareShareTimeout
+    /// it against `timeout`. Whichever wins wins; the loser is
+    /// cancelled. Returns the outcome as a value so the caller can
+    /// dispatch onto MainActor in one place.
+    ///
+    /// `internal` (not `private`) so
+    /// `CloudSharingControllerViewTimeoutRaceTests` can drive it
+    /// directly with a small timeout. Production callers omit
+    /// `timeout` and pick up the 60s default from
+    /// `prepareShareTimeout`.
+    func runPrepareShareWithTimeout(
+        timeout: Duration = Self.prepareShareTimeout
+    ) async -> Result<SharePayload, Error> {
         let householdID = householdID
         let sharing = sharing
         return await withTaskGroup(of: Result<SharePayload, Error>.self) { group in
@@ -108,13 +115,16 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
     /// Tuple-shaped payload kept as a struct so the `Result.success`
     /// destructure at the call site is a single binding (sidesteps the
     /// swift-format / swiftlint disagreement on multi-bound `let` /
-    /// `case let` forms).
-    private struct SharePayload {
+    /// `case let` forms). `internal` so the race-test suite can match
+    /// against it.
+    struct SharePayload {
         let share: CKShare
         let container: CKContainer
     }
 
-    private struct SharingTimeoutError: LocalizedError {
+    /// `internal` so the race-test suite can `is`-check the failure
+    /// type from `runPrepareShareWithTimeout`.
+    struct SharingTimeoutError: LocalizedError {
         var errorDescription: String? {
             // Surfaced to the user by `UICloudSharingController`'s own
             // alert — keep terse and actionable.

--- a/NakedPantreeTests/CloudSharingControllerViewTimeoutRaceTests.swift
+++ b/NakedPantreeTests/CloudSharingControllerViewTimeoutRaceTests.swift
@@ -1,0 +1,124 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import NakedPantree
+@testable import NakedPantreeDomain
+@testable import NakedPantreePersistence
+
+/// Coverage for `CloudSharingControllerView.runPrepareShareWithTimeout` —
+/// the `withTaskGroup` race that backs the #90 timeout safety net. A
+/// regression here would silently break the "blank sheet eventually
+/// surfaces an error" guarantee, so the race wins on three axes are
+/// each pinned down:
+///
+/// - Service resolves before timeout → `.success`
+/// - Service hangs longer than timeout → `.failure(SharingTimeoutError)`
+/// - Service throws before timeout → `.failure(<underlying error>)`
+///
+/// Each test uses a small timeout (~100ms) so the suite finishes
+/// fast; the production default of 60s is overridden via the
+/// `timeout:` parameter.
+@Suite("CloudSharingControllerView timeout race")
+struct CloudSharingControllerViewTimeoutRaceTests {
+    @Test("Service resolves before timeout — returns .success")
+    @MainActor
+    func happyPath() async throws {
+        let view = CloudSharingControllerView(
+            householdID: UUID(),
+            sharing: StubHouseholdSharingService(),
+            onCompletion: {}
+        )
+        let result = await view.runPrepareShareWithTimeout(timeout: .seconds(5))
+        switch result {
+        case .success:
+            break
+        case .failure(let error):
+            Issue.record("Expected success, got failure: \(error)")
+        }
+    }
+
+    @Test("Service hangs longer than timeout — returns SharingTimeoutError")
+    @MainActor
+    func timeoutWins() async throws {
+        let view = CloudSharingControllerView(
+            householdID: UUID(),
+            sharing: HangingSharingService(),
+            onCompletion: {}
+        )
+        let result = await view.runPrepareShareWithTimeout(timeout: .milliseconds(100))
+        switch result {
+        case .success:
+            Issue.record("Expected timeout, got success")
+        case .failure(let error):
+            #expect(
+                error is CloudSharingControllerView.SharingTimeoutError,
+                "Expected SharingTimeoutError, got: \(type(of: error))"
+            )
+        }
+    }
+
+    @Test("Service throws — returns the underlying error, not a timeout")
+    @MainActor
+    func errorPropagates() async throws {
+        let view = CloudSharingControllerView(
+            householdID: UUID(),
+            sharing: ThrowingSharingService(),
+            onCompletion: {}
+        )
+        let result = await view.runPrepareShareWithTimeout(timeout: .seconds(5))
+        switch result {
+        case .success:
+            Issue.record("Expected failure, got success")
+        case .failure(let error):
+            #expect(
+                error is RaceTestSharingError,
+                "Expected RaceTestSharingError, got: \(type(of: error))"
+            )
+        }
+    }
+}
+
+// MARK: - Test stubs
+
+/// Stub that hangs forever via cancellable `Task.sleep`. The
+/// surrounding `withTaskGroup.cancelAll()` will cancel this task once
+/// the timeout sibling wins — `Task.sleep` throws `CancellationError`,
+/// the `do/catch` in `runPrepareShareWithTimeout` converts it to
+/// `.failure(CancellationError)`, but that result is the *loser* and
+/// is discarded by the group's `next()`-then-cancel pattern.
+private struct HangingSharingService: HouseholdSharingService {
+    func prepareShare(
+        for householdID: UUID
+    ) async throws -> (CKShare, CKContainer) {
+        try await Task.sleep(for: .seconds(60))
+        // Unreachable on cancellation — but Swift requires a return
+        // path. Constructing junk here is fine; we never actually
+        // emit it.
+        let zoneID = CKRecordZone.ID(
+            zoneName: "unreachable",
+            ownerName: CKCurrentUserDefaultName
+        )
+        let recordID = CKRecord.ID(
+            recordName: "unreachable",
+            zoneID: zoneID
+        )
+        let record = CKRecord(recordType: "Unreachable", recordID: recordID)
+        return (
+            CKShare(rootRecord: record),
+            CKContainer(identifier: "iCloud.unreachable")
+        )
+    }
+}
+
+/// Distinct error type so the assertion can `is`-check it precisely
+/// rather than matching any error.
+private struct RaceTestSharingError: Error {}
+
+private struct ThrowingSharingService: HouseholdSharingService {
+    func prepareShare(
+        for householdID: UUID
+    ) async throws -> (CKShare, CKContainer) {
+        throw RaceTestSharingError()
+    }
+}


### PR DESCRIPTION
## Summary

Pin down the \`withTaskGroup\` race in \`CloudSharingControllerView.runPrepareShareWithTimeout\` — the #90 timeout safety net that prevents a hung CloudKit \`prepareShare\` from leaving the user staring at an indefinitely blank sheet. A regression in the race logic would silently break that guarantee.

Three tests, total ~100ms:

| Scenario | Stub | Expected |
|---|---|---|
| Service resolves before timeout | \`StubHouseholdSharingService\` (instant return) | \`.success\` |
| Service hangs longer than timeout | \`HangingSharingService\` (\`Task.sleep 60s\`) | \`.failure(SharingTimeoutError)\` |
| Service throws before timeout | \`ThrowingSharingService\` (immediate throw) | \`.failure(RaceTestSharingError)\` |

Each test passes a small \`timeout:\` parameter (~100ms) so the suite stays fast; production callers omit it and pick up the 60s default.

## Visibility changes

To reach the function from \`@testable import NakedPantree\`:

- \`runPrepareShareWithTimeout\` → \`internal\` (was \`private\`)
- \`SharePayload\` → \`internal\` (was \`private\`)
- \`SharingTimeoutError\` → \`internal\` (was \`private\`)
- \`runPrepareShareWithTimeout\` gains an optional \`timeout: Duration\` parameter with default \`Self.prepareShareTimeout\`. Production call site (\`makeUIViewController\`) calls without the parameter — behavior unchanged.

Net: the production code path is byte-identical at runtime; only the access-control surface changed.

## Test plan

- [x] Local: \`xcodebuild test ... -only-testing 'NakedPantreeTests/CloudSharingControllerViewTimeoutRaceTests'\` runs all 3 in 0.103s
- [x] Lint clean
- [ ] CI: signed Debug build runs the suite alongside the existing tests

Refs #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)