### PR TITLE
chore(remote-change): log + cover history-fetch failure path (#114)

### DIFF
--- a/NakedPantreeApp/App/RemoteChangeMonitor.swift
+++ b/NakedPantreeApp/App/RemoteChangeMonitor.swift
@@ -1,6 +1,7 @@
 import CoreData
 import NakedPantreePersistence
 import SwiftUI
+import os
 
 /// Bumps `changeToken` whenever the persistence layer reports a
 /// non-self-emitted remote change — local writes by another household
@@ -219,11 +220,15 @@ final class RemoteChangeMonitor {
     /// `NSManagedObjectModel`.
     /// `Sendable` wrapper around the input token to `fetchHistory`. See
     /// `HistoryFetchOutcome` for the same `@unchecked Sendable` rationale.
-    private struct SendableHistoryToken: @unchecked Sendable {
+    /// `internal` (not `private`) so `RemoteChangeMonitorFailureTests`
+    /// can construct one for the failure-path test (issue #114).
+    struct SendableHistoryToken: @unchecked Sendable {
         let token: NSPersistentHistoryToken?
     }
 
-    private struct HistoryFetchOutcome: @unchecked Sendable {
+    /// `internal` (not `private`) so the failure-path test can read
+    /// the `failed` flag on the returned outcome (issue #114).
+    struct HistoryFetchOutcome: @unchecked Sendable {
         var newToken: NSPersistentHistoryToken?
         var hasNonLocal: Bool
         var failed: Bool
@@ -255,9 +260,24 @@ final class RemoteChangeMonitor {
     /// negative filter). Anything we didn't stamp ourselves is, by
     /// definition, not us.
     ///
+    /// Logger for history-fetch failures (issue #114). The execute call
+    /// can throw on a corrupt history store, a token from a wiped
+    /// store, or a schema-skew window after a Core Data migration.
+    /// Pre-#114 the failure was swallowed silently and the next
+    /// refresh re-ran the same range forever; logging at least makes
+    /// it discoverable in Console.app under
+    /// `subsystem:cc.mnmlst.nakedpantree, category:remote-change`.
+    nonisolated private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "remote-change"
+    )
+
     /// `nonisolated` so the continuation closure can call into it from
     /// the Core Data queue without crossing the MainActor boundary.
-    nonisolated private static func fetchHistory(
+    /// `internal` (not `private`) so `RemoteChangeMonitorFailureTests`
+    /// can drive the failure branch directly with a context that
+    /// rejects `NSPersistentHistoryChangeRequest`.
+    nonisolated static func fetchHistory(
         after token: SendableHistoryToken,
         in context: NSManagedObjectContext
     ) async -> HistoryFetchOutcome {
@@ -287,6 +307,15 @@ final class RemoteChangeMonitor {
                         )
                     )
                 } catch {
+                    // Pre-#114 silent swallow. The token is *not*
+                    // updated, so `refresh()` will re-fetch the same
+                    // range on the next remote-change tick — at
+                    // worst, redundant CPU until the underlying error
+                    // resolves (history store re-initializes,
+                    // migration completes, etc.).
+                    Self.logger.error(
+                        "history fetch failed: \(error.localizedDescription, privacy: .public)"
+                    )
                     continuation.resume(returning: .failure)
                 }
             }

--- a/NakedPantreeTests/RemoteChangeMonitorFailureTests.swift
+++ b/NakedPantreeTests/RemoteChangeMonitorFailureTests.swift
@@ -1,0 +1,72 @@
+import CoreData
+import Foundation
+import Testing
+
+@testable import NakedPantree
+@testable import NakedPantreePersistence
+
+/// Coverage for `RemoteChangeMonitor.fetchHistory`'s failure path —
+/// issue #114. Pre-#114 this branch was a silent swallow that left
+/// `lastHistoryToken` unchanged and re-ran the same range on every
+/// subsequent remote-change tick. apps#125 added an
+/// `os.Logger.error` so the failure is at least discoverable in
+/// Console.app, and pinned the behavior with the tests below.
+///
+/// The existing `RemoteChangeMonitorTests` covers happy-path filter
+/// logic; this file complements it with the negative branch.
+@Suite("RemoteChangeMonitor failure path")
+struct RemoteChangeMonitorFailureTests {
+    /// Build a Core Data context backed by a SQLite store *without*
+    /// `NSPersistentHistoryTrackingKey` enabled. Fetching persistent
+    /// history against such a store throws — the exact behavior the
+    /// failure branch was written for.
+    private static func makeContextWithoutHistoryTracking() throws -> NSManagedObjectContext {
+        let container = NSPersistentContainer(
+            name: "NakedPantree",
+            managedObjectModel: CoreDataStack.model
+        )
+        let description = NSPersistentStoreDescription()
+        description.type = NSSQLiteStoreType
+        description.url = URL(fileURLWithPath: "/dev/null")
+        description.shouldAddStoreAsynchronously = false
+        // Deliberately omit:
+        //   description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        // Without it, the store rejects history-fetch requests.
+        container.persistentStoreDescriptions = [description]
+        var loadError: Error?
+        container.loadPersistentStores { _, error in loadError = error }
+        if let loadError {
+            throw loadError
+        }
+        return container.newBackgroundContext()
+    }
+
+    @Test("fetchHistory returns .failure when history tracking is disabled")
+    func failureBranchSetsFailedFlag() async throws {
+        let context = try Self.makeContextWithoutHistoryTracking()
+        let outcome = await RemoteChangeMonitor.fetchHistory(
+            after: RemoteChangeMonitor.SendableHistoryToken(token: nil),
+            in: context
+        )
+        #expect(outcome.failed == true)
+        #expect(outcome.newToken == nil)
+        #expect(outcome.hasNonLocal == false)
+    }
+
+    @Test("fetchHistory failure produces a log entry under cc.mnmlst.nakedpantree/remote-change")
+    func failureBranchLogs() async throws {
+        // The Logger output is captured by the unified log; we can't
+        // assert against it from inside the test process without
+        // OSLogStore (which requires entitlements not granted to the
+        // simulator). What we *can* pin is that the failure path runs
+        // to completion without hanging or crashing — which is the
+        // pre-#114 silent-swallow behavior plus the new log call.
+        // The actual log line is verifiable manually via Console.app.
+        let context = try Self.makeContextWithoutHistoryTracking()
+        let outcome = await RemoteChangeMonitor.fetchHistory(
+            after: RemoteChangeMonitor.SendableHistoryToken(token: nil),
+            in: context
+        )
+        #expect(outcome.failed == true)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #114 (the failure-path piece — the burst-refresh race turned out to be benign in practice, see below).

Pre-#114, \`RemoteChangeMonitor.fetchHistory\` swallowed any error from \`NSPersistentHistoryChangeRequest.execute\` silently. The failure path returned \`.failure\`, the token was *not* persisted, and the next \`refresh()\` re-ran the same range — repeating the failure forever in cases like a corrupt history store, a token from a wiped store, or a schema-skew window post-migration. No log, no telemetry, no signal.

## Changes

1. **Add `os.Logger.error`** on the catch branch under \`subsystem:cc.mnmlst.nakedpantree, category:remote-change\`. The failure is now discoverable via Console.app. Behavior otherwise unchanged — \`refresh()\` still no-ops cleanly on failure, the token still doesn't update.

2. **Visibility relax** for `fetchHistory`, `SendableHistoryToken`, `HistoryFetchOutcome` (private → internal) so the failure branch can be driven directly from tests. Two tests:
   - Failure branch sets `outcome.failed = true`, `newToken = nil`, `hasNonLocal = false`
   - Failure path runs to completion (proxy for the log call — `OSLogStore` access requires entitlements not granted to the simulator, so we can't directly assert the log entry from inside the test process)

## Burst-refresh race (deferred)

Agent 2's review of #114 also flagged a burst-refresh race: two concurrent `refresh()` calls reading the same `previousToken`. On closer inspection, this is benign in practice — concurrent calls fetch the same superset of transactions and write the same new token. Wasted CPU, not data loss. Deferring serialization until/unless a real symptom surfaces.

## Test plan

- [x] Lint clean
- [ ] CI: 2 failure-path tests pass (signed Debug build)

Refs #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)