### PR TITLE
fix(items): partial updateQuantity to fix stepper-vs-form-save race (#118)

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -341,16 +341,22 @@ struct ItemDetailView: View {
             quantityModel = QuantityStepperModel(
                 initialQuantity: fetched.quantity,
                 persist: { newQuantity in
-                    // Re-fetch under the actor so we don't write a
-                    // stale `name` / `expiresAt` if those were
-                    // edited in another window. If the row vanished
-                    // between tap and write, drop the update — the
-                    // detail view's reload will catch up.
-                    guard var current = try await repository.item(id: fetched.id) else {
-                        return
-                    }
-                    current.quantity = newQuantity
-                    try await repository.update(current)
+                    // Issue #118: use the partial-update API so a
+                    // long-press burst can't race an edit-form save
+                    // and overwrite `name` / `expiresAt`. The previous
+                    // shape did fetch-modify-save of the whole `Item`,
+                    // which read stale fields in the window between a
+                    // form save and the stepper persist.
+                    // `updateQuantity` is atomic at the repository
+                    // layer — it touches only the quantity column. If
+                    // the row was deleted between debounce schedule
+                    // and persist, the implementation no-ops (same
+                    // shape as `update(_:)`'s missing-row semantics)
+                    // and the detail view's reload catches up.
+                    try await repository.updateQuantity(
+                        id: fetched.id,
+                        quantity: newQuantity
+                    )
                 },
                 onPersistFailure: {
                     Task { await reload() }

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -333,6 +333,81 @@ struct ItemRepositoryContractTests {
     }
 
     @Test(
+        "updateQuantity changes only quantity, leaves name and expiresAt untouched (#118)",
+        arguments: RepositoryFactory.all)
+    func updateQuantityIsPartial(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let expiry = Date(timeIntervalSince1970: 1_000_000)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Yogurt",
+            quantity: 1,
+            unit: .count,
+            expiresAt: expiry,
+            notes: "Plain greek"
+        )
+        try await itemRepo.create(item)
+
+        // Issue #118: updateQuantity must NOT touch name / expiresAt /
+        // notes / unit / locationID. The original race was a stepper
+        // persist overwriting these fields after a form save.
+        try await itemRepo.updateQuantity(id: item.id, quantity: 7)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.quantity == 7)
+        #expect(after.name == "Yogurt")
+        #expect(after.expiresAt == expiry)
+        #expect(after.notes == "Plain greek")
+        #expect(after.unit == .count)
+        #expect(after.locationID == kitchen.id)
+    }
+
+    @Test(
+        "updateQuantity is a no-op when the item id doesn't exist",
+        arguments: RepositoryFactory.all)
+    func updateQuantityMissingIDIsNoOp(factory: RepositoryFactory) async throws {
+        let itemRepo = factory.make().item
+        // Random UUID — not in the empty repo. Should silently no-op,
+        // matching `update(_:)`'s missing-row semantics.
+        try await itemRepo.updateQuantity(id: UUID(), quantity: 99)
+    }
+
+    @Test(
+        "updateQuantity stamps updatedAt",
+        arguments: RepositoryFactory.all)
+    func updateQuantityStampsTimestamp(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let originalDate = Date(timeIntervalSince1970: 1)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Sourdough",
+            createdAt: originalDate,
+            updatedAt: originalDate
+        )
+        try await itemRepo.create(item)
+
+        try await itemRepo.updateQuantity(id: item.id, quantity: 5)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.createdAt == originalDate)
+        #expect(after.updatedAt > originalDate)
+    }
+
+    @Test(
         "search matches case-insensitively and trims empty queries",
         arguments: RepositoryFactory.all)
     func searchMatchesAndTrims(factory: RepositoryFactory) async throws {

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -151,6 +151,16 @@ public actor InMemoryItemRepository: ItemRepository {
         items[item.id] = stamped
     }
 
+    public func updateQuantity(id: Item.ID, quantity: Int32) async throws {
+        // Issue #118: partial update — touch only `quantity` and
+        // stamp `updatedAt`. The actor's serial isolation makes
+        // this atomic against concurrent `update(_:)` calls.
+        guard var existing = items[id] else { return }
+        existing.quantity = quantity
+        existing.updatedAt = Date()
+        items[id] = existing
+    }
+
     public func delete(id: Item.ID) async throws {
         items.removeValue(forKey: id)
     }

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -58,6 +58,20 @@ public protocol ItemRepository: Sendable {
     func search(_ query: String, in householdID: Household.ID) async throws -> [Item]
     func create(_ item: Item) async throws
     func update(_ item: Item) async throws
+    /// Partial update that touches only `quantity` (and stamps
+    /// `updatedAt`), leaving every other attribute untouched. Issue
+    /// #118: `QuantityStepperModel.persist` previously did a full
+    /// fetch-modify-save round-trip, which races edit-form saves of
+    /// `name` / `expiresAt` — the stepper's fetch could see a stale
+    /// value the form had just changed and overwrite it. This is the
+    /// atomic alternative; implementations write `quantity` directly
+    /// to the store row without round-tripping through an `Item`
+    /// value type the caller mutates.
+    ///
+    /// No-op if the item doesn't exist (deleted between debounce
+    /// schedule and persist) — same shape as `update(_:)`'s
+    /// silent-skip semantics on a missing row.
+    func updateQuantity(id: Item.ID, quantity: Int32) async throws
     func delete(id: Item.ID) async throws
 }
 

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
@@ -109,6 +109,21 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         }
     }
 
+    public func updateQuantity(id: Item.ID, quantity: Int32) async throws {
+        // Issue #118: partial update — touch only `quantity` and
+        // `updatedAt` on the row. Avoids round-tripping through an
+        // `Item` value the caller mutates, which races edit-form
+        // saves of `name` / `expiresAt` (the form's just-saved value
+        // could be overwritten by a stepper persist that fetched
+        // before the form's save landed).
+        try await container.performBackgroundTaskWithDefaults { context in
+            guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
+            row.setValue(quantity, forKey: "quantity")
+            row.setValue(Date(), forKey: "updatedAt")
+            try context.save()
+        }
+    }
+
     public func delete(id: Item.ID) async throws {
         try await container.performBackgroundTaskWithDefaults { context in
             guard let row = try Self.fetchItemRow(id: id, in: context) else { return }


### PR DESCRIPTION
## Summary

Closes #118. Real bug from the research synthesis (Agent 2, race #8a):

\`QuantityStepperModel.persist\` previously did a full \`fetch → modify → update\` round-trip. A long-press burst on the stepper plus a concurrent edit-form save of \`name\` / \`expiresAt\` could race — the stepper's fetch read pre-form-save values, the persist's full-item update overwrote the form's just-saved fields. Symptom: edit form save lands during a long-press → name silently reverts.

## Fix

- Add \`ItemRepository.updateQuantity(id:quantity:)\` protocol method.
- \`InMemoryItemRepository\` implementation: actor-isolated, atomic.
- \`CoreDataItemRepository\` implementation: \`performBackgroundTaskWithDefaults\` + \`setValue\` on the row's \`quantity\` / \`updatedAt\` keys. Other attributes untouched.
- \`ItemDetailView\` persist closure switches to the new API. The fetch+full-save dance is gone.

## Tests (in \`RepositoryContractTests\`, parameterised over both impls)

- \`updateQuantityIsPartial\` — pins that name / expiresAt / notes / unit / locationID are unchanged
- \`updateQuantityMissingIDIsNoOp\` — silent no-op on a deleted item
- \`updateQuantityStampsTimestamp\` — \`updatedAt\` advances so observers still see the bump

## Test plan

- [x] \`xcodegen generate\` clean
- [x] \`xcodebuild build-for-testing\` clean
- [x] \`./scripts/lint.sh\` clean
- [ ] CI: 3 new contract tests pass on both InMemory and CoreData factories

Refs #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)