### PR TITLE
fix(sync): clarify sign-out banner copy + pin local-first write policy (#109)

### DIFF
--- a/NakedPantreeApp/App/AccountStatusMonitor.swift
+++ b/NakedPantreeApp/App/AccountStatusMonitor.swift
@@ -37,6 +37,19 @@ enum AccountStatus: Sendable, Hashable {
 /// and refreshes whenever `.CKAccountChanged` fires; the brief moment
 /// before the first probe finishes shows no banner, which is the same
 /// outcome as a healthy account — acceptable.
+///
+/// **Policy: writes are local-first regardless of account status (issue #109).**
+/// `ItemFormSaveCoordinator` / `LocationFormSaveCoordinator` deliberately
+/// don't consult this monitor before persisting — `NSPersistentCloudKitContainer`
+/// queues unsynced writes in its local store and replays them once the
+/// account becomes `.available` again. The banner is the only signal we
+/// surface; we don't gate the save button or block writes when the user
+/// is signed out, restricted, or offline. Adding a write-time guard here
+/// would degrade the offline-first experience (a brief network blip would
+/// stop edits) without preventing data loss — the data is already on
+/// disk. If you're tempted to thread `accountStatus` into a save path,
+/// re-read this paragraph and the structural test in
+/// `FormSaveCoordinatorTests` first.
 @Observable
 @MainActor
 final class AccountStatusMonitor {

--- a/NakedPantreeApp/Features/Root/AccountStatusBanner.swift
+++ b/NakedPantreeApp/Features/Root/AccountStatusBanner.swift
@@ -61,9 +61,15 @@ extension AccountStatus {
         case .available:
             nil
         case .noAccount:
-            "Sign in to iCloud to keep your pantry in sync across devices."
+            // Issue #109: spell out the local-first policy explicitly so a
+            // signed-out user understands their edits are not lost. The
+            // `Settings` button still offers the path back to syncing.
+            "Signed out of iCloud. Changes save on this device and will sync when you sign back in."
         case .restricted:
-            "iCloud is restricted on this device. Changes won't sync."
+            // Issue #109: parallel framing to `.noAccount` — restricted
+            // accounts can't sign in to remediate, but local saves still
+            // succeed. Avoid implying the device is read-only.
+            "iCloud is restricted on this device. Changes save here but won't sync."
         case .couldNotDetermine:
             "iCloud is unreachable. Changes will sync when it's back."
         case .temporarilyUnavailable:

--- a/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
+++ b/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import NakedPantree
 @testable import NakedPantreeDomain
 
@@ -217,6 +218,23 @@ struct ItemFormSaveCoordinatorTests {
         #expect(center.addedRequests.isEmpty)
         #expect(center.removedIdentifiersBatches.isEmpty)
     }
+
+    /// Issue #109: writes are local-first regardless of iCloud account
+    /// status. `NSPersistentCloudKitContainer` queues unsynced writes in
+    /// its local store and replays them once the account becomes
+    /// `.available` again, so threading `AccountStatusMonitor` into the
+    /// save path would only degrade offline-first behavior without
+    /// preventing data loss. This binding pins the parameter list — if
+    /// a future refactor adds a required `monitor:` parameter, the
+    /// assignment fails to compile and forces a re-read of the policy
+    /// doc in `AccountStatusMonitor.swift`.
+    @Test("Issue #109: save signature has no AccountStatusMonitor parameter")
+    func saveSignatureOmitsAccountStatusGuard() {
+        let _:
+            (
+                ItemFormView.Mode, ItemFormDraft, any ItemRepository, NotificationScheduler
+            ) async throws -> Item = ItemFormSaveCoordinator.save
+    }
 }
 
 // MARK: - Location form
@@ -293,6 +311,18 @@ struct LocationFormSaveCoordinatorTests {
                 repository: repo
             )
         }
+    }
+
+    /// Companion to `ItemFormSaveCoordinatorTests.saveSignatureOmitsAccountStatusGuard`.
+    /// Same intent: pin the parameter list so issue #109's local-first
+    /// policy can't be silently undone. See the policy paragraph in
+    /// `AccountStatusMonitor.swift` for the rationale.
+    @Test("Issue #109: save signature has no AccountStatusMonitor parameter")
+    func saveSignatureOmitsAccountStatusGuard() {
+        let _:
+            (
+                LocationFormView.Mode, LocationFormDraft, any LocationRepository
+            ) async throws -> Location = LocationFormSaveCoordinator.save
     }
 }
 


### PR DESCRIPTION
## Summary
- Tighten `.noAccount` and `.restricted` `AccountStatusBanner` copy so a signed-out user understands their edits are saved on-device and will replay when iCloud returns. The previous `.noAccount` text read like a prerequisite ("Sign in to iCloud to keep your pantry in sync"); the new copy spells out the local-first policy.
- Document the policy on `AccountStatusMonitor` so future contributors don't reflexively add a write-time guard. `NSPersistentCloudKitContainer` already queues unsynced rows; gating saves on `accountStatus` would only hurt the offline-first experience.
- Add two structural regression tests (one per save coordinator) that pin the `save(...)` parameter list via a typed function reference. If a future refactor adds a required `accountStatusMonitor:` parameter, the assignment fails to compile and the change author must re-read the policy doc.

Closes #109.

## Notes on scope

The issue offered two policy shapes — (A) hard-block writes when iCloud is unavailable, or (B) allow writes and surface a queue-warning. The user's response was to "write it locally then sync when iCloud comes back online" — i.e. neither A nor B as a behavioral change, because **the existing behavior already matches B**: `NSPersistentCloudKitContainer` queues automatically. The remaining gap was UX: the banner copy didn't make the local-first guarantee explicit. This PR closes that gap in copy + pins the architectural decision in code.

The advisor explicitly steered this away from adding a toast or refactoring writes; see the policy paragraph in `AccountStatusMonitor.swift` for the rationale embedded in code.

## Test plan
- [x] `LocationFormSaveCoordinatorTests` and `ItemFormSaveCoordinatorTests` (incl. new structural test) pass — 22 tests across 4 suites green locally
- [x] `AccountStatusTests` voice/length tests still pass against the new copy (longest message is 86 chars; under the 120-char ceiling)
- [x] `swift-format --strict` + swiftlint clean via `./scripts/lint.sh`
- [x] Core SPM tests pass (`cd Packages/Core && swift test`)
- [ ] Reviewer: eyeball both banner messages on a small-iPhone preview to confirm they don't truncate at default DynamicType

🤖 Generated with [Claude Code](https://claude.com/claude-code)