### PR TITLE
chore: sweep build warnings — zero warnings on clean build

### DIFF
--- a/NakedPantreeApp/App/AccountStatusMonitor.swift
+++ b/NakedPantreeApp/App/AccountStatusMonitor.swift
@@ -42,7 +42,20 @@ enum AccountStatus: Sendable, Hashable {
 final class AccountStatusMonitor {
     private(set) var status: AccountStatus = .available
 
-    nonisolated(unsafe) private var task: Task<Void, Never>?
+    /// Cancellation handle for the in-flight account-status fetch.
+    /// Stored inside a `Sendable` holder so `deinit` (nonisolated)
+    /// can read it without hopping back to the main actor.
+    /// `@ObservationIgnored` keeps the `@Observable` macro from
+    /// observing an implementation detail.
+    ///
+    /// Earlier versions used `nonisolated(unsafe) private var task`,
+    /// which the Swift 6 compiler flags with a "has no effect, consider
+    /// using 'nonisolated'" warning — but bare `nonisolated` is then
+    /// rejected for mutable stored properties. The holder is the clean
+    /// way out: `let`-stored so `nonisolated` reads work, with the
+    /// mutable slot living inside a `Sendable` reference type.
+    @ObservationIgnored
+    nonisolated private let taskHolder = MutableTaskHolder()
 
     /// No-op monitor for previews and tests. Status stays `.available`
     /// so the banner is hidden. `nonisolated` so the `@Entry` default
@@ -51,7 +64,7 @@ final class AccountStatusMonitor {
 
     init(container: CKContainer) {
         let stream = NotificationCenter.default.notifications(named: .CKAccountChanged)
-        task = Task { @MainActor [weak self] in
+        taskHolder.task = Task { @MainActor [weak self] in
             await self?.refresh(using: container)
             for await _ in stream {
                 await self?.refresh(using: container)
@@ -60,7 +73,7 @@ final class AccountStatusMonitor {
     }
 
     deinit {
-        task?.cancel()
+        taskHolder.task?.cancel()
     }
 
     private func refresh(using container: CKContainer) async {
@@ -93,4 +106,19 @@ final class AccountStatusMonitor {
 
 extension EnvironmentValues {
     @Entry var accountStatusMonitor = AccountStatusMonitor()
+}
+
+/// Reference-type box that holds the in-flight `Task` for
+/// `AccountStatusMonitor` and `RemoteChangeMonitor`. Lives outside
+/// either class so a `nonisolated let taskHolder` field can be read
+/// from `deinit` without re-entering the main actor — the mutable
+/// slot is inside a `@unchecked Sendable` class instead of being a
+/// mutable stored property on the `@MainActor` enclosing type.
+///
+/// `@unchecked Sendable` is honest here: the `task` slot is only
+/// written from the enclosing class's MainActor-isolated init / setter
+/// paths, and only read from `deinit`. There's no concurrent mutation
+/// to checked-Sendable away.
+final class MutableTaskHolder: @unchecked Sendable {
+    var task: Task<Void, Never>?
 }

--- a/NakedPantreeApp/App/RemoteChangeMonitor.swift
+++ b/NakedPantreeApp/App/RemoteChangeMonitor.swift
@@ -57,13 +57,12 @@ final class RemoteChangeMonitor {
     /// `changeToken` never bumps.
     nonisolated let isObserving: Bool
 
-    // `nonisolated(unsafe)` so `deinit` (which Swift treats as
-    // nonisolated) can cancel the task. The compiler nudges to drop
-    // the `(unsafe)` since `Task<Void, Never>` is Sendable, but the
-    // `@Observable` macro's generated backing storage rejects bare
-    // `nonisolated` on mutable stored properties — so we keep
-    // `(unsafe)` and live with the warning.
-    nonisolated(unsafe) private var task: Task<Void, Never>?
+    // Held inside a `Sendable` `MutableTaskHolder` so `deinit`
+    // (nonisolated) can read it without hopping back to the main
+    // actor. Same pattern as `AccountStatusMonitor` — see the type's
+    // doc comment for the rationale.
+    @ObservationIgnored
+    nonisolated private let taskHolder = MutableTaskHolder()
 
     /// Pending debounce timer. Each incoming notification cancels the
     /// previous timer and starts a new one — only the last
@@ -147,7 +146,7 @@ final class RemoteChangeMonitor {
             named: .NSPersistentStoreRemoteChange,
             object: container.persistentStoreCoordinator
         )
-        task = Task { @MainActor [weak self] in
+        taskHolder.task = Task { @MainActor [weak self] in
             for await _ in stream {
                 self?.scheduleRefresh()
             }
@@ -155,7 +154,7 @@ final class RemoteChangeMonitor {
     }
 
     deinit {
-        task?.cancel()
+        taskHolder.task?.cancel()
     }
 
     private func scheduleRefresh() {

--- a/NakedPantreeApp/Features/Items/QuantityStepperControl.swift
+++ b/NakedPantreeApp/Features/Items/QuantityStepperControl.swift
@@ -345,7 +345,9 @@ final class QuantityStepperModel {
             try? await Task.sleep(for: interval)
             guard !Task.isCancelled else { return }
             await self?.persistIfChanged()
-            await self?.clearPendingTask(matching: token)
+            // `clearPendingTask` is sync and the surrounding Task is
+            // already MainActor-isolated, so no `await` is needed.
+            self?.clearPendingTask(matching: token)
         }
     }
 

--- a/NakedPantreeUITests/BootstrapUITests.swift
+++ b/NakedPantreeUITests/BootstrapUITests.swift
@@ -8,6 +8,7 @@ import XCTest
 /// `SidebarView`'s `.task` ran concurrently — the empty-fetch raced
 /// the bootstrap insert and won, so the sidebar's Locations section
 /// stayed empty until the user manually triggered a refresh.
+@MainActor
 final class BootstrapUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/NakedPantreeUITests/NakedPantreeUITests.swift
+++ b/NakedPantreeUITests/NakedPantreeUITests.swift
@@ -1,5 +1,6 @@
 import XCTest
 
+@MainActor
 final class NakedPantreeUITests: XCTestCase {
     func testAppLaunches() throws {
         let app = XCUIApplication()

--- a/NakedPantreeUITests/SharingUITests.swift
+++ b/NakedPantreeUITests/SharingUITests.swift
@@ -21,6 +21,7 @@ import XCTest
 /// either render its participant UI or surface its own error UI;
 /// either way it produces accessibility children that XCUITest can
 /// see. A genuinely blank sheet (the bug) produces none.
+@MainActor
 final class SharingUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/NakedPantreeUITests/SnapshotsUITests.swift
+++ b/NakedPantreeUITests/SnapshotsUITests.swift
@@ -25,6 +25,7 @@ import XCTest
 ///
 /// See [issue #12](https://github.com/ellisandy/NakedPantree/issues/12)
 /// for the larger pipeline this slots into.
+@MainActor
 final class SnapshotsUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -163,7 +164,7 @@ final class SnapshotsUITests: XCTestCase {
     private func waitForColumn(
         _ app: XCUIApplication,
         navbar identifier: String,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertTrue(


### PR DESCRIPTION
## Summary

User noticed the CI log on #138 had a wave of warnings. This PR clears all of them. Three categories:

### 1. App target

- **`AccountStatusMonitor` / `RemoteChangeMonitor`** — both flagged `'nonisolated(unsafe)' has no effect on property 'task', consider using 'nonisolated'`. The compiler's suggestion is wrong: bare \`nonisolated\` is rejected for *mutable* stored properties. Moved the mutable slot into a new \`MutableTaskHolder: @unchecked Sendable\` reference type and stored a \`nonisolated let\` to it on the enclosing \`@MainActor\` class. \`deinit\` reads through the holder without needing the main actor. No more warnings, no more conflict.
- **\`QuantityStepperControl\`** — stale \`await\` on a sync method (refactor leftover, likely from #118). Dropped.

### 2. UI tests (~60 warnings)

\`XCUIApplication\` and \`XCUIElement\` are \`@MainActor\`-isolated in modern XCTest. The four \`XCTestCase\` subclasses were \`nonisolated\`, so every property access and method call yelled. Annotated each class \`@MainActor\`.

### 3. \`SnapshotsUITests\` outlier

\`waitForColumn(file: StaticString = #file, …)\` mismatched \`XCTAssertTrue\`'s default of \`#filePath\`. Switched to \`#filePath\`.

## Verification

- [x] Clean rebuild: **zero compiler warnings**
- [x] \`AccountStatusMonitor\` mapping tests pass (5/5)
- [x] \`RemoteChangeMonitor\` tests pass (8/8)
- [x] \`./scripts/lint.sh\` clean
- [ ] CI green

## Going forward

The structural failure that let these accumulate: I was treating \`xcodebuild\` exit code as the only signal. Adding a "grep warnings" step to my post-change loop now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)