### PR TITLE
test(account-status): cover CKAccountStatus → AccountStatus mapping (#112)

### DIFF
--- a/NakedPantreeApp/App/AccountStatusMonitor.swift
+++ b/NakedPantreeApp/App/AccountStatusMonitor.swift
@@ -72,7 +72,11 @@ final class AccountStatusMonitor {
         }
     }
 
-    private static func map(_ raw: CKAccountStatus) -> AccountStatus {
+    /// `internal` (not `private`) so `AccountStatusMonitorMappingTests`
+    /// can pin every `CKAccountStatus → AccountStatus` case directly
+    /// (issue #112). Pure function with no dependencies; opening it
+    /// up costs nothing at the type's usage surface.
+    static func map(_ raw: CKAccountStatus) -> AccountStatus {
         switch raw {
         case .available: .available
         case .noAccount: .noAccount

--- a/NakedPantreeApp/App/AccountStatusMonitor.swift
+++ b/NakedPantreeApp/App/AccountStatusMonitor.swift
@@ -72,11 +72,14 @@ final class AccountStatusMonitor {
         }
     }
 
-    /// `internal` (not `private`) so `AccountStatusMonitorMappingTests`
-    /// can pin every `CKAccountStatus → AccountStatus` case directly
-    /// (issue #112). Pure function with no dependencies; opening it
-    /// up costs nothing at the type's usage surface.
-    static func map(_ raw: CKAccountStatus) -> AccountStatus {
+    /// `nonisolated internal` (not `private`) so
+    /// `AccountStatusMonitorMappingTests` can pin every
+    /// `CKAccountStatus → AccountStatus` case directly (issue #112).
+    /// Pure function with no actor-dependent state; the enclosing
+    /// class is `@MainActor` only because of the published `status`
+    /// property and the `task` lifecycle. The mapping itself doesn't
+    /// touch either.
+    nonisolated static func map(_ raw: CKAccountStatus) -> AccountStatus {
         switch raw {
         case .available: .available
         case .noAccount: .noAccount

--- a/NakedPantreeTests/AccountStatusMonitorMappingTests.swift
+++ b/NakedPantreeTests/AccountStatusMonitorMappingTests.swift
@@ -1,0 +1,65 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import NakedPantree
+
+/// Coverage for `AccountStatusMonitor.map(_:)` — the pure
+/// `CKAccountStatus → AccountStatus` mapping that drives the iCloud
+/// banner and the Share Household button visibility. Issue #112.
+///
+/// This is a static function with no side effects, so a regression
+/// here would silently misclassify the user's iCloud state — a
+/// no-account user could see no banner, or an available user could
+/// see a "couldn't reach iCloud" banner. Pinned by case so any future
+/// edit produces an explicit test failure.
+@Suite("AccountStatusMonitor mapping")
+struct AccountStatusMonitorMappingTests {
+    @Test("CKAccountStatus.available maps to .available")
+    func availableMapsToAvailable() {
+        #expect(AccountStatusMonitor.map(.available) == .available)
+    }
+
+    @Test("CKAccountStatus.noAccount maps to .noAccount")
+    func noAccountMapsToNoAccount() {
+        #expect(AccountStatusMonitor.map(.noAccount) == .noAccount)
+    }
+
+    @Test("CKAccountStatus.restricted maps to .restricted")
+    func restrictedMapsToRestricted() {
+        #expect(AccountStatusMonitor.map(.restricted) == .restricted)
+    }
+
+    @Test("CKAccountStatus.couldNotDetermine maps to .couldNotDetermine")
+    func couldNotDetermineMapsToCouldNotDetermine() {
+        #expect(AccountStatusMonitor.map(.couldNotDetermine) == .couldNotDetermine)
+    }
+
+    @Test("CKAccountStatus.temporarilyUnavailable maps to .temporarilyUnavailable")
+    func temporarilyUnavailableMapsToTemporarilyUnavailable() {
+        #expect(AccountStatusMonitor.map(.temporarilyUnavailable) == .temporarilyUnavailable)
+    }
+
+    @Test("Every AccountStatus has a deterministic round-trip mapping")
+    func everyCaseRoundTrips() {
+        // Sanity check covering the @unknown default — if Apple adds a
+        // new CKAccountStatus case, the switch must explicitly handle
+        // it. The current default falls through to .couldNotDetermine.
+        // We can't construct an unknown case in test (the enum is
+        // closed at compile time for known values), but this loop
+        // pins the behavior for every known case in one place.
+        let cases: [(CKAccountStatus, AccountStatus)] = [
+            (.available, .available),
+            (.noAccount, .noAccount),
+            (.restricted, .restricted),
+            (.couldNotDetermine, .couldNotDetermine),
+            (.temporarilyUnavailable, .temporarilyUnavailable),
+        ]
+        for (raw, expected) in cases {
+            #expect(
+                AccountStatusMonitor.map(raw) == expected,
+                "CKAccountStatus(\(raw)) should map to AccountStatus.\(expected)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #112. Adds direct test coverage for \`AccountStatusMonitor.map(_:)\` — the pure function that drives the iCloud banner and Share Household button visibility.

A regression in this mapping would misclassify the user's iCloud state — e.g., a no-account user could see no banner, or an available user could see "couldn't reach iCloud." Pure-function logic with no test coverage is a bad combination; this PR fixes it.

## Changes

- \`map(_:)\` visibility: \`private static\` → \`static\` (internal). Pure function, no dependencies; broadening for \`@testable import\` access costs nothing.
- 6 tests pinning each \`CKAccountStatus\` case + a round-trip loop that pins all known cases in one place. The \`@unknown default\` is documented but can't be constructed in test (closed enum at compile time).

## Out of scope (tracked separately)

- The \`.couldNotDetermine\`-on-throw fallback inside \`refresh(using:)\` requires a protocol seam over \`CKContainer.accountStatus()\` — bigger refactor, separate PR.

## Test plan

- [x] Lint clean
- [ ] CI: 6 mapping tests pass (signed Debug build)

Refs #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)