### PR TITLE
fix(persistence): recover from store-load failure instead of crashing (#106)

### DIFF
--- a/NakedPantreeApp/App/AppLauncher.swift
+++ b/NakedPantreeApp/App/AppLauncher.swift
@@ -1,0 +1,276 @@
+import CloudKit
+import CoreData
+import Foundation
+import NakedPantreeDomain
+import NakedPantreePersistence
+import SwiftUI
+
+/// Owns the wiring between "app boot" and "first user-visible screen".
+///
+/// **Issue #106:** `CoreDataStack.cloudKitContainer()` used to call
+/// `fatalError` on store-load failure — an unrecoverable crash on every
+/// launch for any user who hit a corrupt SQLite, a partially-written
+/// migration, or a failed automatic mapping-model inference. The
+/// launcher catches the throw, parks in a `.failed` state, and renders
+/// `DataRecoveryView` instead. The user can then **Try Again** (handles
+/// transient failures) or **Reset Local Data** (deletes the SQLite
+/// files; CloudKit re-syncs on next start, gated on iCloud being
+/// signed in to avoid permanent data loss).
+///
+/// Same architectural placement as the previous in-init logic — the
+/// launcher just hosts the state machine and exposes a SwiftUI surface.
+/// Snapshot / `EMPTY_STORE` / unit-test paths short-circuit straight
+/// to `.ready` because they don't touch the failing code path.
+@MainActor
+@Observable
+final class AppLauncher {
+    enum State {
+        /// Briefly between init and the first build attempt completing.
+        /// Production currently transitions out of this state
+        /// synchronously inside `init`; the case exists so SwiftUI's
+        /// body is never asked to render an undefined state, and so
+        /// retry / reset can flush back to "loading" before the next
+        /// build attempt completes.
+        case loading
+        /// Happy path. `LiveDependencies` carries every environment
+        /// value `RootView` needs; the launcher hands ownership over
+        /// once we're here.
+        case ready(LiveDependencies)
+        /// Store load threw. Render `DataRecoveryView`.
+        case failed(LoadFailure)
+    }
+
+    /// Bundle of state the failed surface needs.
+    struct LoadFailure {
+        /// Human-readable description of the underlying failure. Used
+        /// verbatim in the recovery view's "details" disclosure.
+        let errorDescription: String
+        /// Live `AccountStatusMonitor` for the recovery view to read
+        /// `status` from — gates the destructive "Reset Local Data"
+        /// button on iCloud being available.
+        let accountStatusMonitor: AccountStatusMonitor
+    }
+
+    private(set) var state: State = .loading
+
+    /// Closure that builds the live dependencies. Defaults to the
+    /// production builder; tests inject a stub that throws to drive
+    /// the `.failed` path.
+    private let buildDependencies: @MainActor () throws -> LiveDependencies
+    /// Closure that returns the `AccountStatusMonitor` to attach to
+    /// a failure. Default constructs the production monitor against
+    /// the iCloud container; tests inject a no-op monitor.
+    private let makeFailureAccountMonitor: @MainActor () -> AccountStatusMonitor
+    /// Closure that deletes the on-disk SQLite stores. Default deletes
+    /// the production files; tests inject a no-op recorder.
+    /// `@MainActor`-typed for parameter homogeneity — the production
+    /// implementation is nonisolated (just filesystem calls) but the
+    /// launcher is `@MainActor` so the conversion is free.
+    private let deleteLocalStores: @MainActor () -> Void
+
+    init(
+        buildDependencies: @escaping @MainActor () throws -> LiveDependencies =
+            AppLauncher.makeProductionDependencies,
+        makeFailureAccountMonitor: @escaping @MainActor () -> AccountStatusMonitor =
+            AppLauncher.makeProductionFailureAccountMonitor,
+        deleteLocalStores: @escaping @MainActor () -> Void =
+            AppLauncher.deleteProductionLocalStores
+    ) {
+        self.buildDependencies = buildDependencies
+        self.makeFailureAccountMonitor = makeFailureAccountMonitor
+        self.deleteLocalStores = deleteLocalStores
+        attemptLoad()
+    }
+
+    /// User tapped "Try Again". Re-runs the same build path. Handles
+    /// transient failures (disk pressure, brief filesystem hiccup)
+    /// without destroying any data.
+    func retry() {
+        state = .loading
+        attemptLoad()
+    }
+
+    /// User tapped "Reset Local Data" and confirmed. Deletes the
+    /// SQLite stores, then re-runs the build. CloudKit will re-sync
+    /// the user's pantry on the next successful launch — provided
+    /// they're signed into iCloud, which the recovery view enforces
+    /// before exposing this action.
+    func resetAndRetry() {
+        deleteLocalStores()
+        state = .loading
+        attemptLoad()
+    }
+
+    private func attemptLoad() {
+        do {
+            state = .ready(try buildDependencies())
+        } catch {
+            state = .failed(
+                LoadFailure(
+                    errorDescription: error.localizedDescription,
+                    accountStatusMonitor: makeFailureAccountMonitor()
+                )
+            )
+        }
+    }
+}
+
+/// Bundle of every environment value `RootView` reads. The launcher
+/// builds this on the happy path and hands it to the body via
+/// `.environment(...)`.
+struct LiveDependencies {
+    let repositories: Repositories
+    let remoteChangeMonitor: RemoteChangeMonitor
+    let accountStatusMonitor: AccountStatusMonitor
+    let householdSharing: (any HouseholdSharingService)?
+    let notificationScheduler: NotificationScheduler
+    let notificationRouting: NotificationRoutingService
+    let notificationSettings: NotificationSettings
+}
+
+// MARK: - Production builders
+
+extension AppLauncher {
+    /// The previous `NakedPantreeApp.init()` body, lifted out so the
+    /// launcher can call it as a closure. Same branch order:
+    /// snapshot-mode → `EMPTY_STORE` → unit-test host → production.
+    /// Only the production branch can throw (issue #106).
+    @MainActor
+    static func makeProductionDependencies() throws -> LiveDependencies {
+        // Phase 4.2: a single routing service across all branches —
+        // preview / snapshot / test surfaces never get tap callbacks
+        // (no scheduled notifications) but the environment value still
+        // needs to resolve, and a fresh service is cheap.
+        let routing = NotificationRoutingService()
+
+        if SnapshotFixtures.isSnapshotMode {
+            // Bypass Core Data when the snapshot UI tests launch us —
+            // they need a deterministic, populated state and never want
+            // a stray SQLite file from a previous run leaking through.
+            NakedPantreeAppDelegate.wireNotificationRouting(routing)
+            return LiveDependencies(
+                repositories: SnapshotFixtures.makeSeededRepositories(),
+                remoteChangeMonitor: RemoteChangeMonitor(),
+                accountStatusMonitor: AccountStatusMonitor(),
+                householdSharing: nil,
+                notificationScheduler: NotificationScheduler(),
+                notificationRouting: routing,
+                notificationSettings: NotificationSettings()
+            )
+        }
+        if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
+            // UI-test escape hatch: empty in-memory repos that exercise
+            // the real bootstrap flow without persisting anything to
+            // disk. Used by `BootstrapUITests` to regression-test the
+            // first-launch race.
+            //
+            // `STUB_SHARING=1` swaps in `StubHouseholdSharingService`
+            // so `SharingUITests` can drive the Settings → Share
+            // Household path on CI without an iCloud account.
+            let stubSharing = ProcessInfo.processInfo.environment["STUB_SHARING"] == "1"
+            let sharing: (any HouseholdSharingService)? =
+                stubSharing ? StubHouseholdSharingService() : nil
+            NakedPantreeAppDelegate.wireNotificationRouting(routing)
+            return LiveDependencies(
+                repositories: .makePreview(),
+                remoteChangeMonitor: RemoteChangeMonitor(),
+                accountStatusMonitor: AccountStatusMonitor(),
+                householdSharing: sharing,
+                notificationScheduler: NotificationScheduler(),
+                notificationRouting: routing,
+                notificationSettings: NotificationSettings()
+            )
+        }
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            // Unit tests load us via BUNDLE_LOADER, but the simulator has
+            // no iCloud account so `cloudKitContainer()` would fail to
+            // load. Repository contract tests stand up their own
+            // in-memory container — the host repos here are never read.
+            NakedPantreeAppDelegate.wireNotificationRouting(routing)
+            return LiveDependencies(
+                repositories: .makePreview(),
+                remoteChangeMonitor: RemoteChangeMonitor(),
+                accountStatusMonitor: AccountStatusMonitor(),
+                householdSharing: nil,
+                notificationScheduler: NotificationScheduler(),
+                notificationRouting: routing,
+                notificationSettings: NotificationSettings()
+            )
+        }
+
+        // Phase 2.1: production stack is CloudKit-mirrored. Phase 3
+        // adds the sharing service against the same container.
+        let container = try CoreDataStack.cloudKitContainer()
+        let cloudKitContainer = CKContainer(
+            identifier: CoreDataStack.cloudKitContainerIdentifier
+        )
+        let repositories = Repositories(
+            household: CoreDataHouseholdRepository(container: container),
+            location: CoreDataLocationRepository(container: container),
+            item: CoreDataItemRepository(container: container),
+            photo: CoreDataItemPhotoRepository(container: container)
+        )
+        let remoteChangeMonitor = RemoteChangeMonitor(container: container)
+        let accountStatusMonitor = AccountStatusMonitor(container: cloudKitContainer)
+        let householdSharing = CloudHouseholdSharingService(
+            container: container,
+            cloudKitContainer: cloudKitContainer
+        )
+        // Phase 3.2: hand the share-acceptance service to the
+        // delegate so `application(_:userDidAcceptCloudKitShareWith:)`
+        // can import shared records when a recipient taps an
+        // invite. The delegate is instantiated by the system before
+        // this init runs, so a static var is the simplest seam.
+        NakedPantreeAppDelegate.wireShareAcceptance(
+            CloudShareAcceptance(container: container)
+        )
+        // Phase 9.3: persisted reminder time, constructed before
+        // the scheduler so it can read `settings.hourOfDay` /
+        // `.minute` when scheduling and when bundling same-day
+        // expiries (Phase 9.4 integration).
+        let notificationSettings = NotificationSettings(defaults: .standard)
+        let notificationScheduler = NotificationScheduler(
+            center: .current(),
+            settings: notificationSettings
+        )
+        // Phase 4.2: the delegate routes notification taps into this
+        // service. Same static-var pattern as `shareAcceptance` —
+        // delegate construction precedes app init, so the seam is a
+        // post-hoc handoff.
+        NakedPantreeAppDelegate.wireNotificationRouting(routing)
+
+        return LiveDependencies(
+            repositories: repositories,
+            remoteChangeMonitor: remoteChangeMonitor,
+            accountStatusMonitor: accountStatusMonitor,
+            householdSharing: householdSharing,
+            notificationScheduler: notificationScheduler,
+            notificationRouting: routing,
+            notificationSettings: notificationSettings
+        )
+    }
+
+    /// Production failure path needs an `AccountStatusMonitor` so the
+    /// recovery view can gate the destructive button on iCloud
+    /// availability. The monitor is independent of Core Data — it
+    /// only needs the iCloud `CKContainer`, which constructs cleanly
+    /// even when `loadPersistentStores` failed.
+    @MainActor
+    static func makeProductionFailureAccountMonitor() -> AccountStatusMonitor {
+        let cloudKitContainer = CKContainer(
+            identifier: CoreDataStack.cloudKitContainerIdentifier
+        )
+        return AccountStatusMonitor(container: cloudKitContainer)
+    }
+
+    /// Deletes the production SQLite stores plus their `-shm` / `-wal`
+    /// sidecar files. `try?` swallows missing-file errors — the user
+    /// might have hit "Reset" twice in a row, and the second pass has
+    /// nothing to delete.
+    static func deleteProductionLocalStores() {
+        let urls = CoreDataStack.cloudKitStoreFileURLs()
+        for url in urls {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+}

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -6,122 +6,49 @@ import NakedPantreePersistence
 import SwiftUI
 import UserNotifications
 
+/// App-level entry point.
+///
+/// **Issue #106:** the previous version did all dependency wiring
+/// synchronously inside `init()` and called `fatalError` if
+/// `CoreDataStack.cloudKitContainer()` threw — crashing every launch
+/// for any user who hit a corrupt SQLite or a bad migration. The
+/// wiring now lives in `AppLauncher`, which catches the throw and
+/// renders `DataRecoveryView` instead. SwiftUI's body switches on
+/// `launcher.state`.
 @main
 struct NakedPantreeApp: App {
     @UIApplicationDelegateAdaptor(NakedPantreeAppDelegate.self) private var appDelegate
-
-    private let repositories: Repositories
-    private let remoteChangeMonitor: RemoteChangeMonitor
-    private let accountStatusMonitor: AccountStatusMonitor
-    private let householdSharing: (any HouseholdSharingService)?
-    private let notificationScheduler: NotificationScheduler
-    private let notificationRouting: NotificationRoutingService
-    private let notificationSettings: NotificationSettings
-
-    init() {
-        // Phase 4.2: a single routing service across all branches —
-        // preview / snapshot / test surfaces never get tap callbacks
-        // (no scheduled notifications) but the environment value still
-        // needs to resolve, and a fresh service is cheap.
-        let routing = NotificationRoutingService()
-        notificationRouting = routing
-
-        if SnapshotFixtures.isSnapshotMode {
-            // Bypass Core Data when the snapshot UI tests launch us —
-            // they need a deterministic, populated state and never want
-            // a stray SQLite file from a previous run leaking through.
-            repositories = SnapshotFixtures.makeSeededRepositories()
-            remoteChangeMonitor = RemoteChangeMonitor()
-            accountStatusMonitor = AccountStatusMonitor()
-            householdSharing = nil
-            notificationScheduler = NotificationScheduler()
-            notificationSettings = NotificationSettings()
-        } else if ProcessInfo.processInfo.environment["EMPTY_STORE"] == "1" {
-            // UI-test escape hatch: empty in-memory repos that exercise
-            // the real bootstrap flow without persisting anything to
-            // disk. Used by `BootstrapUITests` to regression-test the
-            // first-launch race.
-            repositories = .makePreview()
-            remoteChangeMonitor = RemoteChangeMonitor()
-            accountStatusMonitor = AccountStatusMonitor()
-            // `STUB_SHARING=1` swaps in `StubHouseholdSharingService`
-            // so `SharingUITests` can drive the Settings → Share
-            // Household path on CI without an iCloud account. Without
-            // the stub, `householdSharing` stays nil and the Share
-            // Household button hides — same behavior as
-            // `BootstrapUITests` and snapshot mode.
-            if ProcessInfo.processInfo.environment["STUB_SHARING"] == "1" {
-                householdSharing = StubHouseholdSharingService()
-            } else {
-                householdSharing = nil
-            }
-            notificationScheduler = NotificationScheduler()
-            notificationSettings = NotificationSettings()
-        } else if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-            // Unit tests load us via BUNDLE_LOADER, but the simulator has
-            // no iCloud account so `cloudKitContainer()` would fail to
-            // load. Repository contract tests stand up their own
-            // in-memory container — the host repos here are never read.
-            repositories = .makePreview()
-            remoteChangeMonitor = RemoteChangeMonitor()
-            accountStatusMonitor = AccountStatusMonitor()
-            householdSharing = nil
-            notificationScheduler = NotificationScheduler()
-            notificationSettings = NotificationSettings()
-        } else {
-            // Phase 2.1: production stack is CloudKit-mirrored. Phase 3
-            // adds the sharing service against the same container.
-            let container = CoreDataStack.cloudKitContainer()
-            let cloudKitContainer = CKContainer(
-                identifier: CoreDataStack.cloudKitContainerIdentifier
-            )
-            repositories = Repositories(
-                household: CoreDataHouseholdRepository(container: container),
-                location: CoreDataLocationRepository(container: container),
-                item: CoreDataItemRepository(container: container),
-                photo: CoreDataItemPhotoRepository(container: container)
-            )
-            remoteChangeMonitor = RemoteChangeMonitor(container: container)
-            accountStatusMonitor = AccountStatusMonitor(container: cloudKitContainer)
-            householdSharing = CloudHouseholdSharingService(
-                container: container,
-                cloudKitContainer: cloudKitContainer
-            )
-            // Phase 3.2: hand the share-acceptance service to the
-            // delegate so `application(_:userDidAcceptCloudKitShareWith:)`
-            // can import shared records when a recipient taps an
-            // invite. The delegate is instantiated by the system before
-            // this init runs, so a static var is the simplest seam.
-            NakedPantreeAppDelegate.wireShareAcceptance(
-                CloudShareAcceptance(container: container)
-            )
-            // Phase 9.3: persisted reminder time, constructed before
-            // the scheduler so it can read `settings.hourOfDay` /
-            // `.minute` when scheduling and when bundling same-day
-            // expiries (Phase 9.4 integration).
-            notificationSettings = NotificationSettings(defaults: .standard)
-            notificationScheduler = NotificationScheduler(
-                center: .current(),
-                settings: notificationSettings
-            )
-        }
-        // Phase 4.2: the delegate routes notification taps into this
-        // service. Same static-var pattern as `shareAcceptance` —
-        // delegate construction precedes app init, so the seam is a
-        // post-hoc handoff.
-        NakedPantreeAppDelegate.wireNotificationRouting(routing)
-    }
+    @State private var launcher = AppLauncher()
 
     var body: some Scene {
         WindowGroup {
-            RootView()
-                .environment(\.repositories, repositories)
-                .environment(\.remoteChangeMonitor, remoteChangeMonitor)
-                .environment(\.accountStatusMonitor, accountStatusMonitor)
-                .environment(\.householdSharing, householdSharing)
-                .environment(\.notificationScheduler, notificationScheduler)
-                .environment(\.notificationRouting, notificationRouting)
-                .environment(\.notificationSettings, notificationSettings)
+            switch launcher.state {
+            case .loading:
+                // The launcher transitions out of `.loading`
+                // synchronously inside `init`, so this branch only
+                // shows during the brief window between a `retry()` /
+                // `resetAndRetry()` call and the next `attemptLoad()`
+                // completing — single render frame in practice. Reuse
+                // `LaunchView` so the user sees the same brand splash
+                // they saw at cold-start.
+                LaunchView()
+            case .ready(let dependencies):
+                RootView()
+                    .environment(\.repositories, dependencies.repositories)
+                    .environment(\.remoteChangeMonitor, dependencies.remoteChangeMonitor)
+                    .environment(\.accountStatusMonitor, dependencies.accountStatusMonitor)
+                    .environment(\.householdSharing, dependencies.householdSharing)
+                    .environment(\.notificationScheduler, dependencies.notificationScheduler)
+                    .environment(\.notificationRouting, dependencies.notificationRouting)
+                    .environment(\.notificationSettings, dependencies.notificationSettings)
+            case .failed(let failure):
+                DataRecoveryView(
+                    errorDescription: failure.errorDescription,
+                    accountStatusMonitor: failure.accountStatusMonitor,
+                    onTryAgain: { launcher.retry() },
+                    onResetAndRetry: { launcher.resetAndRetry() }
+                )
+            }
         }
     }
 }

--- a/NakedPantreeApp/Features/Root/DataRecoveryView.swift
+++ b/NakedPantreeApp/Features/Root/DataRecoveryView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+/// User-facing surface shown when `AppLauncher` fails to load the
+/// Core Data stack on launch (issue #106). Two-tier remediation:
+///
+/// 1. **Try Again** — re-runs the build path. Fixes transient
+///    failures (disk pressure, brief filesystem hiccup) without
+///    destroying anything.
+/// 2. **Reset Local Data** — destructive; deletes the SQLite stores
+///    so CloudKit re-syncs from cloud. Gated on `accountStatusMonitor.status`
+///    being `.available` so a signed-out user can't permanently lose
+///    their pantry. Two-tap (button → confirmation alert) per
+///    DESIGN_GUIDELINES voice rules and Jack's call in the #106 PR
+///    discussion.
+///
+/// The view is intentionally pure-presentational: callbacks are
+/// handed in by `AppLauncher`, no environment dependencies beyond
+/// the `AccountStatusMonitor` (read for the gating).
+struct DataRecoveryView: View {
+    let errorDescription: String
+    let accountStatusMonitor: AccountStatusMonitor
+    let onTryAgain: () -> Void
+    let onResetAndRetry: () -> Void
+
+    @State private var isPresentingResetConfirmation = false
+    @State private var isShowingDetails = false
+
+    var body: some View {
+        ZStack {
+            Color.brandWarmCream
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.orange)
+                    .accessibilityHidden(true)
+
+                Text("Couldn't load your pantry")
+                    .font(.title2.weight(.semibold))
+                    .multilineTextAlignment(.center)
+
+                Text(bodyCopy)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+
+                detailsSection
+
+                Spacer()
+
+                actionButtons
+
+                if !canResetSafely {
+                    Text("Sign in to iCloud in Settings to make Reset safe to use.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .accessibilityIdentifier("recovery.icloudWarning")
+                }
+            }
+            .padding(.vertical, 32)
+        }
+        .accessibilityIdentifier("view.recovery")
+        .alert(
+            "Reset Local Data?",
+            isPresented: $isPresentingResetConfirmation
+        ) {
+            Button("Cancel", role: .cancel) {}
+            Button("Reset", role: .destructive) {
+                onResetAndRetry()
+            }
+            .accessibilityIdentifier("recovery.confirmReset")
+        } message: {
+            // Copy approved by Jack on #106. Avoids "loading" / "issue"
+            // jargon — describes consequences in user-domain terms.
+            Text(
+                "This deletes your pantry on this device. If iCloud is "
+                    + "available, it will re-sync. Otherwise, this can't be undone."
+            )
+        }
+    }
+
+    /// `.available` is the only `CKAccountStatus` value where we can
+    /// reasonably expect a re-sync to recover the user's data. Every
+    /// other state — signed-out, restricted, account temporarily
+    /// unavailable — risks permanent loss, so we hide the destructive
+    /// button entirely and explain via the inline note.
+    private var canResetSafely: Bool {
+        accountStatusMonitor.status == .available
+    }
+
+    /// Body copy adapts to whether we'll show the destructive button.
+    /// When iCloud isn't available, "Reset" isn't on the table — so
+    /// the body offers the user just the retry framing.
+    private var bodyCopy: String {
+        if canResetSafely {
+            return
+                "We couldn't open the local database. This is usually "
+                + "temporary — try again, or reset your local data and "
+                + "let iCloud sync it back."
+        } else {
+            return
+                "We couldn't open the local database. This is usually "
+                + "temporary — try again to retry the load."
+        }
+    }
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        DisclosureGroup(
+            isExpanded: $isShowingDetails,
+            content: {
+                Text(errorDescription)
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 8)
+                    .accessibilityIdentifier("recovery.errorDescription")
+            },
+            label: {
+                Text("Show technical details")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        )
+        .padding(.horizontal, 32)
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        VStack(spacing: 12) {
+            Button(action: onTryAgain) {
+                Text("Try Again")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(.brandForestGreen)
+            .accessibilityIdentifier("recovery.tryAgain")
+
+            if canResetSafely {
+                Button(role: .destructive) {
+                    isPresentingResetConfirmation = true
+                } label: {
+                    Text("Reset Local Data…")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .accessibilityIdentifier("recovery.resetLocalData")
+            }
+        }
+        .padding(.horizontal, 32)
+    }
+}
+
+#Preview("iCloud available") {
+    DataRecoveryView(
+        errorDescription:
+            "The persistent store could not be opened. (NSCocoaErrorDomain Code=134060)",
+        accountStatusMonitor: AccountStatusMonitor(),
+        onTryAgain: {},
+        onResetAndRetry: {}
+    )
+}

--- a/NakedPantreeTests/AppLauncherTests.swift
+++ b/NakedPantreeTests/AppLauncherTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+
+@testable import NakedPantree
+
+/// Coverage for the issue #106 store-load failure surface. The previous
+/// `fatalError` crashed the app on every launch when Core Data couldn't
+/// open its store. The launcher's new shape catches the throw, transitions
+/// to `.failed`, and re-runs the builder on retry / reset.
+@MainActor
+@Suite("AppLauncher")
+struct AppLauncherTests {
+    @Test("Builder succeeds — state is .ready, no failure surface")
+    func builderSuccessReadyState() {
+        let stubMonitor = AccountStatusMonitor()
+        var deleteCallCount = 0
+
+        let launcher = AppLauncher(
+            buildDependencies: { LiveDependencies.makeStub() },
+            makeFailureAccountMonitor: { stubMonitor },
+            deleteLocalStores: { deleteCallCount += 1 }
+        )
+
+        guard case .ready = launcher.state else {
+            Issue.record("Expected .ready, got: \(launcher.state)")
+            return
+        }
+        #expect(deleteCallCount == 0, "Reset action must not fire on a happy-path launch.")
+    }
+
+    @Test("Builder throws — state is .failed, monitor and description are surfaced")
+    func builderFailureCarriesContext() {
+        let stubMonitor = AccountStatusMonitor()
+        let underlying = LauncherTestError(message: "Stubbed store load failure")
+
+        let launcher = AppLauncher(
+            buildDependencies: { throw underlying },
+            makeFailureAccountMonitor: { stubMonitor },
+            deleteLocalStores: {}
+        )
+
+        guard case .failed(let failure) = launcher.state else {
+            Issue.record("Expected .failed, got: \(launcher.state)")
+            return
+        }
+        #expect(failure.errorDescription == underlying.localizedDescription)
+        // The recovery view reads `.status` off this exact instance, so
+        // identity matters — pin it.
+        #expect(failure.accountStatusMonitor === stubMonitor)
+    }
+
+    @Test("retry() re-runs the builder — failure → success transitions to .ready")
+    func retryRecoversAfterTransientFailure() {
+        let stubMonitor = AccountStatusMonitor()
+        var attemptCount = 0
+        // First call throws (transient failure), second call succeeds —
+        // models the user tapping Try Again after a brief filesystem
+        // hiccup.
+        let launcher = AppLauncher(
+            buildDependencies: {
+                attemptCount += 1
+                if attemptCount == 1 {
+                    throw LauncherTestError(message: "Transient")
+                }
+                return LiveDependencies.makeStub()
+            },
+            makeFailureAccountMonitor: { stubMonitor },
+            deleteLocalStores: {}
+        )
+
+        guard case .failed = launcher.state else {
+            Issue.record("Expected .failed after first attempt, got: \(launcher.state)")
+            return
+        }
+
+        launcher.retry()
+
+        guard case .ready = launcher.state else {
+            Issue.record("Expected .ready after retry, got: \(launcher.state)")
+            return
+        }
+        #expect(attemptCount == 2)
+    }
+
+    @Test("resetAndRetry() deletes local stores then re-runs the builder")
+    func resetAndRetryDeletesAndRebuilds() {
+        let stubMonitor = AccountStatusMonitor()
+        var deleteCallCount = 0
+        var attemptCount = 0
+        // First attempt throws (init); second attempt (post-reset) succeeds.
+        let launcher = AppLauncher(
+            buildDependencies: {
+                attemptCount += 1
+                if attemptCount == 1 {
+                    throw LauncherTestError(message: "Corrupt store")
+                }
+                return LiveDependencies.makeStub()
+            },
+            makeFailureAccountMonitor: { stubMonitor },
+            deleteLocalStores: { deleteCallCount += 1 }
+        )
+
+        guard case .failed = launcher.state else {
+            Issue.record("Expected .failed at init, got: \(launcher.state)")
+            return
+        }
+
+        launcher.resetAndRetry()
+
+        #expect(deleteCallCount == 1, "Reset must delete local stores exactly once.")
+        #expect(attemptCount == 2, "Reset must trigger a fresh build attempt.")
+        guard case .ready = launcher.state else {
+            Issue.record("Expected .ready after resetAndRetry, got: \(launcher.state)")
+            return
+        }
+    }
+
+    @Test("retry() does NOT call the delete-stores closure")
+    func retryDoesNotDelete() {
+        var deleteCallCount = 0
+        let launcher = AppLauncher(
+            buildDependencies: { throw LauncherTestError(message: "Persistent failure") },
+            makeFailureAccountMonitor: { AccountStatusMonitor() },
+            deleteLocalStores: { deleteCallCount += 1 }
+        )
+        launcher.retry()
+        #expect(
+            deleteCallCount == 0,
+            "Try Again must never delete user data — only Reset should."
+        )
+    }
+
+    @Test("After a persistent failure, state stays .failed across retries")
+    func persistentFailureStaysFailed() {
+        let launcher = AppLauncher(
+            buildDependencies: { throw LauncherTestError(message: "Always fails") },
+            makeFailureAccountMonitor: { AccountStatusMonitor() },
+            deleteLocalStores: {}
+        )
+        launcher.retry()
+        launcher.retry()
+        guard case .failed = launcher.state else {
+            Issue.record("Expected .failed, got: \(launcher.state)")
+            return
+        }
+    }
+}
+
+// MARK: - Test fixtures
+
+private struct LauncherTestError: LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
+}
+
+extension LiveDependencies {
+    /// Stubbed dependencies for `AppLauncher` tests — the builder
+    /// returns this on the success path so the launcher transitions
+    /// to `.ready` without standing up a real Core Data stack.
+    @MainActor
+    fileprivate static func makeStub() -> LiveDependencies {
+        LiveDependencies(
+            repositories: .makePreview(),
+            remoteChangeMonitor: RemoteChangeMonitor(),
+            accountStatusMonitor: AccountStatusMonitor(),
+            householdSharing: nil,
+            notificationScheduler: NotificationScheduler(),
+            notificationRouting: NotificationRoutingService(),
+            notificationSettings: NotificationSettings()
+        )
+    }
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataStack.swift
@@ -73,10 +73,18 @@ public enum CoreDataStack {
     /// without each repository having to remember.
     ///
     /// Both stores live in the OS-default Application Support directory.
+    ///
+    /// **Issue #106:** the load failure used to call `fatalError`, crashing
+    /// the app on every cold start when a user hit a corrupt SQLite or a
+    /// failed automatic mapping-model inference (which `shouldMigrate…` +
+    /// `shouldInferMappingModel…` can produce on dev-untested edge cases).
+    /// Now the function throws `CoreDataStackError.storeLoadFailed`; the
+    /// caller (`AppLauncher`) catches and routes the user into a recovery
+    /// surface with retry + iCloud-gated reset options.
     public static func cloudKitContainer(
         name: String = "NakedPantree",
         containerIdentifier: String = cloudKitContainerIdentifier
-    ) -> NSPersistentCloudKitContainer {
+    ) throws -> NSPersistentCloudKitContainer {
         let container = NSPersistentCloudKitContainer(name: name, managedObjectModel: model)
 
         let storeDirectory = NSPersistentContainer.defaultDirectoryURL()
@@ -101,13 +109,29 @@ public enum CoreDataStack {
             if let error { loadError = error }
         }
         if let loadError {
-            fatalError("CloudKit persistent stores failed to load: \(loadError)")
+            throw CoreDataStackError.storeLoadFailed(underlying: loadError)
         }
 
         container.viewContext.mergePolicy = defaultMergePolicy
         container.viewContext.automaticallyMergesChangesFromParent = true
 
         return container
+    }
+
+    /// File URLs of the on-disk SQLite stores plus their sidecar files
+    /// (`-shm`, `-wal`). Issue #106: `AppLauncher.resetAndRetry` deletes
+    /// these before re-attempting load. Exposed `public` so the launcher
+    /// (in the app target) can call into it without knowing the
+    /// per-store filename convention.
+    public static func cloudKitStoreFileURLs(
+        name: String = "NakedPantree"
+    ) -> [URL] {
+        let directory = NSPersistentContainer.defaultDirectoryURL()
+        let stems = ["\(name)-private.sqlite", "\(name)-shared.sqlite"]
+        let suffixes = ["", "-shm", "-wal"]
+        return stems.flatMap { stem in
+            suffixes.map { directory.appendingPathComponent(stem + $0) }
+        }
     }
 
     /// Returns the private CloudKit-backed store on a multi-store container,
@@ -172,6 +196,25 @@ public enum CoreDataStack {
     /// `ARCHITECTURE.md` §5 conflict resolution for the rationale.
     public static var defaultMergePolicy: NSMergePolicy {
         NSMergePolicy(merge: .mergeByPropertyObjectTrumpMergePolicyType)
+    }
+
+    /// Errors `cloudKitContainer(...)` can throw. Added in #106 — the
+    /// previous failure mode was `fatalError` on store load, crashing
+    /// the app with no recovery path. Callers (`AppLauncher`) catch
+    /// and route to the recovery surface.
+    public enum CoreDataStackError: Error, LocalizedError {
+        /// `loadPersistentStores` reported a non-nil error. The wrapped
+        /// `Error` is opaque (Core Data domain typically) — surface
+        /// `localizedDescription` to users; log the full value for
+        /// triage.
+        case storeLoadFailed(underlying: Error)
+
+        public var errorDescription: String? {
+            switch self {
+            case .storeLoadFailed(let underlying):
+                return underlying.localizedDescription
+            }
+        }
     }
 
     private static func makeDescription(


### PR DESCRIPTION
## Summary

Closes the #106 blocker. Replaces the `fatalError` in `CoreDataStack.cloudKitContainer()` with a typed throw + a recovery surface that lets the user retry or reset local data instead of staring at a launch crash.

## What changed

### `CoreDataStack.cloudKitContainer()` now `throws`

- New `CoreDataStackError.storeLoadFailed(underlying:)` carries the original Core Data error.
- The other three `fatalError` sites (`model`, `persistentContainer`, `inMemoryContainer`) are intentionally untouched — `model` is install-time bundle corruption (no recovery possible), the other two are test/tool paths.

### `AppLauncher` — new `@MainActor @Observable` state machine

States: `.loading` → `.ready(LiveDependencies)` | `.failed(LoadFailure)`.

Lifted the previous `NakedPantreeApp.init` body wholesale into `AppLauncher.makeProductionDependencies` — same branch order (snapshot → `EMPTY_STORE` → unit-test → production), same wiring, just throws-aware on the production path.

### `DataRecoveryView` — two-tier remediation UI

Per Jack's call on the design discussion:

- **Try Again** — re-runs the build path (handles transient failures: disk pressure, brief filesystem hiccup).
- **Reset Local Data…** — destructive, **gated on `accountStatusMonitor.status == .available`**. Two-tap: button → confirmation alert with the copy Jack approved (\"This deletes your pantry on this device. If iCloud is available, it will re-sync. Otherwise, this can't be undone.\"). Then deletes the SQLite + sidecar files and re-runs the build.
- When iCloud isn't available, the destructive button is **hidden entirely** and an inline note explains. Avoids permanent data loss for signed-out users — the load-bearing safety property of the design.

### `NakedPantreeApp` shrinks dramatically

`init` becomes just `@State var launcher = AppLauncher()`. Body switches on `launcher.state` and binds environments only on `.ready`.

### Tests

`AppLauncherTests` covers 6 paths:
- Builder success → `.ready`
- Builder throws → `.failed` with monitor + description surfaced
- `retry()` recovers from a transient failure (1st throw, 2nd succeed)
- `resetAndRetry()` deletes local stores **then** rebuilds
- `retry()` never deletes (load-bearing — Try Again must not destroy data)
- Persistent failures stay `.failed` across multiple retries

The `DataRecoveryView` itself is presentational — exercised through manual QA / preview, not unit-tested. Same shape as the existing `LaunchView`.

## What's a follow-up

The third #106 acceptance criterion was a migration-fixture regression test (older `.momd` snapshot pinned against the current model). I'm filing that as a separate issue — it's an independent test artifact that adds nothing to the recovery surface and would bloat this diff.

## Test plan

- [x] Clean rebuild: zero warnings
- [x] `AppLauncherTests` all pass (6/6)
- [x] Existing test suite still green (no regressions)
- [x] `./scripts/lint.sh` clean
- [ ] CI green
- [ ] Manual smoke: corrupt the SQLite by hand on a debug build, verify `DataRecoveryView` renders + Try Again recovers (after fix) + Reset works

🤖 Generated with [Claude Code](https://claude.com/claude-code)