### PR TITLE
fix(sharing): replace deprecated UICloudSharingController init (#90)

### DIFF
--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -33,7 +33,16 @@ struct SettingsView: View {
     /// a neutral placeholder in that case rather than blocking the
     /// whole screen — the share action doesn't depend on the name.
     @State private var household: Household?
-    @State private var isPresentingShareSheet = false
+
+    /// Issue #90: share preparation state machine. Prep runs *before*
+    /// the sheet presents so `UICloudSharingController(share:container:)`
+    /// can be constructed against an already-resolved share — the
+    /// non-deprecated path. `preparedShare != nil` drives the sheet;
+    /// `isPreparingShare` drives the spinner; `shareError` drives the
+    /// alert.
+    @State private var preparedShare: ShareSheetPreparation.PreparedShare?
+    @State private var isPreparingShare = false
+    @State private var shareError: ShareErrorAlert?
 
     /// Trace for #90 (blank Share Household sheet on TestFlight).
     /// Same subsystem/category as `CloudSharingControllerView` and
@@ -63,31 +72,25 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .sheet(isPresented: $isPresentingShareSheet) {
-                if let household, let sharing = householdSharing {
-                    CloudSharingControllerView(
-                        householdID: household.id,
-                        sharing: sharing,
-                        onCompletion: { isPresentingShareSheet = false }
-                    )
-                    .ignoresSafeArea()
-                } else {
-                    // Diagnostic fallback for #90. If the sheet
-                    // presents but the if-let above fails, the user
-                    // sees a blank sheet — exactly the reported
-                    // symptom. The .onAppear log captures which input
-                    // was nil so the bug surfaces in Console without
-                    // needing to attach a debugger.
-                    Color.clear
-                        .onAppear {
-                            let householdState = household != nil ? "set" : "nil"
-                            let sharingState = householdSharing != nil ? "set" : "nil"
-                            Self.logger.error(
-                                // swiftlint:disable:next line_length
-                                "share sheet presented but if-let failed — household=\(householdState, privacy: .public) sharing=\(sharingState, privacy: .public)"
-                            )
-                        }
-                }
+            .sheet(item: $preparedShare) { prepared in
+                // Issue #90: by the time this closure fires, the share
+                // is already a real `CKShare` resolved by
+                // `ShareSheetPreparation`. The controller uses
+                // `init(share:container:)` and renders participant UI
+                // immediately — no more lazy preparation handler.
+                CloudSharingControllerView(
+                    share: prepared.share,
+                    container: prepared.container,
+                    onCompletion: { preparedShare = nil }
+                )
+                .ignoresSafeArea()
+            }
+            .alert(item: $shareError) { wrapper in
+                Alert(
+                    title: Text("Couldn't share"),
+                    message: Text(wrapper.message),
+                    dismissButton: .default(Text("OK"))
+                )
             }
             .task { await loadHousehold() }
         }
@@ -121,12 +124,19 @@ struct SettingsView: View {
                         // swiftlint:disable:next line_length
                         "share button tapped — household=\(householdState, privacy: .public) sharing=\(sharingState, privacy: .public)"
                     )
-                    isPresentingShareSheet = true
+                    Task { await prepareShareForPresentation() }
                 } label: {
-                    Label("Share Household", systemImage: "person.crop.circle.badge.plus")
+                    HStack {
+                        Label("Share Household", systemImage: "person.crop.circle.badge.plus")
+                        if isPreparingShare {
+                            Spacer()
+                            ProgressView()
+                                .accessibilityIdentifier("settings.shareHousehold.spinner")
+                        }
+                    }
                 }
                 .accessibilityIdentifier("settings.shareHousehold")
-                .disabled(household == nil)
+                .disabled(household == nil || isPreparingShare)
             }
         } header: {
             Text("Household")
@@ -185,6 +195,46 @@ struct SettingsView: View {
             household = nil
         }
     }
+
+    /// Issue #90: kicks off `ShareSheetPreparation.prepareShare`,
+    /// driving the spinner / sheet / alert state. Idempotent against
+    /// the existing share — `CloudHouseholdSharingService` returns the
+    /// same `CKShare` on subsequent calls so a tap → dismiss → tap
+    /// sequence reuses the prepared share rather than minting a new
+    /// one. The orphan-share trade-off (a single tap before any
+    /// invite leaves a `CKShare` on iCloud) is accepted; a follow-up
+    /// issue covers cleaning up empty shares on dismiss if it ever
+    /// matters.
+    @MainActor
+    private func prepareShareForPresentation() async {
+        guard let household, let sharing = householdSharing else {
+            Self.logger.error(
+                // swiftlint:disable:next line_length
+                "prepareShareForPresentation: missing household or sharing service — household=\(household != nil ? "set" : "nil", privacy: .public) sharing=\(householdSharing != nil ? "set" : "nil", privacy: .public)"
+            )
+            return
+        }
+        isPreparingShare = true
+        defer { isPreparingShare = false }
+
+        let result = await ShareSheetPreparation.prepareShare(
+            for: household.id,
+            using: sharing
+        )
+        switch result {
+        case .success(let payload):
+            preparedShare = payload
+        case .failure(let error):
+            shareError = ShareErrorAlert(message: error.localizedDescription)
+        }
+    }
+}
+
+/// `Identifiable` wrapper so `.alert(item:)` can drive on a single
+/// state binding rather than a paired `isPresented` + `errorMessage`.
+struct ShareErrorAlert: Identifiable {
+    let id = UUID()
+    let message: String
 }
 
 #Preview("Default 9:00 AM") {

--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -5,132 +5,52 @@ import SwiftUI
 import UIKit
 import os
 
-/// `UIViewControllerRepresentable` over `UICloudSharingController`. iOS
-/// 26 still doesn't have a SwiftUI-native participant manager — the
-/// generic `ShareLink` doesn't surface CKShare semantics — so the bridge
-/// is the supported path. See `ARCHITECTURE.md` §5.
+/// `UIViewControllerRepresentable` over `UICloudSharingController`.
 ///
-/// The controller takes a `preparationHandler` so the share is created
-/// lazily *while* the controller presents — that avoids leaving a
-/// dangling CKShare behind if the user taps "Share" then dismisses
-/// without inviting anyone.
+/// **Issue #90 / Phase 11 refactor.** Earlier shipping versions used
+/// `UICloudSharingController.init(preparationHandler:)` so the share
+/// could be created lazily *while* the controller presented (avoiding
+/// a dangling `CKShare` if the user dismissed without inviting). That
+/// initializer was deprecated in iOS 17, and on iOS 17+/26 simulators
+/// we observed the preparation handler closure silently never being
+/// invoked — leaving the user with a blank sheet (the literal #90
+/// symptom).
+///
+/// The fix is to move share preparation up to the parent view via
+/// `ShareSheetPreparation`, then pass the resolved `(CKShare, CKContainer)`
+/// to the non-deprecated `init(share:container:)`. The controller
+/// renders participant UI immediately because the share already
+/// exists. The orphan-share trade-off (a tap of "Share Household"
+/// followed by an immediate dismiss leaves a CKShare on iCloud)
+/// is accepted: `CloudHouseholdSharingService.prepareShare` is
+/// idempotent — the next tap reuses the existing share via
+/// `existingShare(matching:)`. A follow-up issue covers cleaning up
+/// truly-empty shares on dismiss.
 struct CloudSharingControllerView: UIViewControllerRepresentable {
-    let householdID: Household.ID
-    let sharing: any HouseholdSharingService
+    let share: CKShare
+    let container: CKContainer
 
     /// Fired when the controller dismisses (saved or cancelled). The
     /// caller drops the sheet binding and may want to refresh state.
     let onCompletion: () -> Void
 
-    /// Trace for #90 (blank Share Household sheet on TestFlight).
-    /// Visible via Console.app filtered by subsystem
+    /// Trace for #90. Visible via Console.app filtered by subsystem
     /// `cc.mnmlst.nakedpantree`, category `sharing`. Same lifetime
     /// note as `CloudHouseholdSharingService.logger` — keep until #90
-    /// is fully closed.
-    ///
-    /// `nonisolated` because `UIViewControllerRepresentable` infers
-    /// `@MainActor` on the struct, but the `Task` in the preparation
-    /// handler runs off-main and reads `Self.logger` from there.
+    /// is fully closed and the failure mode is documented in
+    /// DEVELOPMENT.md §7.
     nonisolated private static let logger = Logger(
         subsystem: "cc.mnmlst.nakedpantree",
         category: "sharing"
     )
 
-    /// Cap on how long we wait for `prepareShare` before surfacing a
-    /// timeout error to the controller. 60s is generous — first-time
-    /// share creation can legitimately spend many seconds in
-    /// `NSPersistentCloudKitContainer.share(_:to:)` while CloudKit
-    /// lazy-creates the shared zone — but it's tight enough that a
-    /// genuine hang produces an alert instead of an indefinitely
-    /// blank sheet (the symptom in #90). Same `nonisolated` rationale
-    /// as `logger`.
-    nonisolated private static let prepareShareTimeout: Duration = .seconds(60)
-
     func makeUIViewController(context: Context) -> UICloudSharingController {
-        Self.logger.notice("makeUIViewController: creating UICloudSharingController")
-        let controller = UICloudSharingController { _, completion in
-            // The controller calls this on the main queue once it's
-            // ready to show participant UI. We race `prepareShare`
-            // against a timeout (#90) so a hang surfaces as an error
-            // alert instead of a blank sheet.
-            Self.logger.notice("preparation handler fired — racing prepareShare against timeout")
-            Task {
-                let outcome = await runPrepareShareWithTimeout()
-                await MainActor.run {
-                    switch outcome {
-                    case .success(let payload):
-                        Self.logger.notice("preparation handler: completion(share, container, nil)")
-                        completion(payload.share, payload.container, nil)
-                    case .failure(let error):
-                        let description = error.localizedDescription
-                        Self.logger.error(
-                            "preparation handler: completion(nil, nil, \(description, privacy: .public))"
-                        )
-                        completion(nil, nil, error)
-                    }
-                }
-            }
-        }
+        Self.logger.notice(
+            "makeUIViewController: creating UICloudSharingController(share:container:)"
+        )
+        let controller = UICloudSharingController(share: share, container: container)
         controller.delegate = context.coordinator
         return controller
-    }
-
-    /// Runs `prepareShare(for:)` on the actor-isolated service, racing
-    /// it against `timeout`. Whichever wins wins; the loser is
-    /// cancelled. Returns the outcome as a value so the caller can
-    /// dispatch onto MainActor in one place.
-    ///
-    /// `internal` (not `private`) so
-    /// `CloudSharingControllerViewTimeoutRaceTests` can drive it
-    /// directly with a small timeout. Production callers omit
-    /// `timeout` and pick up the 60s default from
-    /// `prepareShareTimeout`.
-    func runPrepareShareWithTimeout(
-        timeout: Duration = Self.prepareShareTimeout
-    ) async -> Result<SharePayload, Error> {
-        let householdID = householdID
-        let sharing = sharing
-        return await withTaskGroup(of: Result<SharePayload, Error>.self) { group in
-            group.addTask {
-                do {
-                    let (share, container) = try await sharing.prepareShare(for: householdID)
-                    return .success(SharePayload(share: share, container: container))
-                } catch {
-                    return .failure(error)
-                }
-            }
-            group.addTask {
-                try? await Task.sleep(for: timeout)
-                Self.logger.error(
-                    "prepareShare timed out after \(timeout, privacy: .public)"
-                )
-                return .failure(SharingTimeoutError())
-            }
-            let first = await group.next() ?? .failure(SharingTimeoutError())
-            group.cancelAll()
-            return first
-        }
-    }
-
-    /// Tuple-shaped payload kept as a struct so the `Result.success`
-    /// destructure at the call site is a single binding (sidesteps the
-    /// swift-format / swiftlint disagreement on multi-bound `let` /
-    /// `case let` forms). `internal` so the race-test suite can match
-    /// against it.
-    struct SharePayload {
-        let share: CKShare
-        let container: CKContainer
-    }
-
-    /// `internal` so the race-test suite can `is`-check the failure
-    /// type from `runPrepareShareWithTimeout`.
-    struct SharingTimeoutError: LocalizedError {
-        var errorDescription: String? {
-            // Surfaced to the user by `UICloudSharingController`'s own
-            // alert — keep terse and actionable.
-            "Couldn't reach iCloud to prepare the share. Try again — "
-                + "if it keeps happening, check the iCloud account in Settings."
-        }
     }
 
     func updateUIViewController(_ controller: UICloudSharingController, context: Context) {
@@ -156,9 +76,9 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
             _ csc: UICloudSharingController,
             failedToSaveShareWithError error: Error
         ) {
-            // Surfaced to the user by `UICloudSharingController` itself —
-            // it shows an alert before dismissing. Nothing more for us
-            // to do until 3.3 introduces user-facing feedback.
+            // `UICloudSharingController` shows its own alert for the
+            // failure before dismissing; we just propagate the
+            // dismissal up so the sheet binding clears.
             onCompletion()
         }
 

--- a/NakedPantreeApp/Sharing/ShareSheetPreparation.swift
+++ b/NakedPantreeApp/Sharing/ShareSheetPreparation.swift
@@ -1,0 +1,101 @@
+import CloudKit
+import Foundation
+import NakedPantreeDomain
+import NakedPantreePersistence
+import os
+
+/// Top-level helper that bridges `HouseholdSharingService.prepareShare`
+/// to the `UICloudSharingController` presentation flow. Issue #90.
+///
+/// **Why it exists.** `UICloudSharingController(preparationHandler:)`
+/// was deprecated in iOS 17, and on iOS 17+/26 simulators we observed
+/// the preparation handler closure simply never being invoked — leaving
+/// the user staring at a blank sheet (the literal #90 symptom). Apple's
+/// non-deprecated initializer is `init(share:container:)`, which
+/// requires the share to exist *before* the controller is constructed.
+/// That moves the prep step out of the controller and up to the parent
+/// view, which is exactly what this helper supports.
+///
+/// The race-against-timeout shape that used to live on
+/// `CloudSharingControllerView.runPrepareShareWithTimeout` lives here
+/// now — a hang in `prepareShare` should still surface as an alert
+/// rather than a perceptibly-stuck "Preparing…" spinner.
+enum ShareSheetPreparation {
+    /// `Identifiable` so SwiftUI can drive a `.sheet(item:)` binding
+    /// off the prepared payload. The id is fresh per prepare call so
+    /// presenting twice in a row replaces the sheet rather than
+    /// reusing a stale instance.
+    struct PreparedShare: Identifiable, Sendable {
+        let id = UUID()
+        let share: CKShare
+        let container: CKContainer
+    }
+
+    /// Surfaced in the user-facing alert when the prepare step
+    /// exceeds `timeout`. Same copy as the legacy in-controller
+    /// timeout — keep terse and actionable.
+    struct TimeoutError: LocalizedError {
+        var errorDescription: String? {
+            "Couldn't reach iCloud to prepare the share. Try again — "
+                + "if it keeps happening, check the iCloud account in Settings."
+        }
+    }
+
+    /// Default upper bound on how long the parent view spins waiting
+    /// for `prepareShare`. 60s matches the legacy timeout — long
+    /// enough to cover first-share latency on a slow connection,
+    /// short enough that a genuine hang produces an alert instead
+    /// of an indefinitely stuck UI.
+    static let defaultTimeout: Duration = .seconds(60)
+
+    /// Trace lines come out under the same subsystem/category as
+    /// `CloudSharingControllerView` and `CloudHouseholdSharingService`,
+    /// so a single `subsystem:cc.mnmlst.nakedpantree` filter in
+    /// Console.app captures the whole share path.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "sharing"
+    )
+
+    /// Race `service.prepareShare(for:)` against `timeout`. Whichever
+    /// task wins the group's first slot wins; the loser is cancelled.
+    /// The shape mirrors the old `runPrepareShareWithTimeout` so the
+    /// test suite that drove that helper carries forward verbatim.
+    static func prepareShare(
+        for householdID: Household.ID,
+        using service: any HouseholdSharingService,
+        timeout: Duration = defaultTimeout
+    ) async -> Result<PreparedShare, Error> {
+        Self.logger.notice(
+            "ShareSheetPreparation.prepareShare start: \(householdID, privacy: .public)"
+        )
+        return await withTaskGroup(of: Result<PreparedShare, Error>.self) { group in
+            group.addTask {
+                do {
+                    let (share, container) = try await service.prepareShare(for: householdID)
+                    return .success(PreparedShare(share: share, container: container))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                Self.logger.error(
+                    "ShareSheetPreparation timed out after \(timeout, privacy: .public)"
+                )
+                return .failure(TimeoutError())
+            }
+            let first = await group.next() ?? .failure(TimeoutError())
+            group.cancelAll()
+            switch first {
+            case .success:
+                Self.logger.notice("ShareSheetPreparation succeeded — payload ready")
+            case .failure(let error):
+                Self.logger.error(
+                    "ShareSheetPreparation failed: \(error.localizedDescription, privacy: .public)"
+                )
+            }
+            return first
+        }
+    }
+}

--- a/NakedPantreeTests/CloudSharingControllerViewTimeoutRaceTests.swift
+++ b/NakedPantreeTests/CloudSharingControllerViewTimeoutRaceTests.swift
@@ -6,30 +6,35 @@ import Testing
 @testable import NakedPantreeDomain
 @testable import NakedPantreePersistence
 
-/// Coverage for `CloudSharingControllerView.runPrepareShareWithTimeout` —
-/// the `withTaskGroup` race that backs the #90 timeout safety net. A
-/// regression here would silently break the "blank sheet eventually
-/// surfaces an error" guarantee, so the race wins on three axes are
-/// each pinned down:
+/// Coverage for `ShareSheetPreparation.prepareShare` — the
+/// `withTaskGroup` race that backs the #90 timeout safety net. Pinned
+/// against the three race outcomes:
 ///
 /// - Service resolves before timeout → `.success`
-/// - Service hangs longer than timeout → `.failure(SharingTimeoutError)`
+/// - Service hangs longer than timeout → `.failure(TimeoutError)`
 /// - Service throws before timeout → `.failure(<underlying error>)`
+///
+/// **Pre-Phase-11 history.** This logic used to live on
+/// `CloudSharingControllerView.runPrepareShareWithTimeout`, paired
+/// with the now-deprecated `UICloudSharingController(preparationHandler:)`.
+/// Issue #90: that init silently fails to invoke its preparation
+/// handler on iOS 17+/26, so the race was moved up to
+/// `ShareSheetPreparation` and the controller now uses
+/// `init(share:container:)` against an already-resolved share. Tests
+/// follow the logic; their shape is otherwise unchanged.
 ///
 /// Each test uses a small timeout (~100ms) so the suite finishes
 /// fast; the production default of 60s is overridden via the
 /// `timeout:` parameter.
-@Suite("CloudSharingControllerView timeout race")
-struct CloudSharingControllerViewTimeoutRaceTests {
+@Suite("ShareSheetPreparation timeout race")
+struct ShareSheetPreparationTimeoutRaceTests {
     @Test("Service resolves before timeout — returns .success")
-    @MainActor
     func happyPath() async throws {
-        let view = CloudSharingControllerView(
-            householdID: UUID(),
-            sharing: StubHouseholdSharingService(),
-            onCompletion: {}
+        let result = await ShareSheetPreparation.prepareShare(
+            for: UUID(),
+            using: StubHouseholdSharingService(),
+            timeout: .seconds(5)
         )
-        let result = await view.runPrepareShareWithTimeout(timeout: .seconds(5))
         switch result {
         case .success:
             break
@@ -38,35 +43,31 @@ struct CloudSharingControllerViewTimeoutRaceTests {
         }
     }
 
-    @Test("Service hangs longer than timeout — returns SharingTimeoutError")
-    @MainActor
+    @Test("Service hangs longer than timeout — returns TimeoutError")
     func timeoutWins() async throws {
-        let view = CloudSharingControllerView(
-            householdID: UUID(),
-            sharing: HangingSharingService(),
-            onCompletion: {}
+        let result = await ShareSheetPreparation.prepareShare(
+            for: UUID(),
+            using: HangingSharingService(),
+            timeout: .milliseconds(100)
         )
-        let result = await view.runPrepareShareWithTimeout(timeout: .milliseconds(100))
         switch result {
         case .success:
             Issue.record("Expected timeout, got success")
         case .failure(let error):
             #expect(
-                error is CloudSharingControllerView.SharingTimeoutError,
-                "Expected SharingTimeoutError, got: \(type(of: error))"
+                error is ShareSheetPreparation.TimeoutError,
+                "Expected TimeoutError, got: \(type(of: error))"
             )
         }
     }
 
     @Test("Service throws — returns the underlying error, not a timeout")
-    @MainActor
     func errorPropagates() async throws {
-        let view = CloudSharingControllerView(
-            householdID: UUID(),
-            sharing: ThrowingSharingService(),
-            onCompletion: {}
+        let result = await ShareSheetPreparation.prepareShare(
+            for: UUID(),
+            using: ThrowingSharingService(),
+            timeout: .seconds(5)
         )
-        let result = await view.runPrepareShareWithTimeout(timeout: .seconds(5))
         switch result {
         case .success:
             Issue.record("Expected failure, got success")
@@ -84,9 +85,9 @@ struct CloudSharingControllerViewTimeoutRaceTests {
 /// Stub that hangs forever via cancellable `Task.sleep`. The
 /// surrounding `withTaskGroup.cancelAll()` will cancel this task once
 /// the timeout sibling wins — `Task.sleep` throws `CancellationError`,
-/// the `do/catch` in `runPrepareShareWithTimeout` converts it to
-/// `.failure(CancellationError)`, but that result is the *loser* and
-/// is discarded by the group's `next()`-then-cancel pattern.
+/// the `do/catch` in `prepareShare` converts it to `.failure`, but
+/// that result is the *loser* and is discarded by the group's
+/// `next()`-then-cancel pattern.
 private struct HangingSharingService: HouseholdSharingService {
     func prepareShare(
         for householdID: UUID


### PR DESCRIPTION
## Summary

- Diagnosed #90 (blank "Share Household" sheet on simulator/TestFlight) as a side-effect of the deprecated `UICloudSharingController.init(preparationHandler:)` — the preparation handler closure is silently never invoked on iOS 17+/26.
- Replaced it with the non-deprecated `init(share:container:)`. Share preparation now happens *before* the sheet presents, in a new `ShareSheetPreparation` helper.
- `SettingsView` gains a small idle→preparing→ready/failed state machine. The user sees a brief spinner on the row while the share is created, then the sheet appears with participant UI rendered immediately.

## Why now

The user reproduced #90 deterministically on simulator running `origin/main` and confirmed via debugger that the preparation handler closure never fires. The deprecation warning Xcode has been emitting was hand-delivering us the fix.

## Trade-offs

The legacy lazy-prep path used `init(preparationHandler:)` so a `CKShare` was only minted if the user actually invited someone. The new path mints it on tap. `CloudHouseholdSharingService.prepareShare` is idempotent (existing-share check), so this won't multiply, but a single tap-then-dismiss leaves an empty share. Accepted for shipping. Filed a follow-up issue to clean up empty shares on dismiss if it ever surfaces as confusion.

## Test plan

- [x] Local: `ShareSheetPreparation` timeout + throw race tests pass (happyPath stub-CK construction needs codesigning so it runs on CI, not locally)
- [x] Build clean — deprecation warning gone
- [x] `./scripts/lint.sh` clean
- [ ] CI green
- [ ] User: rebuild on simulator → tap Share Household → confirm participant UI now renders
- [ ] User: validate end-to-end share invite + accept on TestFlight before closing #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)