### PR TITLE
test(persistence): add MultiStoreFixture for two-store CloudKit testing (#111)

### DIFF
--- a/NakedPantreeTests/Persistence/MultiStoreFixture.swift
+++ b/NakedPantreeTests/Persistence/MultiStoreFixture.swift
@@ -1,0 +1,102 @@
+import CoreData
+import Foundation
+
+@testable import NakedPantreePersistence
+
+/// Test fixture mirroring the production two-store layout
+/// (`<name>-private.sqlite` + `<name>-shared.sqlite`) without
+/// requiring a real iCloud account. Issue #111.
+///
+/// Why this exists: `CoreDataStack.cloudKitContainer(...)` (the
+/// production stack) sets up two `NSPersistentStoreDescription`s with
+/// `cloudKitContainerOptions` configured for `.private` and `.shared`
+/// scopes. Repository code (`CoreDataLocationRepository.assignToParentStore`,
+/// `CoreDataItemRepository.assignToParentStore`,
+/// `CoreDataItemPhotoRepository.assignToParentStore`) and
+/// `HouseholdRepository.currentHousehold`'s shared-store-preferred
+/// branch all depend on the two stores being distinguishable by URL
+/// pattern via `CoreDataStack.privateCloudKitStore(in:)` /
+/// `CoreDataStack.sharedCloudKitStore(in:)`. None of that surface
+/// area was reachable from the existing single-store
+/// `inMemoryContainer()` test fixture.
+///
+/// Strategy: real SQLite files in a per-instance unique directory
+/// under `NSTemporaryDirectory()`. The filenames carry the
+/// `-private.sqlite` / `-shared.sqlite` suffixes the production
+/// helpers key off, so a fixture-backed `NSPersistentCloudKitContainer`
+/// looks identical to the production stack from the repositories'
+/// point of view. `cloudKitContainerOptions` is left `nil` so the
+/// framework doesn't try to mirror against a non-existent iCloud
+/// account; locally-saved data still routes correctly between
+/// stores.
+///
+/// Cleanup happens via `cleanup()` (call from a Swift Testing
+/// `@Test`'s `defer` or a tear-down block) or implicitly at process
+/// exit if the test runner crashes — `NSTemporaryDirectory()` is
+/// system-cleared.
+final class MultiStoreFixture {
+    let container: NSPersistentCloudKitContainer
+    private let baseDirectory: URL
+
+    init(name: String = "NakedPantree") throws {
+        let unique = UUID().uuidString
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("nakedpantree-multi-store-\(unique)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        self.baseDirectory = directory
+
+        let privateURL = directory.appendingPathComponent("\(name)-private.sqlite")
+        let sharedURL = directory.appendingPathComponent("\(name)-shared.sqlite")
+
+        let container = NSPersistentCloudKitContainer(
+            name: name,
+            managedObjectModel: CoreDataStack.model
+        )
+        container.persistentStoreDescriptions = [
+            Self.makeDescription(url: privateURL),
+            Self.makeDescription(url: sharedURL),
+        ]
+
+        var loadErrors: [Error] = []
+        container.loadPersistentStores { _, error in
+            if let error { loadErrors.append(error) }
+        }
+        if let firstError = loadErrors.first {
+            throw firstError
+        }
+
+        container.viewContext.mergePolicy = CoreDataStack.defaultMergePolicy
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        self.container = container
+    }
+
+    /// Removes the fixture's per-instance directory. Idempotent.
+    /// Call from a `defer` block at the top of each test that uses
+    /// the fixture so files don't accumulate across runs.
+    func cleanup() {
+        try? FileManager.default.removeItem(at: baseDirectory)
+    }
+
+    /// `NSPersistentStoreDescription` configured the same way the
+    /// production stack does (`CoreDataStack.makeDescription(...)`),
+    /// minus `cloudKitContainerOptions` — the test fixture is
+    /// local-only.
+    private static func makeDescription(url: URL) -> NSPersistentStoreDescription {
+        let description = NSPersistentStoreDescription(url: url)
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
+        description.shouldAddStoreAsynchronously = false
+        description.setOption(
+            true as NSNumber,
+            forKey: NSPersistentHistoryTrackingKey
+        )
+        description.setOption(
+            true as NSNumber,
+            forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey
+        )
+        return description
+    }
+}

--- a/NakedPantreeTests/Persistence/MultiStoreFixtureTests.swift
+++ b/NakedPantreeTests/Persistence/MultiStoreFixtureTests.swift
@@ -1,0 +1,61 @@
+import CoreData
+import Foundation
+import Testing
+
+@testable import NakedPantreePersistence
+
+/// Sanity coverage for the `MultiStoreFixture` itself (issue #111) —
+/// every test that depends on the fixture's correctness benefits from
+/// pinning the invariants in one place.
+@Suite("MultiStoreFixture")
+struct MultiStoreFixtureTests {
+    @Test("Both stores load and live at distinct, expected URLs")
+    func bothStoresLoad() throws {
+        let fixture = try MultiStoreFixture()
+        defer { fixture.cleanup() }
+
+        let stores = fixture.container.persistentStoreCoordinator.persistentStores
+        #expect(stores.count == 2)
+
+        let urls = stores.compactMap(\.url).map(\.lastPathComponent)
+        #expect(urls.contains("NakedPantree-private.sqlite"))
+        #expect(urls.contains("NakedPantree-shared.sqlite"))
+    }
+
+    @Test("CoreDataStack.privateCloudKitStore(in:) finds the private store")
+    func privateStoreLookup() throws {
+        let fixture = try MultiStoreFixture()
+        defer { fixture.cleanup() }
+
+        let privateStore = CoreDataStack.privateCloudKitStore(in: fixture.container)
+        #expect(privateStore != nil)
+        #expect(privateStore?.url?.lastPathComponent == "NakedPantree-private.sqlite")
+    }
+
+    @Test("CoreDataStack.sharedCloudKitStore(in:) finds the shared store")
+    func sharedStoreLookup() throws {
+        let fixture = try MultiStoreFixture()
+        defer { fixture.cleanup() }
+
+        let sharedStore = CoreDataStack.sharedCloudKitStore(in: fixture.container)
+        #expect(sharedStore != nil)
+        #expect(sharedStore?.url?.lastPathComponent == "NakedPantree-shared.sqlite")
+    }
+
+    @Test("Cleanup removes the per-instance directory")
+    func cleanupRemovesDirectory() throws {
+        let fixture = try MultiStoreFixture()
+        let urls = fixture.container.persistentStoreCoordinator.persistentStores
+            .compactMap(\.url)
+        #expect(urls.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+
+        fixture.cleanup()
+        // Files are gone, but the persistent stores still hold references
+        // — `urls` was captured pre-cleanup. Verify by checking the
+        // parent directory itself was removed.
+        let parentDirectory = urls.first?.deletingLastPathComponent()
+        if let parentDirectory {
+            #expect(FileManager.default.fileExists(atPath: parentDirectory.path) == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #111. Adds a test-only \`MultiStoreFixture\` that mirrors the production two-store layout (\`<name>-private.sqlite\` + \`<name>-shared.sqlite\`) so test code can exercise repository paths that depend on \`CoreDataStack.privateCloudKitStore(in:)\` / \`sharedCloudKitStore(in:)\` URL-pattern lookups.

## Why

Existing single-store \`inMemoryContainer()\` tests can't reach:

- \`CoreDataHouseholdRepository.swift:29-44\` — shared-store-preferred branch
- \`CoreDataLocationRepository.swift:132-143\`, \`CoreDataItemRepository.swift:158-169\`, \`CoreDataItemPhotoRepository.swift:103-114\` — \`assignToParentStore\` cross-store routing fallbacks
- \`CloudHouseholdSharingService.existingShare\` (covered next in #115)
- The duplicate-Kitchen partial-import scenario (covered in #110)

## Strategy

Real SQLite files in a per-instance unique directory under \`NSTemporaryDirectory()\`. Filenames carry the \`-private.sqlite\` / \`-shared.sqlite\` suffixes the production helpers key off — fixture-backed container looks identical to production from the repositories' POV.

\`cloudKitContainerOptions\` left \`nil\`: local-only, no iCloud round-trip needed.

\`cleanup()\` opt-in via \`defer\`; \`NSTemporaryDirectory()\` is system-cleared as a safety net.

## Tests

4 sanity tests pin the fixture's invariants:
- Both stores load at distinct expected URLs
- \`privateCloudKitStore(in:)\` finds the private store
- \`sharedCloudKitStore(in:)\` finds the shared store
- Cleanup removes the per-instance directory

## Unblocks

- #115 — \`CloudHouseholdSharingService.existingShare\` branch test
- #110 — first-launch partial-import duplicate Kitchen scenario

Refs #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)