### PR TITLE
fix(notifications): publish pendingItemID before tap completion (#119)

### DIFF
--- a/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
+++ b/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
@@ -74,13 +74,27 @@ final class NakedPantreeAppDelegate:
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
-        defer { completionHandler() }
+        let userInfo = response.notification.request.content.userInfo
         guard
-            let id = notificationItemID(from: response.notification.request.content.userInfo),
+            let id = notificationItemID(from: userInfo),
             let routing = Self.notificationRouting
-        else { return }
+        else {
+            completionHandler()
+            return
+        }
+        // #119: previously this method used `defer { completionHandler() }`,
+        // which signalled "done" before the `Task { @MainActor in }` had
+        // a chance to publish `pendingItemID`. Two consecutive taps could
+        // interleave on MainActor and the *earlier* tap could win the
+        // routing slot, dropping the user's most recent intent. Call
+        // `completionHandler()` AFTER the publish: the Task is enqueued
+        // on MainActor before this nonisolated method returns, and
+        // tasks awaiting the same actor honour FIFO arrival order, so
+        // tap A's Task runs before tap B's Task and `pendingItemID`
+        // ends up matching the last tap.
         Task { @MainActor in
             routing.pendingItemID = id
+            completionHandler()
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #119. Pre-#119, the tap-handler used \`defer { completionHandler() }\` so the system saw "done" before the \`Task { @MainActor in }\` published \`pendingItemID\`. Two consecutive taps could interleave and the earlier tap could win the routing slot, dropping the user's most recent intent.

## Fix

Remove the defer. Call \`completionHandler()\` inside the @MainActor Task after the publish. Tasks enqueued on MainActor honour FIFO arrival order, so tap A's Task runs before tap B's Task and the user sees the most recent tap's destination.

The early-return paths (malformed payload, no routing service wired) call \`completionHandler()\` immediately — no Task needed. The "static-var seam not yet wired" branch is still a known no-op; the full pre-init queueing fix lives in #108.

## Test plan

- [x] Lint clean
- [ ] CI: existing notification tests still pass
- Behavioral verification (burst-tap ordering) is hard to unit-test without a real UNUserNotificationCenter delivery path; the comment in code documents the FIFO-on-MainActor reasoning

Refs #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)