### PR TITLE
fix(sharing): suppress spurious timeout log on race-loser cancellation

### DIFF
--- a/NakedPantreeApp/Sharing/ShareSheetPreparation.swift
+++ b/NakedPantreeApp/Sharing/ShareSheetPreparation.swift
@@ -80,6 +80,18 @@ enum ShareSheetPreparation {
             }
             group.addTask {
                 try? await Task.sleep(for: timeout)
+                // Skip the log when this task lost the race and the
+                // group cancelled us out of `Task.sleep`. Without the
+                // guard, a successful prepare emits a misleading
+                // "timed out" line right after "succeeded — payload
+                // ready" because `try?` swallows `CancellationError`
+                // and the rest of the closure runs anyway. The
+                // returned `.failure(TimeoutError())` itself is fine
+                // — it gets discarded by the group's first-result
+                // semantic — but the log line still ships.
+                if Task.isCancelled {
+                    return .failure(CancellationError())
+                }
                 Self.logger.error(
                     "ShareSheetPreparation timed out after \(timeout, privacy: .public)"
                 )


### PR DESCRIPTION
## Summary

Follow-up to #135. User testing on simulator surfaced a misleading log line right after a successful prepareShare:

\`\`\`
ShareSheetPreparation succeeded — payload ready
ShareSheetPreparation timed out after 60.0 seconds   ← shouldn't be there
\`\`\`

The timeout sibling task lost the \`withTaskGroup\` race and got cancelled mid-\`Task.sleep\`. \`try?\` swallows the \`CancellationError\`, so the closure runs through to the \`logger.error\` line. The returned \`.failure(TimeoutError())\` is fine — it gets discarded by the group's first-result semantic — but the log line still shipped.

Fix: \`Task.isCancelled\` guard before logging, return \`CancellationError\` so the surface stays consistent.

## Test plan

- [x] \`ShareSheetPreparationTimeoutRaceTests\` still pass locally (2 of 3; the happyPath test needs CK-signing on CI)
- [x] \`./scripts/lint.sh\` clean
- [x] CI green
- [ ] User retest on simulator: tap Share Household, watch Console — no spurious "timed out" line after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)