### PR TITLE
test(rootview): extract RemoteChangeWaiter for testability (#116)

### DIFF
--- a/NakedPantreeApp/App/RemoteChangeWaiter.swift
+++ b/NakedPantreeApp/App/RemoteChangeWaiter.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Pure-function home for `RootView.makeRemoteChangeWaiter`'s
+/// closure body, lifted out for testability (issue #116).
+///
+/// **Why this lives at file scope, not on `RootView`:**
+/// `RootView` is `@MainActor`-isolated and its body is hard to
+/// reach from `@testable import`. Extracting here gives us a
+/// pure function that takes its dependencies as closures — a
+/// `RemoteChangeMonitor`'s `isObserving` flag, an
+/// `AccountStatusMonitor`'s `.available` predicate, and a
+/// change-token reader — so tests can drive every gate (no-op
+/// monitor, account unavailable, token bump, cancellation) with
+/// stubbed values.
+///
+/// The production closure in `RootView` constructs three closures
+/// from its environment monitors and forwards to `wait(...)`.
+enum RemoteChangeWaiter {
+    /// Wait for the remote-change monitor's token to advance, or
+    /// for the surrounding task to be cancelled — whichever comes
+    /// first. Returns once one of these gates trips:
+    ///
+    /// 1. `isObserving()` returns `false` — no-op monitor (preview /
+    ///    snapshot / EMPTY_STORE / unit-test-host paths). Returns
+    ///    immediately so bootstrap doesn't burn its timeout in
+    ///    those configurations where a token bump will never come.
+    /// 2. `accountStatusIsAvailable()` returns `false` — iCloud
+    ///    isn't reachable, so the CloudKit mirror won't deliver
+    ///    notifications. Same fast-fail rationale.
+    /// 3. `changeToken()` advances past `initial` — the actual
+    ///    "remote change observed" condition.
+    /// 4. `Task.isCancelled` becomes `true` — bootstrap's timeout
+    ///    fired and is racing us; honour it.
+    ///
+    /// The polling interval (~75ms) is short enough that the
+    /// monitor's 120ms debounce dominates wakeup latency anyway.
+    static func wait(
+        isObserving: @Sendable () -> Bool,
+        accountStatusIsAvailable: @Sendable () async -> Bool,
+        changeToken: @Sendable () async -> UUID,
+        pollInterval: Duration = .milliseconds(75)
+    ) async {
+        guard isObserving() else { return }
+        guard await accountStatusIsAvailable() else { return }
+        let initial = await changeToken()
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: pollInterval)
+            } catch {
+                return
+            }
+            let current = await changeToken()
+            if current != initial { return }
+        }
+    }
+}

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -156,28 +156,20 @@ struct RootView: View {
         let monitor = remoteChangeMonitor
         let statusMonitor = accountStatusMonitor
         return {
-            // No-op monitor (preview / snapshot / EMPTY_STORE / unit
-            // test host paths) → no remote-change tick will ever
-            // arrive. Skip the wait so bootstrap falls through to
-            // create immediately rather than burning the timeout
-            // every cold launch in those configurations.
-            guard monitor.isObserving else { return }
-            let isAvailable = await MainActor.run { statusMonitor.status == .available }
-            guard isAvailable else { return }
-            let initial = await MainActor.run { monitor.changeToken }
-            // Poll every ~75ms until the token bumps or the task is
-            // cancelled by the bootstrap timeout. The monitor's own
-            // 120ms debounce dominates the worst-case wakeup latency
-            // anyway — a tighter poll buys nothing real.
-            while !Task.isCancelled {
-                do {
-                    try await Task.sleep(for: .milliseconds(75))
-                } catch {
-                    return
+            // The wait logic itself lives in `RemoteChangeWaiter.wait`
+            // for testability (#116). This closure just bridges the
+            // SwiftUI environment monitors into the function's
+            // closure parameters, hopping to MainActor for each
+            // observable read.
+            await RemoteChangeWaiter.wait(
+                isObserving: { monitor.isObserving },
+                accountStatusIsAvailable: {
+                    await MainActor.run { statusMonitor.status == .available }
+                },
+                changeToken: {
+                    await MainActor.run { monitor.changeToken }
                 }
-                let current = await MainActor.run { monitor.changeToken }
-                if current != initial { return }
-            }
+            )
         }
     }
 

--- a/NakedPantreeTests/RemoteChangeWaiterTests.swift
+++ b/NakedPantreeTests/RemoteChangeWaiterTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import NakedPantree
+
+/// Coverage for `RemoteChangeWaiter.wait` — the bootstrap-deferred
+/// "wait for the first remote-change tick or bail" closure that
+/// `RootView.makeRemoteChangeWaiter` previously held inline (issue
+/// #116). A regression in any of the three gates (no-op monitor
+/// fast-fail, account-unavailable fast-fail, token-advance return)
+/// or the cancellation handling would silently keep the splash
+/// screen up past the bootstrap timeout, or worse, never let
+/// bootstrap proceed.
+@Suite("RemoteChangeWaiter")
+struct RemoteChangeWaiterTests {
+    @Test("Returns immediately when isObserving() is false (no-op monitor)")
+    func notObservingReturnsImmediately() async throws {
+        // Both fall-through closures `Issue.record` if invoked —
+        // when isObserving returns false, neither should be called.
+        await RemoteChangeWaiter.wait(
+            isObserving: { false },
+            accountStatusIsAvailable: {
+                Issue.record("should not be called when not observing")
+                return true
+            },
+            changeToken: {
+                Issue.record("should not be called when not observing")
+                return UUID()
+            }
+        )
+    }
+
+    @Test("Returns immediately when account status is not .available")
+    func unavailableAccountReturnsImmediately() async throws {
+        await RemoteChangeWaiter.wait(
+            isObserving: { true },
+            accountStatusIsAvailable: { false },
+            changeToken: {
+                Issue.record("should not be called when account is unavailable")
+                return UUID()
+            }
+        )
+    }
+
+    @Test("Returns when changeToken advances")
+    func tokenAdvanceReturns() async throws {
+        // Counter ticks per call. First read = initial; subsequent
+        // reads return a different UUID once `bumped == true`.
+        let bumped = AtomicBool(false)
+        let initial = UUID()
+        let bumpedID = UUID()
+        // Bump after a short delay so the polling loop sees it.
+        Task {
+            try? await Task.sleep(for: .milliseconds(20))
+            bumped.value = true
+        }
+
+        let start = Date()
+        await RemoteChangeWaiter.wait(
+            isObserving: { true },
+            accountStatusIsAvailable: { true },
+            changeToken: { bumped.value ? bumpedID : initial },
+            pollInterval: .milliseconds(10)
+        )
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(elapsed < 1.0, "Waiter should return promptly after the bump.")
+    }
+
+    @Test("Returns when the surrounding task is cancelled")
+    func cancellationReturns() async throws {
+        let waiter = Task {
+            await RemoteChangeWaiter.wait(
+                isObserving: { true },
+                accountStatusIsAvailable: { true },
+                // Stable token — without cancellation, this would loop forever.
+                changeToken: { UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) },
+                pollInterval: .milliseconds(10)
+            )
+        }
+        // Give the waiter a chance to enter the loop.
+        try? await Task.sleep(for: .milliseconds(30))
+        waiter.cancel()
+        // `await waiter.value` returns once the waiter exits. If
+        // cancellation isn't honoured, this hangs the test until
+        // Swift Testing's per-test timeout kicks in.
+        let start = Date()
+        await waiter.value
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(elapsed < 1.0, "Cancelled waiter should return promptly.")
+    }
+}
+
+/// Tiny `Sendable` mutable holder so the closures in
+/// `tokenAdvanceReturns` can flip a flag mid-test. Avoiding a full
+/// actor since the test logic is straightforward and the lock is
+/// trivial.
+private final class AtomicBool: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Bool
+
+    init(_ initial: Bool) {
+        storage = initial
+    }
+
+    var value: Bool {
+        get { lock.withLock { storage } }
+        set { lock.withLock { storage = newValue } }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #116. Extracts \`RootView.makeRemoteChangeWaiter\`'s closure body into a free function \`RemoteChangeWaiter.wait(...)\` so its three gates and cancellation handling can be unit-tested.

## Why

The pre-#116 closure held three subtle gates inline (no-op-monitor fast-fail, account-unavailable fast-fail, token-advance return) plus cancellation handling. None of it was reachable from \`@testable import\` — the closure was nested inside a \`@MainActor\` view method whose body is hard to drive from XCUITest. \`BootstrapServiceTests\` injected its own waiter, leaving the production closure with zero coverage.

## Changes

- New \`RemoteChangeWaiter\` enum (file scope) with a single \`wait(isObserving:accountStatusIsAvailable:changeToken:pollInterval:)\` static function.
- \`RootView.makeRemoteChangeWaiter\` now bridges SwiftUI environment monitors into the function's closure parameters — no logic.
- Production behavior is identical: same MainActor hops (now inside the bridging closures), same default 75ms poll, same cancellation handling.

## Tests

4 tests pinning every branch:
- \`notObservingReturnsImmediately\` — \`isObserving=false\` short-circuits before either fall-through closure runs
- \`unavailableAccountReturnsImmediately\` — account-status gate fails without reading the change token
- \`tokenAdvanceReturns\` — bumps the token after a delay, asserts return within 1s
- \`cancellationReturns\` — \`task.cancel()\` mid-wait returns promptly via the \`Task.sleep\` throw

## Test plan

- [x] Lint clean
- [x] Local build clean
- [ ] CI: 4 waiter tests pass

Refs #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)