### PR TITLE
fix(plist): configure UILaunchScreen with brand cream background (#87)

### DIFF
--- a/NakedPantreeApp/Resources/Info.plist
+++ b/NakedPantreeApp/Resources/Info.plist
@@ -58,8 +58,35 @@
     <array>
         <string>remote-notification</string>
     </array>
+    <!--
+        Issue #87 — UIKit's "Update the Info.plist: Launch screens
+        will soon be required" runtime warning was firing because
+        the previous value was an empty dict, which iOS treats as
+        "no launch screen configured". Apple is moving toward
+        making `UILaunchScreen` mandatory for App Store submission,
+        so this is a release blocker as much as a polish item.
+
+        Color: `BrandWarmCream` from `Assets.xcassets/Brand/`. The
+        catalog's `Brand` group has `provides-namespace: false` so
+        the launch screen resolves the bare name without needing
+        `Brand/BrandWarmCream`. This matches the in-app cream
+        background of `LaunchView` (Phase 8.2 splash) — no flash
+        on handoff between the OS launch screen and the first
+        SwiftUI frame.
+
+        No `UIImageName` yet — the brand wordmark exists as text in
+        `LaunchView`, not as an asset image, and the launch screen
+        takes a static image not text. Adding an image is a polish
+        follow-up; the cream background alone satisfies the
+        requirement and avoids the blank-window flash.
+    -->
     <key>UILaunchScreen</key>
-    <dict/>
+    <dict>
+        <key>UIColorName</key>
+        <string>BrandWarmCream</string>
+        <key>UIImageRespectsSafeAreaInsets</key>
+        <true/>
+    </dict>
     <key>UISupportedInterfaceOrientations</key>
     <array>
         <string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Summary

Closes #87. UIKit was firing the \"Update the Info.plist: Launch screens will soon be required\" runtime warning at every cold launch — the previous value was an empty \`<dict/>\` which iOS treats as no launch screen.

Set \`UIColorName\` to \`BrandWarmCream\` so there's no flash on handoff to \`LaunchView\` (Phase 8.2 splash uses the same color).

No \`UIImageName\` yet — the brand wordmark exists as SwiftUI text in \`LaunchView\`, not as a static image. Adding a logo asset is a polish follow-up; the cream background alone clears the warning and avoids the blank-window flash.

## Test plan

- [x] Build clean, no compiler/runtime warnings about launch screens
- [x] Local simulator launch — confirmed no \`Update the Info.plist\` warning in Console
- [x] Lint clean
- [ ] CI green
- [ ] User verifies cold-launch on real device shows the cream background, not a blank window

🤖 Generated with [Claude Code](https://claude.com/claude-code)