### PR TITLE
feat(domain): Item.needsRestocking + smart-list contract (#16, foundation)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,6 +147,7 @@ forward-incompatible client don't crash decode.
 | `unitRaw` | String | `Unit` enum raw, default `"count"` |
 | `expiresAt` | Date? | Drives expiry notifications |
 | `notes` | String? | |
+| `needsRestocking` | Bool | Default `false`. User-flagged restock signal — issue #16. Surfaces in the "Needs Restocking" smart list together with `quantity == 0`. |
 | `createdAt` | Date | |
 | `updatedAt` | Date | Touched on every edit |
 | `location` | `Location?` | Inverse |

--- a/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
+++ b/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
@@ -314,6 +314,10 @@ private actor ThrowingItemRepository: ItemRepository {
     func updateQuantity(id: Item.ID, quantity: Int32) async throws {
         throw FormCoordinatorTestError()
     }
+    func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        throw FormCoordinatorTestError()
+    }
+    func needsRestocking(in householdID: Household.ID) async throws -> [Item] { [] }
     func delete(id: Item.ID) async throws { throw FormCoordinatorTestError() }
 }
 

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -671,6 +671,197 @@ struct ItemRepositoryContractTests {
     }
 }
 
+/// Issue #16: smart-list contract for items that need restocking. Lives
+/// in its own suite (rather than nested in `ItemRepositoryContractTests`)
+/// because adding it inline pushed that struct past
+/// SwiftLint's `type_body_length` ceiling, and these tests cohere
+/// around a single feature anyway.
+@Suite("ItemRepository needs-restocking contract")
+struct ItemRepositoryNeedsRestockingContractTests {
+    @Test(
+        "create + item(id:) round-trips needsRestocking",
+        arguments: RepositoryFactory.all)
+    func needsRestockingRoundTrips(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        // Default false branch.
+        let bread = Item(locationID: kitchen.id, name: "Bread")
+        try await itemRepo.create(bread)
+        let breadFetched = try #require(try await itemRepo.item(id: bread.id))
+        #expect(breadFetched.needsRestocking == false)
+
+        // Explicit true branch.
+        let coffee = Item(locationID: kitchen.id, name: "Coffee", needsRestocking: true)
+        try await itemRepo.create(coffee)
+        let coffeeFetched = try #require(try await itemRepo.item(id: coffee.id))
+        #expect(coffeeFetched.needsRestocking == true)
+    }
+
+    @Test(
+        "setNeedsRestocking flips only that flag — quantity / name / expiresAt untouched",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingIsPartial(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let expiry = Date(timeIntervalSince1970: 1_000_000)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Yogurt",
+            quantity: 2,
+            unit: .count,
+            expiresAt: expiry,
+            notes: "Plain greek"
+        )
+        try await itemRepo.create(item)
+
+        // Same race contract as `updateQuantity` (#118): the partial
+        // update must NOT touch sibling fields. Issue #16: a swipe
+        // action / detail toggle that races a form save shouldn't
+        // clobber the form's just-saved name/expiry/notes.
+        try await itemRepo.setNeedsRestocking(id: item.id, needsRestocking: true)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.needsRestocking == true)
+        #expect(after.quantity == 2)
+        #expect(after.name == "Yogurt")
+        #expect(after.expiresAt == expiry)
+        #expect(after.notes == "Plain greek")
+        #expect(after.unit == .count)
+    }
+
+    @Test(
+        "setNeedsRestocking is a no-op when the item id doesn't exist",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingMissingIDIsNoOp(factory: RepositoryFactory) async throws {
+        let itemRepo = factory.make().item
+        // Random UUID — not in the empty repo. Should silently no-op,
+        // matching `update(_:)` / `updateQuantity` semantics.
+        try await itemRepo.setNeedsRestocking(id: UUID(), needsRestocking: true)
+    }
+
+    @Test(
+        "setNeedsRestocking stamps updatedAt",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingStampsTimestamp(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let originalDate = Date(timeIntervalSince1970: 1)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Coffee",
+            createdAt: originalDate,
+            updatedAt: originalDate
+        )
+        try await itemRepo.create(item)
+
+        try await itemRepo.setNeedsRestocking(id: item.id, needsRestocking: true)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.createdAt == originalDate)
+        #expect(after.updatedAt > originalDate)
+    }
+
+    @Test(
+        "needsRestocking(in:) includes flagged + zero-quantity items, sorted by name",
+        arguments: RepositoryFactory.all)
+    func needsRestockingUnion(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Pantry")
+        let freezer = Location(householdID: house.id, name: "Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        // Flagged manually (typical "we'll need this soon") — non-zero qty.
+        try await itemRepo.create(
+            Item(locationID: pantry.id, name: "Olive Oil", quantity: 1, needsRestocking: true)
+        )
+        // Implicitly out-of-stock (zero qty, not flagged) — kept around
+        // so the user remembers it's a staple.
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Coffee", quantity: 0))
+        // In another location, flagged.
+        try await itemRepo.create(
+            Item(locationID: freezer.id, name: "Ice Cream", quantity: 2, needsRestocking: true)
+        )
+        // Has stock and not flagged — should be excluded.
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Rice", quantity: 5))
+        // Both flagged AND zero qty — appears once, not duplicated.
+        try await itemRepo.create(
+            Item(locationID: freezer.id, name: "Bread", quantity: 0, needsRestocking: true)
+        )
+
+        let restocking = try await itemRepo.needsRestocking(in: house.id)
+        #expect(restocking.map(\.name) == ["Bread", "Coffee", "Ice Cream", "Olive Oil"])
+    }
+
+    @Test(
+        "needsRestocking(in:) is scoped — items in other households are filtered out",
+        arguments: RepositoryFactory.all)
+    func needsRestockingScopedByHousehold(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+
+        let mine = try await household.currentHousehold()
+        let elsewhere = Household(name: "Mom's Pantry")
+        let myKitchen = Location(householdID: mine.id, name: "Kitchen")
+        let momsKitchen = Location(householdID: elsewhere.id, name: "Mom's Kitchen")
+        try await locationRepo.create(myKitchen)
+        try await locationRepo.create(momsKitchen)
+
+        try await itemRepo.create(
+            Item(locationID: myKitchen.id, name: "My Coffee", needsRestocking: true)
+        )
+        try await itemRepo.create(
+            Item(locationID: momsKitchen.id, name: "Mom's Coffee", needsRestocking: true)
+        )
+
+        let mineResults = try await itemRepo.needsRestocking(in: mine.id)
+        #expect(mineResults.map(\.name) == ["My Coffee"])
+    }
+
+    @Test(
+        "needsRestocking(in:) is empty when nothing qualifies",
+        arguments: RepositoryFactory.all)
+    func needsRestockingEmpty(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Rice", quantity: 5))
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Beans", quantity: 3))
+
+        let restocking = try await itemRepo.needsRestocking(in: house.id)
+        #expect(restocking.isEmpty)
+    }
+}
+
 @Suite("ItemPhotoRepository contract")
 struct ItemPhotoRepositoryContractTests {
     @Test(

--- a/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
@@ -54,6 +54,14 @@ public struct Item: Sendable, Hashable, Identifiable {
     public var unit: Unit
     public var expiresAt: Date?
     public var notes: String?
+    /// Issue #16: user-flagged restock signal. Survives sync. Set from a
+    /// detail-view toggle or a swipe action on any items list. Items with
+    /// `needsRestocking == true` *or* `quantity == 0` surface in the
+    /// "Needs Restocking" smart list — see `ItemRepository.needsRestocking(in:)`.
+    /// Default `false` so existing rows in CloudKit / Core Data parse
+    /// without migration; the new column writes `false` on insert and
+    /// the in-memory store seeds it the same way.
+    public var needsRestocking: Bool
     public let createdAt: Date
     public var updatedAt: Date
 
@@ -65,6 +73,7 @@ public struct Item: Sendable, Hashable, Identifiable {
         unit: Unit = .count,
         expiresAt: Date? = nil,
         notes: String? = nil,
+        needsRestocking: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -75,6 +84,7 @@ public struct Item: Sendable, Hashable, Identifiable {
         self.unit = unit
         self.expiresAt = expiresAt
         self.notes = notes
+        self.needsRestocking = needsRestocking
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -200,6 +200,29 @@ public actor InMemoryItemRepository: ItemRepository {
         items[id] = existing
     }
 
+    public func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        // Issue #16: partial update — touch only `needsRestocking`
+        // and `updatedAt`. Same actor-serialized atomicity as
+        // `updateQuantity`.
+        guard var existing = items[id] else { return }
+        existing.needsRestocking = needsRestocking
+        existing.updatedAt = Date()
+        items[id] = existing
+    }
+
+    public func needsRestocking(in householdID: Household.ID) async throws -> [Item] {
+        var results: [Item] = []
+        for item in items.values where item.needsRestocking || item.quantity == 0 {
+            let location = try await locationLookup(item.locationID)
+            if location?.householdID == householdID {
+                results.append(item)
+            }
+        }
+        return results.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
     public func delete(id: Item.ID) async throws {
         items.removeValue(forKey: id)
     }

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -121,6 +121,22 @@ public protocol ItemRepository: Sendable {
     /// schedule and persist) — same shape as `update(_:)`'s
     /// silent-skip semantics on a missing row.
     func updateQuantity(id: Item.ID, quantity: Int32) async throws
+    /// Partial update that touches only `needsRestocking` (and stamps
+    /// `updatedAt`), leaving every other attribute untouched. Issue
+    /// #16: same race-prevention shape as `updateQuantity` — the
+    /// detail-view toggle and the swipe action both flip a single
+    /// boolean, and a full fetch-modify-save round-trip would race
+    /// concurrent edit-form saves of `name` / `expiresAt`.
+    ///
+    /// No-op if the item doesn't exist (deleted between gesture and
+    /// persist) — same shape as `update(_:)`'s silent-skip semantics.
+    func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws
+    /// Items in the household that need restocking — flagged manually
+    /// (`needsRestocking == true`) or implicitly out-of-stock
+    /// (`quantity == 0`). Backs the "Needs Restocking" smart list
+    /// (issue #16). Sorted by name for stable list output, matching
+    /// `allItems(in:)`.
+    func needsRestocking(in householdID: Household.ID) async throws -> [Item]
     func delete(id: Item.ID) async throws
 }
 

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
@@ -124,6 +124,39 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         }
     }
 
+    public func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        // Issue #16: partial update — touches `needsRestocking` and
+        // `updatedAt` only. Mirrors `updateQuantity`'s race-prevention
+        // shape: a swipe action or detail toggle flipping a single bool
+        // shouldn't read-modify-write a whole `Item` and risk clobbering
+        // a concurrent edit-form save of `name` / `expiresAt`.
+        try await container.performBackgroundTaskWithDefaults { context in
+            guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
+            row.setValue(needsRestocking, forKey: "needsRestocking")
+            row.setValue(Date(), forKey: "updatedAt")
+            try context.save()
+        }
+    }
+
+    public func needsRestocking(in householdID: Household.ID) async throws -> [Item] {
+        // Issue #16: union of explicitly-flagged and implicitly-out-of-stock
+        // items in the household. The OR predicate runs at the Core Data
+        // layer so the fetch returns only matching rows — no in-memory
+        // filtering. Sort by name to match `allItems(in:)`'s order.
+        try await container.performBackgroundTaskWithDefaults { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+            request.predicate = NSPredicate(
+                format:
+                    "location.household.id == %@ AND (needsRestocking == YES OR quantity == 0)",
+                householdID as CVarArg
+            )
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "name", ascending: true)
+            ]
+            return try context.fetch(request).map(Self.makeItem)
+        }
+    }
+
     public func delete(id: Item.ID) async throws {
         try await container.performBackgroundTaskWithDefaults { context in
             guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
@@ -143,6 +176,7 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         row.setValue(item.unit.rawValue, forKey: "unitRaw")
         row.setValue(item.expiresAt, forKey: "expiresAt")
         row.setValue(item.notes, forKey: "notes")
+        row.setValue(item.needsRestocking, forKey: "needsRestocking")
         row.setValue(item.createdAt, forKey: "createdAt")
         row.setValue(stampUpdatedAt ? Date() : item.updatedAt, forKey: "updatedAt")
     }
@@ -205,6 +239,10 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
             unit: Unit(rawValue: row.value(forKey: "unitRaw") as? String ?? "count"),
             expiresAt: row.value(forKey: "expiresAt") as? Date,
             notes: row.value(forKey: "notes") as? String,
+            // Issue #16: defaults to `false` for rows persisted before
+            // the column existed (CloudKit additive migration — the
+            // attribute is optional with `defaultValueString="NO"`).
+            needsRestocking: row.value(forKey: "needsRestocking") as? Bool ?? false,
             createdAt: row.value(forKey: "createdAt") as? Date ?? Date(),
             updatedAt: row.value(forKey: "updatedAt") as? Date ?? Date()
         )

--- a/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
+++ b/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
@@ -20,6 +20,7 @@
         <attribute name="expiresAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="needsRestocking" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="notes" optional="YES" attributeType="String"/>
         <attribute name="quantity" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="unitRaw" optional="YES" attributeType="String" defaultValueString="count"/>


### PR DESCRIPTION
## Summary

First of **two stacked PRs** for issue #16 ("identify items that need to be added to a grocery list"). This PR is **data-foundation only** — no user-visible surface yet. The UI (sidebar smart list entry, content view, detail toggle, swipe action, form integration) lands in a follow-up branch stacked on this one so the schema lands ahead of the surface that depends on it.

The split keeps each diff small and gives you a reviewable schema change before I commit to the UI shape.

### What's in this PR

**Schema**
- `Item.needsRestocking: Bool` (default `false`) on the domain value type and the `ItemEntity` Core Data attribute. Additive — existing rows in iCloud parse without migration; the row→Item branch defaults missing values to `false`.

**Repository contract**
- `ItemRepository.setNeedsRestocking(id:needsRestocking:)` — partial update (same race-prevention shape as `updateQuantity`, issue #118). The swipe action / detail toggle in PR 2 will call this rather than round-tripping a full `Item`, so a concurrent edit-form save can't clobber `name` / `expiresAt`.
- `ItemRepository.needsRestocking(in:)` — returns the union of user-flagged (`needsRestocking == true`) and implicitly-out-of-stock (`quantity == 0`) items in the household, sorted by name. The OR predicate runs at the Core Data fetch layer.

**Docs**
- `ARCHITECTURE.md` §4 Item table updated per `AGENTS.md` §2 hard rule.

### What's *not* in this PR (deferred to PR 2)

- `SmartList.needsRestocking` enum case + sidebar entry
- `NeedsRestockingView` content column
- Detail-view toggle on `ItemDetailView`
- Swipe action on item list rows
- `ItemFormView` integration (set the flag at create/edit time)

### What's deferred entirely (per the issue's "stretch")

- `Item.restockThreshold: Int32?` — out of scope for v1.0
- Apple Reminders push (separate `ARCHITECTURE.md` §12 line item)

## Test plan

- [x] `ItemRepositoryNeedsRestockingContractTests` (new suite, 7 tests × 2 factories = 14 cases) green locally — round-trip, partial-update non-clobber, no-op on missing id, updatedAt stamp, union semantics, household scoping, empty fallback
- [x] Existing `ItemRepositoryContractTests` still green
- [x] Core SPM tests green (`swift test` in `Packages/Core`)
- [x] `swift-format --strict` + swiftlint clean via `./scripts/lint.sh`
- [ ] Reviewer: confirm the additive Core Data attribute (`Boolean optional, default NO`) is the right CloudKit-friendly shape; remember that the CloudKit dev schema needs a manual `needsRestocking` column added in the Dashboard before this lands in production (issue #16 ACs call this out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)