### PR TITLE
refactor(forms): extract save coordinators + add tests (#117)

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemFormSaveCoordinator.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormSaveCoordinator.swift
@@ -1,0 +1,94 @@
+import Foundation
+import NakedPantreeDomain
+
+/// Plain-data snapshot of the editor's `@State` at save time. Keeps the
+/// coordinator free of SwiftUI state types so tests can construct one
+/// directly without `@State` ceremony.
+///
+/// `hasExpiry` + `expiresAt` mirror the form's "toggle off → no expiry"
+/// affordance: the coordinator collapses them into the optional
+/// `Item.expiresAt` exactly the way the view used to.
+struct ItemFormDraft {
+    var name: String
+    var quantity: Int32
+    var unit: NakedPantreeDomain.Unit
+    var hasExpiry: Bool
+    var expiresAt: Date
+    var notes: String
+}
+
+/// Save logic extracted from `ItemFormView` (issue #117). Lives here
+/// rather than inside the view body so the create/edit branches, the
+/// whitespace trimming, the empty-notes-to-nil collapse, and the
+/// expiry-toggle-off-clears-date semantics can be unit-tested without
+/// driving SwiftUI.
+///
+/// `@MainActor` because `NotificationScheduler` is `@MainActor`, and
+/// the post-save `scheduleIfNeeded(for:)` call has to land on its
+/// isolation. Tests run on the main actor too — `@Test` methods
+/// inherit isolation from the enclosing type when none is specified,
+/// and `@MainActor` calls are fine from a `@MainActor`-attributed
+/// `@Test` function.
+@MainActor
+enum ItemFormSaveCoordinator {
+    /// Whitespace-trim-then-empty check that mirrors what `save` does
+    /// before persisting. Pulled out as a static so the view can use
+    /// it for the save-button disable state and the predicate stays
+    /// in lock-step with what the save itself enforces.
+    static func isValid(name: String) -> Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Performs the save. Returns the persisted `Item` on success;
+    /// rethrows whatever the repository raises on failure (the form
+    /// surfaces it as the "Couldn't save. Try again." banner).
+    ///
+    /// On the create branch we mint a new `Item` with a fresh UUID and
+    /// pass it to `repository.create`; on edit we copy the original
+    /// (preserving `id`, `createdAt`, etc.) and only overwrite the
+    /// editable fields. Either way, after a successful save we hand
+    /// the persisted value to `scheduler.scheduleIfNeeded(for:)`,
+    /// which handles both the "schedule with new expiry" and
+    /// "cancel because expiry was cleared" cases idempotently.
+    static func save(
+        mode: ItemFormView.Mode,
+        draft: ItemFormDraft,
+        repository: any ItemRepository,
+        scheduler: NotificationScheduler
+    ) async throws -> Item {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = draft.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedNotes: String? = trimmedNotes.isEmpty ? nil : trimmedNotes
+        let resolvedExpiry: Date? = draft.hasExpiry ? draft.expiresAt : nil
+
+        let saved: Item
+        switch mode {
+        case .create(let locationID):
+            let item = Item(
+                locationID: locationID,
+                name: trimmedName,
+                quantity: draft.quantity,
+                unit: draft.unit,
+                expiresAt: resolvedExpiry,
+                notes: resolvedNotes
+            )
+            try await repository.create(item)
+            saved = item
+        case .edit(let original):
+            var updated = original
+            updated.name = trimmedName
+            updated.quantity = draft.quantity
+            updated.unit = draft.unit
+            updated.expiresAt = resolvedExpiry
+            updated.notes = resolvedNotes
+            try await repository.update(updated)
+            saved = updated
+        }
+        // Phase 4.1: schedule (or clear) the expiry notification off
+        // the just-persisted item. `scheduleIfNeeded` handles the
+        // nil-expiry case symmetrically with create vs edit — clearing
+        // an expiry on edit cancels the pending request.
+        await scheduler.scheduleIfNeeded(for: saved)
+        return saved
+    }
+}

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -115,7 +115,7 @@ struct ItemFormView: View {
     }
 
     private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ItemFormSaveCoordinator.isValid(name: name)
     }
 
     private func prefill() {
@@ -133,43 +133,27 @@ struct ItemFormView: View {
 
     @MainActor
     private func save() async {
-        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedNotes: String? = trimmedNotes.isEmpty ? nil : trimmedNotes
-        let resolvedExpiry: Date? = hasExpiry ? expiresAt : nil
-
+        // Issue #117: persistence + post-save scheduling now live in
+        // `ItemFormSaveCoordinator`. The view stays responsible for the
+        // SwiftUI surface (saving spinner, error banner, dismiss).
+        let draft = ItemFormDraft(
+            name: name,
+            quantity: quantity,
+            unit: unit,
+            hasExpiry: hasExpiry,
+            expiresAt: expiresAt,
+            notes: notes
+        )
         isSaving = true
         defer { isSaving = false }
 
         do {
-            let saved: Item
-            switch mode {
-            case .create(let locationID):
-                let item = Item(
-                    locationID: locationID,
-                    name: trimmedName,
-                    quantity: quantity,
-                    unit: unit,
-                    expiresAt: resolvedExpiry,
-                    notes: resolvedNotes
-                )
-                try await repositories.item.create(item)
-                saved = item
-            case .edit(let original):
-                var updated = original
-                updated.name = trimmedName
-                updated.quantity = quantity
-                updated.unit = unit
-                updated.expiresAt = resolvedExpiry
-                updated.notes = resolvedNotes
-                try await repositories.item.update(updated)
-                saved = updated
-            }
-            // Phase 4.1: schedule (or clear) the expiry notification
-            // off the just-persisted item. `scheduleIfNeeded` handles
-            // the nil-expiry case symmetrically with create vs edit —
-            // clearing an expiry on edit cancels the pending request.
-            await notificationScheduler.scheduleIfNeeded(for: saved)
+            _ = try await ItemFormSaveCoordinator.save(
+                mode: mode,
+                draft: draft,
+                repository: repositories.item,
+                scheduler: notificationScheduler
+            )
             onSaved()
             dismiss()
         } catch {

--- a/NakedPantreeApp/Features/Sidebar/LocationFormSaveCoordinator.swift
+++ b/NakedPantreeApp/Features/Sidebar/LocationFormSaveCoordinator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import NakedPantreeDomain
+
+/// Plain-data snapshot of `LocationFormView`'s editor state at save
+/// time. Same role as `ItemFormDraft` — see that type for the rationale.
+struct LocationFormDraft {
+    var name: String
+    var kind: LocationKind
+}
+
+/// Save logic extracted from `LocationFormView` (issue #117). The
+/// shape mirrors `ItemFormSaveCoordinator` minus the notification
+/// scheduler: locations don't carry expiries.
+///
+/// `@MainActor` is incidental here (no MainActor-isolated dependencies),
+/// but kept consistent with `ItemFormSaveCoordinator` so callers don't
+/// have to reason about whether the namespace they're using needs
+/// hopping or not.
+@MainActor
+enum LocationFormSaveCoordinator {
+    /// Same trim-then-empty predicate as the item form. Pulled out so
+    /// the view's save-button disable state stays in lock-step with
+    /// what the save itself enforces.
+    static func isValid(name: String) -> Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Performs the save. Returns the persisted `Location`; rethrows
+    /// repository errors so the form can surface its banner.
+    static func save(
+        mode: LocationFormView.Mode,
+        draft: LocationFormDraft,
+        repository: any LocationRepository
+    ) async throws -> Location {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch mode {
+        case .create(let householdID):
+            let location = Location(
+                householdID: householdID,
+                name: trimmedName,
+                kind: draft.kind
+            )
+            try await repository.create(location)
+            return location
+        case .edit(let original):
+            var updated = original
+            updated.name = trimmedName
+            updated.kind = draft.kind
+            try await repository.update(updated)
+            return updated
+        }
+    }
+}

--- a/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
+++ b/NakedPantreeApp/Features/Sidebar/LocationFormView.swift
@@ -93,7 +93,7 @@ struct LocationFormView: View {
     }
 
     private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        LocationFormSaveCoordinator.isValid(name: name)
     }
 
     private func prefill() {
@@ -105,21 +105,18 @@ struct LocationFormView: View {
 
     @MainActor
     private func save() async {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Issue #117: persistence lives in `LocationFormSaveCoordinator`;
+        // view keeps the spinner / banner / dismiss responsibilities.
+        let draft = LocationFormDraft(name: name, kind: kind)
         isSaving = true
         defer { isSaving = false }
 
         do {
-            switch mode {
-            case .create(let householdID):
-                let location = Location(householdID: householdID, name: trimmed, kind: kind)
-                try await repositories.location.create(location)
-            case .edit(let original):
-                var updated = original
-                updated.name = trimmed
-                updated.kind = kind
-                try await repositories.location.update(updated)
-            }
+            _ = try await LocationFormSaveCoordinator.save(
+                mode: mode,
+                draft: draft,
+                repository: repositories.location
+            )
             onSaved()
             dismiss()
         } catch {

--- a/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
+++ b/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
@@ -1,0 +1,326 @@
+import Foundation
+import Testing
+@testable import NakedPantree
+@testable import NakedPantreeDomain
+
+// MARK: - Item form
+
+@MainActor
+@Suite("ItemFormSaveCoordinator")
+struct ItemFormSaveCoordinatorTests {
+    @Test("isValid(name:) — empty / whitespace returns false")
+    func isValidEmptyAndWhitespace() {
+        #expect(!ItemFormSaveCoordinator.isValid(name: ""))
+        #expect(!ItemFormSaveCoordinator.isValid(name: "   "))
+        #expect(!ItemFormSaveCoordinator.isValid(name: "\t \n"))
+    }
+
+    @Test("isValid(name:) — non-empty (with or without padding) returns true")
+    func isValidNonEmpty() {
+        #expect(ItemFormSaveCoordinator.isValid(name: "Apples"))
+        #expect(ItemFormSaveCoordinator.isValid(name: "  Apples  "))
+    }
+
+    /// The combination test for the create branch: trims the name,
+    /// collapses whitespace-only notes to nil, drops the expiry when
+    /// `hasExpiry` is false, and persists the resulting item to the
+    /// repo. One test instead of three because the trim/collapse logic
+    /// is a single statement per field — splitting hides whether the
+    /// branches compose.
+    @Test("Create — name trimmed; whitespace-only notes → nil; toggle-off clears expiry")
+    func createTrimsCollapsesAndClearsExpiry() async throws {
+        let repo = InMemoryItemRepository()
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+        let locationID = UUID()
+
+        let draft = ItemFormDraft(
+            name: "  Sourdough  ",
+            quantity: 2,
+            unit: .count,
+            // Toggle off — even with `expiresAt` set the persisted
+            // item should land with `nil` expiry.
+            hasExpiry: false,
+            expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 30),
+            notes: "   "
+        )
+
+        let saved = try await ItemFormSaveCoordinator.save(
+            mode: .create(locationID: locationID),
+            draft: draft,
+            repository: repo,
+            scheduler: scheduler
+        )
+
+        #expect(saved.name == "Sourdough")
+        #expect(saved.notes == nil)
+        #expect(saved.expiresAt == nil)
+        #expect(saved.locationID == locationID)
+        #expect(saved.quantity == 2)
+
+        let persisted = try await repo.items(in: locationID)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.name == "Sourdough")
+        #expect(persisted.first?.notes == nil)
+    }
+
+    @Test("Create with future expiry — scheduler adds a request keyed to the item id")
+    func createWithExpiryAddsRequest() async throws {
+        let repo = InMemoryItemRepository()
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+        let locationID = UUID()
+
+        // 30 days out — comfortably past the 3-day lead window so
+        // `expiryNotificationTriggerDate` resolves a real future date
+        // and the "add" branch runs.
+        let future = Date.now.addingTimeInterval(60 * 60 * 24 * 30)
+        let draft = ItemFormDraft(
+            name: "Tomatoes",
+            quantity: 1,
+            unit: .count,
+            hasExpiry: true,
+            expiresAt: future,
+            notes: "Heirlooms"
+        )
+
+        let saved = try await ItemFormSaveCoordinator.save(
+            mode: .create(locationID: locationID),
+            draft: draft,
+            repository: repo,
+            scheduler: scheduler
+        )
+
+        #expect(saved.expiresAt == future)
+        #expect(saved.notes == "Heirlooms")
+
+        let added = center.addedRequests
+        #expect(added.count == 1)
+        #expect(added.first?.identifier == "item.\(saved.id.uuidString).expiry")
+    }
+
+    @Test("Create with hasExpiry=false — scheduler removes any prior pending request")
+    func createNoExpiryRemoves() async throws {
+        let repo = InMemoryItemRepository()
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+        let locationID = UUID()
+
+        let draft = ItemFormDraft(
+            name: "Tinned tuna",
+            quantity: 4,
+            unit: .count,
+            hasExpiry: false,
+            expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 30),
+            notes: ""
+        )
+
+        let saved = try await ItemFormSaveCoordinator.save(
+            mode: .create(locationID: locationID),
+            draft: draft,
+            repository: repo,
+            scheduler: scheduler
+        )
+
+        #expect(saved.expiresAt == nil)
+        // The nil-expiry branch in `scheduleIfNeeded` calls
+        // `removePendingNotificationRequests` for the item's identifier
+        // — even on a brand-new item, since it's idempotent and lets
+        // the scheduler stay symmetric for create vs edit.
+        let removed = center.removedIdentifiersBatches
+        #expect(removed.count == 1)
+        let expected = "item.\(saved.id.uuidString).expiry"
+        #expect(removed.first?.contains(expected) == true)
+        #expect(center.addedRequests.isEmpty)
+    }
+
+    @Test("Edit — preserves id/createdAt; updates editable fields; toggle-off cancels expiry")
+    func editPreservesIdAndCancelsOldExpiry() async throws {
+        let originalCreated = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = Item(
+            id: UUID(),
+            locationID: UUID(),
+            name: "Bread",
+            quantity: 1,
+            unit: .count,
+            expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 30),
+            notes: "Old note",
+            createdAt: originalCreated
+        )
+        let repo = InMemoryItemRepository(initial: [original])
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+
+        let draft = ItemFormDraft(
+            name: "  Sourdough  ",
+            quantity: 3,
+            unit: .package,
+            // User flipped the expiry toggle off — the persisted item
+            // should land with `nil` expiry and the scheduler should
+            // cancel the pending request keyed by the (preserved) id.
+            hasExpiry: false,
+            expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 30),
+            notes: "  fresh  "
+        )
+
+        let saved = try await ItemFormSaveCoordinator.save(
+            mode: .edit(original),
+            draft: draft,
+            repository: repo,
+            scheduler: scheduler
+        )
+
+        #expect(saved.id == original.id)
+        #expect(saved.createdAt == originalCreated)
+        #expect(saved.name == "Sourdough")
+        #expect(saved.quantity == 3)
+        #expect(saved.unit == .package)
+        #expect(saved.notes == "fresh")
+        #expect(saved.expiresAt == nil)
+
+        let expected = "item.\(original.id.uuidString).expiry"
+        let removed = center.removedIdentifiersBatches
+        // The cancellation may interleave with the protocol's own
+        // background sweeps, so use `flatMap` rather than checking
+        // a specific batch index.
+        let removedFlat = removed.flatMap { $0 }
+        #expect(removedFlat.contains(expected))
+    }
+
+    @Test("Repository error — propagates and scheduler is never called")
+    func repositoryErrorPropagates() async throws {
+        let repo = ThrowingItemRepository()
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+
+        let draft = ItemFormDraft(
+            name: "Bread",
+            quantity: 1,
+            unit: .count,
+            hasExpiry: true,
+            expiresAt: .now.addingTimeInterval(60 * 60 * 24 * 30),
+            notes: ""
+        )
+
+        await #expect(throws: FormCoordinatorTestError.self) {
+            _ = try await ItemFormSaveCoordinator.save(
+                mode: .create(locationID: UUID()),
+                draft: draft,
+                repository: repo,
+                scheduler: scheduler
+            )
+        }
+        // Scheduler intentionally runs after the repo write succeeds.
+        // A repo throw should leave both stub buckets untouched —
+        // catches a regression that swaps the order or swallows the
+        // error.
+        #expect(center.addedRequests.isEmpty)
+        #expect(center.removedIdentifiersBatches.isEmpty)
+    }
+}
+
+// MARK: - Location form
+
+@MainActor
+@Suite("LocationFormSaveCoordinator")
+struct LocationFormSaveCoordinatorTests {
+    @Test("isValid(name:) — empty/whitespace false; non-empty true")
+    func isValidPredicate() {
+        #expect(!LocationFormSaveCoordinator.isValid(name: ""))
+        #expect(!LocationFormSaveCoordinator.isValid(name: "   "))
+        #expect(LocationFormSaveCoordinator.isValid(name: "Pantry"))
+        #expect(LocationFormSaveCoordinator.isValid(name: "  Pantry "))
+    }
+
+    @Test("Create — name trimmed; kind preserved; persisted to the household")
+    func createTrimsAndPersists() async throws {
+        let repo = InMemoryLocationRepository()
+        let householdID = UUID()
+        let draft = LocationFormDraft(name: "  Garage Freezer  ", kind: .freezer)
+
+        let saved = try await LocationFormSaveCoordinator.save(
+            mode: .create(householdID: householdID),
+            draft: draft,
+            repository: repo
+        )
+
+        #expect(saved.name == "Garage Freezer")
+        #expect(saved.kind == .freezer)
+        #expect(saved.householdID == householdID)
+
+        let persisted = try await repo.locations(in: householdID)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.name == "Garage Freezer")
+        #expect(persisted.first?.kind == .freezer)
+    }
+
+    @Test("Edit — preserves id/createdAt; updates name and kind")
+    func editPreservesIdentity() async throws {
+        let originalCreated = Date(timeIntervalSince1970: 1_700_000_000)
+        let householdID = UUID()
+        let original = Location(
+            id: UUID(),
+            householdID: householdID,
+            name: "Kitchen",
+            kind: .pantry,
+            createdAt: originalCreated
+        )
+        let repo = InMemoryLocationRepository()
+        try await repo.create(original)
+
+        let draft = LocationFormDraft(name: "  Pantry Shelf  ", kind: .dryGoods)
+        let saved = try await LocationFormSaveCoordinator.save(
+            mode: .edit(original),
+            draft: draft,
+            repository: repo
+        )
+
+        #expect(saved.id == original.id)
+        #expect(saved.createdAt == originalCreated)
+        #expect(saved.name == "Pantry Shelf")
+        #expect(saved.kind == .dryGoods)
+        #expect(saved.householdID == householdID)
+    }
+
+    @Test("Repository error — propagates")
+    func repositoryErrorPropagates() async throws {
+        let repo = ThrowingLocationRepository()
+        let draft = LocationFormDraft(name: "Pantry", kind: .pantry)
+        await #expect(throws: FormCoordinatorTestError.self) {
+            _ = try await LocationFormSaveCoordinator.save(
+                mode: .create(householdID: UUID()),
+                draft: draft,
+                repository: repo
+            )
+        }
+    }
+}
+
+// MARK: - Throwing repository stubs
+
+private struct FormCoordinatorTestError: Error, Equatable {}
+
+/// Always-throwing `ItemRepository` for verifying the coordinator's
+/// error propagation. Reads return empty so accidental "did we read
+/// before we wrote?" regressions don't blow up before we hit the
+/// throwing branch under test.
+private actor ThrowingItemRepository: ItemRepository {
+    func items(in locationID: Location.ID) async throws -> [Item] { [] }
+    func item(id: Item.ID) async throws -> Item? { nil }
+    func allItems(in householdID: Household.ID) async throws -> [Item] { [] }
+    func search(_ query: String, in householdID: Household.ID) async throws -> [Item] { [] }
+    func create(_ item: Item) async throws { throw FormCoordinatorTestError() }
+    func update(_ item: Item) async throws { throw FormCoordinatorTestError() }
+    func updateQuantity(id: Item.ID, quantity: Int32) async throws {
+        throw FormCoordinatorTestError()
+    }
+    func delete(id: Item.ID) async throws { throw FormCoordinatorTestError() }
+}
+
+private actor ThrowingLocationRepository: LocationRepository {
+    func locations(in householdID: Household.ID) async throws -> [Location] { [] }
+    func location(id: Location.ID) async throws -> Location? { nil }
+    func create(_ location: Location) async throws { throw FormCoordinatorTestError() }
+    func update(_ location: Location) async throws { throw FormCoordinatorTestError() }
+    func delete(id: Location.ID) async throws { throw FormCoordinatorTestError() }
+}


### PR DESCRIPTION
## Summary

- Extract `ItemFormView.save()` and `LocationFormView.save()` into testable `@MainActor enum` coordinators — pure-data drafts in, persisted entity out, repository errors rethrown.
- 11 new tests cover the load-bearing write-path branches that had zero coverage: trim/whitespace, notes-empty-to-nil, expiry-toggle-off-clears-date, scheduler add (future expiry), scheduler cancel (no expiry), edit preserves id/createdAt, repository-throws short-circuits before scheduler runs.

## Why

Issue #117 — `ItemFormView.save()` was an untested, load-bearing user write path. Regressions in trim or expiry-toggle would silently lose data or schedule wrong notifications. Surfaced by Agent 3's public-surface inventory.

## Test plan

- [x] `xcodebuild test-without-building -only-testing:NakedPantreeTests/ItemFormSaveCoordinatorTests` — 7/7 pass locally
- [x] `xcodebuild test-without-building -only-testing:NakedPantreeTests/LocationFormSaveCoordinatorTests` — 4/4 pass locally
- [x] `./scripts/lint.sh` clean
- [ ] CI green
- [ ] Manual smoke: open ItemFormView, save with whitespace name, save with empty notes, toggle expiry off then save — behavior unchanged

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)