### PR TITLE
fix(bootstrap): wait for locations sync before seeding Kitchen (#110)

### DIFF
--- a/NakedPantreeApp/App/BootstrapService.swift
+++ b/NakedPantreeApp/App/BootstrapService.swift
@@ -55,12 +55,54 @@ struct BootstrapService: Sendable {
     }
 
     func bootstrapIfNeeded() async throws {
-        let house = try await resolvePrivateHousehold()
-        let existing = try await location.locations(in: house.id)
+        let resolution = try await resolvePrivateHousehold()
+        var existing = try await location.locations(in: resolution.household.id)
+
+        // Issue #110: locations ride a separate CloudKit transaction
+        // from the household. When this device joins an iCloud account
+        // for the first time, the household can sync down on the first
+        // remote-change tick while locations are still in flight.
+        // Pre-#110, bootstrap saw "household exists, locations empty"
+        // and seeded a Kitchen — only for the synced Kitchen to land
+        // moments later, leaving the device with two. Do a second
+        // wait when the household came from sync, so the locations
+        // collection has a chance to settle before we decide to seed.
+        if existing.isEmpty && resolution.source == .syncedDown {
+            await waitForFirstRemoteChangeOrTimeout()
+            existing = try await location.locations(in: resolution.household.id)
+        }
+
         guard existing.isEmpty else { return }
         try await location.create(
-            Location(householdID: house.id, name: "Kitchen", kind: .pantry)
+            Location(householdID: resolution.household.id, name: "Kitchen", kind: .pantry)
         )
+    }
+
+    /// Where the bootstrap obtained the private household — used by
+    /// `bootstrapIfNeeded` to decide whether to wait an extra tick
+    /// for locations to sync (issue #110).
+    enum HouseholdSource: Equatable {
+        /// Already in the local private store at launch — idempotent
+        /// re-bootstrap, or a device whose CloudKit sync has already
+        /// landed before launch. Locations are typically also already
+        /// present.
+        case localExisting
+        /// Arrived via the first remote-change tick — e.g. a second
+        /// device joining an iCloud account. Locations may still be
+        /// in flight; bootstrap waits one more tick before deciding
+        /// to seed.
+        case syncedDown
+        /// We just created it via `ensurePrivateHousehold` — first
+        /// launch ever (or offline / signed-out). No remote locations
+        /// to wait for; seed the Kitchen now.
+        case freshlyCreated
+    }
+
+    /// Outcome of `resolvePrivateHousehold` — the resolved household
+    /// plus where it came from.
+    struct HouseholdResolution: Equatable {
+        let household: Household
+        let source: HouseholdSource
     }
 
     /// Decides which household this device should bootstrap into.
@@ -74,15 +116,16 @@ struct BootstrapService: Sendable {
     ///    sync brought a household down, return it.
     /// 3. Still empty after the wait: this really is first launch
     ///    ever (or offline / signed-out), so create one.
-    private func resolvePrivateHousehold() async throws -> Household {
+    private func resolvePrivateHousehold() async throws -> HouseholdResolution {
         if let existing = try await household.existingPrivateHousehold() {
-            return existing
+            return HouseholdResolution(household: existing, source: .localExisting)
         }
         await waitForFirstRemoteChangeOrTimeout()
         if let existing = try await household.existingPrivateHousehold() {
-            return existing
+            return HouseholdResolution(household: existing, source: .syncedDown)
         }
-        return try await household.ensurePrivateHousehold()
+        let created = try await household.ensurePrivateHousehold()
+        return HouseholdResolution(household: created, source: .freshlyCreated)
     }
 
     /// Suspends until either the injected `waitForRemoteChange` closure

--- a/NakedPantreeTests/BootstrapServiceTests.swift
+++ b/NakedPantreeTests/BootstrapServiceTests.swift
@@ -156,4 +156,101 @@ struct BootstrapServiceTests {
 private actor WaitCounter {
     private(set) var value = 0
     func increment() { value += 1 }
+
+    /// Returns the pre-increment value so callers can dispatch on
+    /// "this is the Nth call" without observing their own bump.
+    func snapshotAndIncrement() -> Int {
+        let snapshot = value
+        value += 1
+        return snapshot
+    }
+}
+
+@Suite("BootstrapService — issue #110 multi-device race")
+struct BootstrapServiceMultiDeviceTests {
+    /// Models a second device joining an iCloud account: the household
+    /// arrives via the first remote-change tick, and a "Kitchen"
+    /// location arrives on a later remote-change tick. Pre-#110,
+    /// bootstrap saw "household synced, locations empty" between the
+    /// two ticks and seeded a Kitchen — duplicating once the synced
+    /// Kitchen landed. Post-#110, the second wait gives locations
+    /// time to land before bootstrap decides.
+    @Test("Two-stage sync: household arrives, then locations — no duplicate Kitchen")
+    func locationsArriveAfterHouseholdNoDuplicate() async throws {
+        let household = InMemoryHouseholdRepository()
+        let location = InMemoryLocationRepository()
+        let preExistingHousehold = Household(name: "My Pantry")
+        let preExistingKitchen = Location(
+            householdID: preExistingHousehold.id,
+            name: "Kitchen",
+            kind: .pantry
+        )
+
+        // Two-stage waiter: first call seeds the household, second call
+        // seeds the Kitchen. Mirrors the real CloudKit pattern of
+        // separate transactions per record-zone change.
+        let callCount = WaitCounter()
+        let waitForRemoteChange: @Sendable () async -> Void = {
+            let invocation = await callCount.snapshotAndIncrement()
+            try? await Task.sleep(for: .milliseconds(50))
+            switch invocation {
+            case 0:
+                try? await household.update(preExistingHousehold)
+            case 1:
+                try? await location.create(preExistingKitchen)
+            default:
+                break
+            }
+        }
+
+        let service = BootstrapService(
+            household: household,
+            location: location,
+            waitForRemoteChange: waitForRemoteChange,
+            syncWaitTimeout: .seconds(5)
+        )
+        try await service.bootstrapIfNeeded()
+
+        let locations = try await location.locations(in: preExistingHousehold.id)
+        #expect(locations.count == 1, "Bootstrap must not duplicate the synced Kitchen.")
+        #expect(locations.first?.id == preExistingKitchen.id)
+
+        // Both wait calls fired: first to bring down the household,
+        // second to give locations time to settle.
+        let waits = await callCount.value
+        #expect(waits == 2, "Bootstrap should wait twice when household arrives via sync.")
+    }
+
+    /// If the second wait elapses without locations arriving, bootstrap
+    /// proceeds to seed — assumes the user really has zero locations
+    /// (e.g. they deleted them all on the originating device).
+    @Test("Two-stage sync: household arrives, locations don't — bootstrap seeds Kitchen")
+    func locationsNeverArriveBootstrapSeeds() async throws {
+        let household = InMemoryHouseholdRepository()
+        let location = InMemoryLocationRepository()
+        let preExistingHousehold = Household(name: "My Pantry")
+
+        let callCount = WaitCounter()
+        let waitForRemoteChange: @Sendable () async -> Void = {
+            let invocation = await callCount.snapshotAndIncrement()
+            try? await Task.sleep(for: .milliseconds(20))
+            if invocation == 0 {
+                try? await household.update(preExistingHousehold)
+            }
+            // Subsequent calls intentionally do nothing — locations
+            // never sync in this test scenario.
+        }
+
+        let service = BootstrapService(
+            household: household,
+            location: location,
+            waitForRemoteChange: waitForRemoteChange,
+            syncWaitTimeout: .milliseconds(100)
+        )
+        try await service.bootstrapIfNeeded()
+
+        let locations = try await location.locations(in: preExistingHousehold.id)
+        #expect(locations.count == 1, "Bootstrap must seed Kitchen when no locations sync.")
+        #expect(locations.first?.name == "Kitchen")
+    }
 }


### PR DESCRIPTION
## Summary

Closes #110. Real bug from research synthesis.

When a second device joined an iCloud account for the first time, bootstrap could observe "household synced, locations empty" in the window between two CloudKit remote-change ticks (first tick brings the household, second brings the Kitchen). Pre-#110, bootstrap seeded a fresh Kitchen during that window — only for the synced Kitchen to land moments later. Symptom: second device ends up with two Kitchens.

## Fix

Track *where* the household came from via a new \`HouseholdSource\` enum (\`localExisting\` / \`syncedDown\` / \`freshlyCreated\`). When the locations collection is empty AND the household came via sync, do a second \`waitForFirstRemoteChangeOrTimeout\` and re-fetch before deciding to seed.

The other two source cases skip the second wait:
- \`localExisting\` — locations were already synced or genuinely empty
- \`freshlyCreated\` — no remote state exists; seed now

## Tests

In a new \`BootstrapServiceMultiDeviceTests\` suite:
- Two-stage sync (household, then Kitchen) → no duplicate, exactly one Kitchen with the synced ID, `callCount == 2`
- Two-stage sync where locations never arrive → bootstrap seeds Kitchen as fallback (matches true-first-launch user expectation)

## Test plan

- [x] Lint clean
- [x] \`xcodebuild build-for-testing\` clean
- [ ] CI: 2 new multi-device tests pass; existing 6 BootstrapService tests still pass

Refs #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)