### PR TITLE
feat(ui): Needs Restocking smart list + detail toggle + swipe action (#16)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -147,6 +147,7 @@ forward-incompatible client don't crash decode.
 | `unitRaw` | String | `Unit` enum raw, default `"count"` |
 | `expiresAt` | Date? | Drives expiry notifications |
 | `notes` | String? | |
+| `needsRestocking` | Bool | Default `false`. User-flagged restock signal — issue #16. Surfaces in the "Needs Restocking" smart list together with `quantity == 0`. |
 | `createdAt` | Date | |
 | `updatedAt` | Date | Touched on every edit |
 | `location` | `Location?` | Inverse |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -317,6 +317,7 @@ Smart Lists
   ▢ Expiring Soon       (items with expiresAt within 7 days, sorted soonest)
   ▢ All Items           (every item across every location, sorted by name)
   ▢ Recently Added      (items added in the last 14 days)
+  ▢ Needs Restocking    (items flagged for restock or out of stock — issue #16)
 
 Locations
   🥫 Kitchen Pantry

--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -25,6 +25,21 @@ struct AllItemsView: View {
                     ForEach(items) { item in
                         AllItemsRow(item: item, locationName: locationsByID[item.locationID]?.name)
                             .tag(item.id)
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                                // Issue #16: cross-location restock
+                                // toggle. Uses the same partial-update
+                                // path as the per-location list so a
+                                // burst of taps doesn't race an
+                                // edit-form save.
+                                RestockSwipeButton(item: item) { newValue in
+                                    Task {
+                                        await toggleRestocking(
+                                            for: item.id,
+                                            to: newValue
+                                        )
+                                    }
+                                }
+                            }
                     }
                 }
                 .scrollContentBackground(.hidden)
@@ -58,6 +73,19 @@ struct AllItemsView: View {
             items = []
         }
         didLoad = true
+    }
+
+    /// Issue #16: persists the swipe-action toggle and reloads.
+    private func toggleRestocking(for id: Item.ID, to newValue: Bool) async {
+        do {
+            try await repositories.item.setNeedsRestocking(
+                id: id,
+                needsRestocking: newValue
+            )
+            await load()
+        } catch {
+            // Soft-fail — next remote-change tick reloads.
+        }
     }
 }
 

--- a/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
+++ b/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
@@ -49,6 +49,20 @@ struct ExpiringSoonView: View {
                             locationName: locationsByID[item.locationID]?.name
                         )
                         .tag(item.id)
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            // Issue #16: same restock toggle as the
+                            // other smart lists. Useful here for "this
+                            // is about to expire AND we'll need a
+                            // replacement" two-bird gestures.
+                            RestockSwipeButton(item: item) { newValue in
+                                Task {
+                                    await toggleRestocking(
+                                        for: item.id,
+                                        to: newValue
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
                 .scrollContentBackground(.hidden)
@@ -81,6 +95,19 @@ struct ExpiringSoonView: View {
             items = []
         }
         didLoad = true
+    }
+
+    /// Issue #16: persists the swipe-action toggle and reloads.
+    private func toggleRestocking(for id: Item.ID, to newValue: Bool) async {
+        do {
+            try await repositories.item.setNeedsRestocking(
+                id: id,
+                needsRestocking: newValue
+            )
+            await load()
+        } catch {
+            // Soft-fail — next remote-change tick reloads.
+        }
     }
 }
 

--- a/NakedPantreeApp/Features/Items/ItemDetailView.swift
+++ b/NakedPantreeApp/Features/Items/ItemDetailView.swift
@@ -166,6 +166,13 @@ struct ItemDetailView: View {
                 }
             }
 
+            // Issue #16: persistent toggle for the "Needs Restocking"
+            // smart list. Lives in its own subview to keep this
+            // detail body under SwiftLint's `type_body_length`
+            // ceiling — see the photo extension below for the same
+            // rationale.
+            RestockSection(item: item)
+
             if let expiresAt = item.expiresAt {
                 Section("Expires") {
                     Text(expiresAt, style: .date)

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -115,6 +115,8 @@ struct ItemsView: View {
             ExpiringSoonView(selectedItemID: $selectedItemID)
         case .recentlyAdded:
             RecentlyAddedView(selectedItemID: $selectedItemID)
+        case .needsRestocking:
+            NeedsRestockingView(selectedItemID: $selectedItemID)
         }
     }
 
@@ -149,6 +151,20 @@ struct ItemsView: View {
                             }
                             .tint(.indigo)
                         }
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            // Issue #16: leading edge for the
+                            // restock toggle keeps it visually
+                            // distinct from the destructive trailing
+                            // actions.
+                            RestockSwipeButton(item: item) { newValue in
+                                Task {
+                                    await toggleRestocking(
+                                        for: item.id,
+                                        to: newValue
+                                    )
+                                }
+                            }
+                        }
                 }
             }
             .scrollContentBackground(.hidden)
@@ -164,6 +180,24 @@ struct ItemsView: View {
     @ViewBuilder
     private func placeholder(_ message: String) -> some View {
         ContentUnavailableView(message, systemImage: "list.bullet")
+    }
+
+    /// Issue #16: persists the swipe-action toggle and reloads. Hides
+    /// repository-call ceremony from the row's `.swipeActions` block
+    /// where it would clutter the view body.
+    private func toggleRestocking(for id: Item.ID, to newValue: Bool) async {
+        do {
+            try await repositories.item.setNeedsRestocking(
+                id: id,
+                needsRestocking: newValue
+            )
+            if case .location(let locationID) = selection {
+                await reload(locationID: locationID)
+            }
+        } catch {
+            // Soft-fail — the next remote-change tick will reload
+            // canonical state. Same shape as `delete`'s catch arm.
+        }
     }
 
     private func reload(locationID: Location.ID) async {

--- a/NakedPantreeApp/Features/Items/NeedsRestockingView.swift
+++ b/NakedPantreeApp/Features/Items/NeedsRestockingView.swift
@@ -1,25 +1,18 @@
 import NakedPantreeDomain
 import SwiftUI
 
-/// Sorts a household's items by `createdAt` descending — most-recent
-/// adds first. Pure free function so tests can pin the input order
-/// and verify the sort without a Core Data round-trip.
+/// Issue #16: "Needs Restocking" smart-list content column. Cross-
+/// household list of items the user has flagged for restocking
+/// (`needsRestocking == true`) or that are out of stock
+/// (`quantity == 0`). The repository handles the union and sort —
+/// see `ItemRepository.needsRestocking(in:)`.
 ///
-/// No time-window or count cap. The smart list is "items by recency,"
-/// not "items added in the last N days" — a household with 50 items
-/// total still scrolls cheaply, and capping is a polish decision
-/// better made when real-world household sizes are visible. Same
-/// shape as `itemsExpiringSoon` (no cutoff there either) — keep the
-/// two consistent.
-func itemsRecentlyAdded(_ items: [Item]) -> [Item] {
-    items.sorted { $0.createdAt > $1.createdAt }
-}
-
-/// "Recently Added" smart-list content column. Cross-location list of
-/// every item in the household, sorted with the most-recently-added
-/// first. Useful for "what did I just put in" and "did my partner add
-/// anything since I last looked."
-struct RecentlyAddedView: View {
+/// Same shape as `AllItemsView` / `RecentlyAddedView`: load on the
+/// remote-change tick, render rows + leading swipe to flip the flag
+/// off (the swipe label flips to "Got it" when the item is already
+/// flagged), trailing swipe stays empty here — destructive deletes
+/// belong on the per-location list, not on a smart projection.
+struct NeedsRestockingView: View {
     @Binding var selectedItemID: Item.ID?
 
     @Environment(\.repositories) private var repositories
@@ -37,24 +30,14 @@ struct RecentlyAddedView: View {
             } else {
                 List(selection: $selectedItemID) {
                     ForEach(items) { item in
-                        RecentlyAddedRow(
+                        NeedsRestockingRow(
                             item: item,
                             locationName: locationsByID[item.locationID]?.name
                         )
                         .tag(item.id)
                         .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                            // Issue #16: restock toggle on the
-                            // most-recent feed too — sometimes the
-                            // shopper-of-record adds an item right
-                            // after a trip and immediately wants to
-                            // re-flag it for next time.
                             RestockSwipeButton(item: item) { newValue in
-                                Task {
-                                    await toggleRestocking(
-                                        for: item.id,
-                                        to: newValue
-                                    )
-                                }
+                                Task { await toggle(item.id, to: newValue) }
                             }
                         }
                     }
@@ -63,7 +46,7 @@ struct RecentlyAddedView: View {
                 .background(Color.surface)
             }
         }
-        .navigationTitle("Recently Added")
+        .navigationTitle("Needs Restocking")
         .task(id: remoteChangeMonitor.changeToken) {
             await load()
         }
@@ -71,10 +54,14 @@ struct RecentlyAddedView: View {
 
     @ViewBuilder
     private var emptyState: some View {
+        // Voice rule §10: short, calming, with a brand wink that's
+        // *not* about a sync failure (those are off-limits per §9).
+        // "Pantry's stocked." was the canonical line in the issue's
+        // empty-state suggestion — keeping it.
         ContentUnavailableView(
-            "Nothing added yet",
-            systemImage: "sparkles",
-            description: Text("Items you add will show up here.")
+            "Pantry's stocked.",
+            systemImage: "checkmark.seal",
+            description: Text("Items you flag for restocking will show up here.")
         )
     }
 
@@ -83,16 +70,14 @@ struct RecentlyAddedView: View {
             let household = try await repositories.household.currentHousehold()
             let locations = try await repositories.location.locations(in: household.id)
             locationsByID = Dictionary(uniqueKeysWithValues: locations.map { ($0.id, $0) })
-            let allItems = try await repositories.item.allItems(in: household.id)
-            items = itemsRecentlyAdded(allItems)
+            items = try await repositories.item.needsRestocking(in: household.id)
         } catch {
             items = []
         }
         didLoad = true
     }
 
-    /// Issue #16: persists the swipe-action toggle and reloads.
-    private func toggleRestocking(for id: Item.ID, to newValue: Bool) async {
+    private func toggle(_ id: Item.ID, to newValue: Bool) async {
         do {
             try await repositories.item.setNeedsRestocking(
                 id: id,
@@ -100,12 +85,14 @@ struct RecentlyAddedView: View {
             )
             await load()
         } catch {
-            // Soft-fail — next remote-change tick reloads.
+            // Soft-fail — reload picks up canonical state on the
+            // next remote-change tick. Swallowing matches the same
+            // shape as `ItemsView.delete`'s catch arm.
         }
     }
 }
 
-private struct RecentlyAddedRow: View {
+private struct NeedsRestockingRow: View {
     let item: Item
     let locationName: String?
 
@@ -117,9 +104,18 @@ private struct RecentlyAddedRow: View {
                     Text(locationName)
                     Text("·")
                 }
-                Text("\(item.quantity) \(item.unit.displayLabel)")
-                Text("·")
-                Text(item.createdAt, style: .relative)
+                // The two reasons an item lands here render as a hint
+                // the user can scan without opening the detail. Both
+                // reasons show when both apply.
+                if item.quantity == 0 {
+                    Text("Out of stock")
+                }
+                if item.needsRestocking && item.quantity == 0 {
+                    Text("·")
+                }
+                if item.needsRestocking {
+                    Text("Flagged")
+                }
             }
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -130,7 +126,7 @@ private struct RecentlyAddedRow: View {
 #Preview {
     @Previewable @State var selectedItemID: Item.ID?
     NavigationStack {
-        RecentlyAddedView(selectedItemID: $selectedItemID)
+        NeedsRestockingView(selectedItemID: $selectedItemID)
     }
     .environment(\.repositories, .makePreview())
 }

--- a/NakedPantreeApp/Features/Items/RestockSection.swift
+++ b/NakedPantreeApp/Features/Items/RestockSection.swift
@@ -1,0 +1,50 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Issue #16: detail-view toggle for the "Needs Restocking" flag.
+/// Carved out of `ItemDetailView` so the parent body stays under
+/// SwiftLint's `type_body_length` ceiling, and so the persistence
+/// path can fail-soft without dragging detail-view error UI into
+/// the picture.
+///
+/// The toggle binds against a local `@State` mirror of `item.needsRestocking`
+/// so the UI flips immediately on tap. The repository call runs in a
+/// `Task` and persists via `setNeedsRestocking` — the partial-update
+/// path. If the write fails (transient store hiccup) the local
+/// optimistic value sticks; the next remote-change tick replaces
+/// `item` and re-seeds the mirror, so canonical state always wins
+/// eventually. This shape mirrors how `QuantityStepperControl` debounces
+/// + reloads.
+struct RestockSection: View {
+    let item: Item
+    @Environment(\.repositories) private var repositories
+    @State private var optimistic: Bool?
+
+    var body: some View {
+        Section("Restock") {
+            Toggle(
+                "Needs restocking",
+                isOn: Binding(
+                    get: { optimistic ?? item.needsRestocking },
+                    set: { newValue in
+                        optimistic = newValue
+                        Task { await persist(newValue) }
+                    }
+                )
+            )
+            .accessibilityIdentifier("itemDetail.needsRestocking")
+        }
+    }
+
+    private func persist(_ newValue: Bool) async {
+        do {
+            try await repositories.item.setNeedsRestocking(
+                id: item.id,
+                needsRestocking: newValue
+            )
+        } catch {
+            // Soft-fail — next remote-change tick reloads canonical
+            // state. Same shape as `ItemsView.delete`'s catch arm.
+        }
+    }
+}

--- a/NakedPantreeApp/Features/Items/RestockSwipeButton.swift
+++ b/NakedPantreeApp/Features/Items/RestockSwipeButton.swift
@@ -1,0 +1,38 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Issue #16: leading-edge swipe action that flips an item's
+/// `needsRestocking` flag. The label and icon swap based on the
+/// current state — same self-describing pattern Apple Mail uses for
+/// "Mark as Read" / "Mark as Unread".
+///
+/// Used by every items list (per-location `ItemsView`, the smart-list
+/// content views, search results, and the `Needs Restocking` smart
+/// list itself). Lives in its own file so a copy / icon / color tweak
+/// touches one site instead of six.
+///
+/// `onToggle` is called with the *new* value the caller should
+/// persist. Persistence is the caller's responsibility — it has the
+/// repository handle and knows how to reload its own list state.
+@MainActor
+struct RestockSwipeButton: View {
+    let item: Item
+    let onToggle: @MainActor (Bool) -> Void
+
+    var body: some View {
+        Button {
+            onToggle(!item.needsRestocking)
+        } label: {
+            // Icon + text per `DESIGN_GUIDELINES.md` §10 — never color
+            // alone. Voice rule: short, useful. "Restock" / "Got it"
+            // both fit the one-word swipe-button real estate.
+            Label(
+                item.needsRestocking ? "Got it" : "Restock",
+                systemImage: item.needsRestocking
+                    ? "checkmark.circle"
+                    : "cart.badge.plus"
+            )
+        }
+        .tint(item.needsRestocking ? .green : .blue)
+    }
+}

--- a/NakedPantreeApp/Features/Items/SearchResultsView.swift
+++ b/NakedPantreeApp/Features/Items/SearchResultsView.swift
@@ -38,6 +38,20 @@ struct SearchResultsView: View {
                             locationName: locationsByID[item.locationID]?.name
                         )
                         .tag(item.id)
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            // Issue #16: search results get the same
+                            // restock toggle as the other lists. The
+                            // refresh after toggle is the existing
+                            // `loadResults` path.
+                            RestockSwipeButton(item: item) { newValue in
+                                Task {
+                                    await toggleRestocking(
+                                        for: item.id,
+                                        to: newValue
+                                    )
+                                }
+                            }
+                        }
                     }
                 }
                 .scrollContentBackground(.hidden)
@@ -86,6 +100,22 @@ struct SearchResultsView: View {
             items = []
         }
         didSearch = true
+    }
+
+    /// Issue #16: persists the swipe-action toggle and re-runs the
+    /// search. The next keystroke would supersede this anyway, but
+    /// reloading immediately keeps the row's swipe-state visually
+    /// in sync.
+    private func toggleRestocking(for id: Item.ID, to newValue: Bool) async {
+        do {
+            try await repositories.item.setNeedsRestocking(
+                id: id,
+                needsRestocking: newValue
+            )
+            await loadResults()
+        } catch {
+            // Soft-fail — next keystroke or remote-change tick reloads.
+        }
     }
 }
 

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -222,11 +222,13 @@ enum SidebarSelection: Hashable, Sendable {
 /// Sidebar Smart Lists. `All Items` is wired up in Phase 1.5 (cross-
 /// location list with search). The other projections (`expiresAt` within
 /// 7 days, recently-added) arrive with the Smart Lists feature in
-/// Phase 6 — selecting one of those shows a placeholder until then.
+/// Phase 6. `needsRestocking` (issue #16) surfaces flagged or
+/// out-of-stock items — backed by `ItemRepository.needsRestocking(in:)`.
 enum SmartList: String, CaseIterable, Identifiable, Sendable {
     case expiringSoon
     case allItems
     case recentlyAdded
+    case needsRestocking
 
     var id: Self { self }
 
@@ -235,6 +237,7 @@ enum SmartList: String, CaseIterable, Identifiable, Sendable {
         case .expiringSoon: "Expiring Soon"
         case .allItems: "All Items"
         case .recentlyAdded: "Recently Added"
+        case .needsRestocking: "Needs Restocking"
         }
     }
 
@@ -243,6 +246,7 @@ enum SmartList: String, CaseIterable, Identifiable, Sendable {
         case .expiringSoon: "clock.badge.exclamationmark"
         case .allItems: "tray.full"
         case .recentlyAdded: "sparkles"
+        case .needsRestocking: "cart"
         }
     }
 }

--- a/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
+++ b/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
@@ -314,6 +314,10 @@ private actor ThrowingItemRepository: ItemRepository {
     func updateQuantity(id: Item.ID, quantity: Int32) async throws {
         throw FormCoordinatorTestError()
     }
+    func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        throw FormCoordinatorTestError()
+    }
+    func needsRestocking(in householdID: Household.ID) async throws -> [Item] { [] }
     func delete(id: Item.ID) async throws { throw FormCoordinatorTestError() }
 }
 

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -671,6 +671,197 @@ struct ItemRepositoryContractTests {
     }
 }
 
+/// Issue #16: smart-list contract for items that need restocking. Lives
+/// in its own suite (rather than nested in `ItemRepositoryContractTests`)
+/// because adding it inline pushed that struct past
+/// SwiftLint's `type_body_length` ceiling, and these tests cohere
+/// around a single feature anyway.
+@Suite("ItemRepository needs-restocking contract")
+struct ItemRepositoryNeedsRestockingContractTests {
+    @Test(
+        "create + item(id:) round-trips needsRestocking",
+        arguments: RepositoryFactory.all)
+    func needsRestockingRoundTrips(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        // Default false branch.
+        let bread = Item(locationID: kitchen.id, name: "Bread")
+        try await itemRepo.create(bread)
+        let breadFetched = try #require(try await itemRepo.item(id: bread.id))
+        #expect(breadFetched.needsRestocking == false)
+
+        // Explicit true branch.
+        let coffee = Item(locationID: kitchen.id, name: "Coffee", needsRestocking: true)
+        try await itemRepo.create(coffee)
+        let coffeeFetched = try #require(try await itemRepo.item(id: coffee.id))
+        #expect(coffeeFetched.needsRestocking == true)
+    }
+
+    @Test(
+        "setNeedsRestocking flips only that flag — quantity / name / expiresAt untouched",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingIsPartial(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let expiry = Date(timeIntervalSince1970: 1_000_000)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Yogurt",
+            quantity: 2,
+            unit: .count,
+            expiresAt: expiry,
+            notes: "Plain greek"
+        )
+        try await itemRepo.create(item)
+
+        // Same race contract as `updateQuantity` (#118): the partial
+        // update must NOT touch sibling fields. Issue #16: a swipe
+        // action / detail toggle that races a form save shouldn't
+        // clobber the form's just-saved name/expiry/notes.
+        try await itemRepo.setNeedsRestocking(id: item.id, needsRestocking: true)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.needsRestocking == true)
+        #expect(after.quantity == 2)
+        #expect(after.name == "Yogurt")
+        #expect(after.expiresAt == expiry)
+        #expect(after.notes == "Plain greek")
+        #expect(after.unit == .count)
+    }
+
+    @Test(
+        "setNeedsRestocking is a no-op when the item id doesn't exist",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingMissingIDIsNoOp(factory: RepositoryFactory) async throws {
+        let itemRepo = factory.make().item
+        // Random UUID — not in the empty repo. Should silently no-op,
+        // matching `update(_:)` / `updateQuantity` semantics.
+        try await itemRepo.setNeedsRestocking(id: UUID(), needsRestocking: true)
+    }
+
+    @Test(
+        "setNeedsRestocking stamps updatedAt",
+        arguments: RepositoryFactory.all)
+    func setNeedsRestockingStampsTimestamp(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        let originalDate = Date(timeIntervalSince1970: 1)
+        let item = Item(
+            locationID: kitchen.id,
+            name: "Coffee",
+            createdAt: originalDate,
+            updatedAt: originalDate
+        )
+        try await itemRepo.create(item)
+
+        try await itemRepo.setNeedsRestocking(id: item.id, needsRestocking: true)
+
+        let after = try #require(try await itemRepo.item(id: item.id))
+        #expect(after.createdAt == originalDate)
+        #expect(after.updatedAt > originalDate)
+    }
+
+    @Test(
+        "needsRestocking(in:) includes flagged + zero-quantity items, sorted by name",
+        arguments: RepositoryFactory.all)
+    func needsRestockingUnion(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Pantry")
+        let freezer = Location(householdID: house.id, name: "Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        // Flagged manually (typical "we'll need this soon") — non-zero qty.
+        try await itemRepo.create(
+            Item(locationID: pantry.id, name: "Olive Oil", quantity: 1, needsRestocking: true)
+        )
+        // Implicitly out-of-stock (zero qty, not flagged) — kept around
+        // so the user remembers it's a staple.
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Coffee", quantity: 0))
+        // In another location, flagged.
+        try await itemRepo.create(
+            Item(locationID: freezer.id, name: "Ice Cream", quantity: 2, needsRestocking: true)
+        )
+        // Has stock and not flagged — should be excluded.
+        try await itemRepo.create(Item(locationID: pantry.id, name: "Rice", quantity: 5))
+        // Both flagged AND zero qty — appears once, not duplicated.
+        try await itemRepo.create(
+            Item(locationID: freezer.id, name: "Bread", quantity: 0, needsRestocking: true)
+        )
+
+        let restocking = try await itemRepo.needsRestocking(in: house.id)
+        #expect(restocking.map(\.name) == ["Bread", "Coffee", "Ice Cream", "Olive Oil"])
+    }
+
+    @Test(
+        "needsRestocking(in:) is scoped — items in other households are filtered out",
+        arguments: RepositoryFactory.all)
+    func needsRestockingScopedByHousehold(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+
+        let mine = try await household.currentHousehold()
+        let elsewhere = Household(name: "Mom's Pantry")
+        let myKitchen = Location(householdID: mine.id, name: "Kitchen")
+        let momsKitchen = Location(householdID: elsewhere.id, name: "Mom's Kitchen")
+        try await locationRepo.create(myKitchen)
+        try await locationRepo.create(momsKitchen)
+
+        try await itemRepo.create(
+            Item(locationID: myKitchen.id, name: "My Coffee", needsRestocking: true)
+        )
+        try await itemRepo.create(
+            Item(locationID: momsKitchen.id, name: "Mom's Coffee", needsRestocking: true)
+        )
+
+        let mineResults = try await itemRepo.needsRestocking(in: mine.id)
+        #expect(mineResults.map(\.name) == ["My Coffee"])
+    }
+
+    @Test(
+        "needsRestocking(in:) is empty when nothing qualifies",
+        arguments: RepositoryFactory.all)
+    func needsRestockingEmpty(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let kitchen = Location(householdID: house.id, name: "Kitchen")
+        try await locationRepo.create(kitchen)
+
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Rice", quantity: 5))
+        try await itemRepo.create(Item(locationID: kitchen.id, name: "Beans", quantity: 3))
+
+        let restocking = try await itemRepo.needsRestocking(in: house.id)
+        #expect(restocking.isEmpty)
+    }
+}
+
 @Suite("ItemPhotoRepository contract")
 struct ItemPhotoRepositoryContractTests {
     @Test(

--- a/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
@@ -54,6 +54,14 @@ public struct Item: Sendable, Hashable, Identifiable {
     public var unit: Unit
     public var expiresAt: Date?
     public var notes: String?
+    /// Issue #16: user-flagged restock signal. Survives sync. Set from a
+    /// detail-view toggle or a swipe action on any items list. Items with
+    /// `needsRestocking == true` *or* `quantity == 0` surface in the
+    /// "Needs Restocking" smart list — see `ItemRepository.needsRestocking(in:)`.
+    /// Default `false` so existing rows in CloudKit / Core Data parse
+    /// without migration; the new column writes `false` on insert and
+    /// the in-memory store seeds it the same way.
+    public var needsRestocking: Bool
     public let createdAt: Date
     public var updatedAt: Date
 
@@ -65,6 +73,7 @@ public struct Item: Sendable, Hashable, Identifiable {
         unit: Unit = .count,
         expiresAt: Date? = nil,
         notes: String? = nil,
+        needsRestocking: Bool = false,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -75,6 +84,7 @@ public struct Item: Sendable, Hashable, Identifiable {
         self.unit = unit
         self.expiresAt = expiresAt
         self.notes = notes
+        self.needsRestocking = needsRestocking
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/InMemoryRepositories.swift
@@ -200,6 +200,29 @@ public actor InMemoryItemRepository: ItemRepository {
         items[id] = existing
     }
 
+    public func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        // Issue #16: partial update — touch only `needsRestocking`
+        // and `updatedAt`. Same actor-serialized atomicity as
+        // `updateQuantity`.
+        guard var existing = items[id] else { return }
+        existing.needsRestocking = needsRestocking
+        existing.updatedAt = Date()
+        items[id] = existing
+    }
+
+    public func needsRestocking(in householdID: Household.ID) async throws -> [Item] {
+        var results: [Item] = []
+        for item in items.values where item.needsRestocking || item.quantity == 0 {
+            let location = try await locationLookup(item.locationID)
+            if location?.householdID == householdID {
+                results.append(item)
+            }
+        }
+        return results.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+    }
+
     public func delete(id: Item.ID) async throws {
         items.removeValue(forKey: id)
     }

--- a/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Repositories.swift
@@ -121,6 +121,22 @@ public protocol ItemRepository: Sendable {
     /// schedule and persist) — same shape as `update(_:)`'s
     /// silent-skip semantics on a missing row.
     func updateQuantity(id: Item.ID, quantity: Int32) async throws
+    /// Partial update that touches only `needsRestocking` (and stamps
+    /// `updatedAt`), leaving every other attribute untouched. Issue
+    /// #16: same race-prevention shape as `updateQuantity` — the
+    /// detail-view toggle and the swipe action both flip a single
+    /// boolean, and a full fetch-modify-save round-trip would race
+    /// concurrent edit-form saves of `name` / `expiresAt`.
+    ///
+    /// No-op if the item doesn't exist (deleted between gesture and
+    /// persist) — same shape as `update(_:)`'s silent-skip semantics.
+    func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws
+    /// Items in the household that need restocking — flagged manually
+    /// (`needsRestocking == true`) or implicitly out-of-stock
+    /// (`quantity == 0`). Backs the "Needs Restocking" smart list
+    /// (issue #16). Sorted by name for stable list output, matching
+    /// `allItems(in:)`.
+    func needsRestocking(in householdID: Household.ID) async throws -> [Item]
     func delete(id: Item.ID) async throws
 }
 

--- a/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CoreDataItemRepository.swift
@@ -124,6 +124,39 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         }
     }
 
+    public func setNeedsRestocking(id: Item.ID, needsRestocking: Bool) async throws {
+        // Issue #16: partial update — touches `needsRestocking` and
+        // `updatedAt` only. Mirrors `updateQuantity`'s race-prevention
+        // shape: a swipe action or detail toggle flipping a single bool
+        // shouldn't read-modify-write a whole `Item` and risk clobbering
+        // a concurrent edit-form save of `name` / `expiresAt`.
+        try await container.performBackgroundTaskWithDefaults { context in
+            guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
+            row.setValue(needsRestocking, forKey: "needsRestocking")
+            row.setValue(Date(), forKey: "updatedAt")
+            try context.save()
+        }
+    }
+
+    public func needsRestocking(in householdID: Household.ID) async throws -> [Item] {
+        // Issue #16: union of explicitly-flagged and implicitly-out-of-stock
+        // items in the household. The OR predicate runs at the Core Data
+        // layer so the fetch returns only matching rows — no in-memory
+        // filtering. Sort by name to match `allItems(in:)`'s order.
+        try await container.performBackgroundTaskWithDefaults { context in
+            let request = NSFetchRequest<NSManagedObject>(entityName: "ItemEntity")
+            request.predicate = NSPredicate(
+                format:
+                    "location.household.id == %@ AND (needsRestocking == YES OR quantity == 0)",
+                householdID as CVarArg
+            )
+            request.sortDescriptors = [
+                NSSortDescriptor(key: "name", ascending: true)
+            ]
+            return try context.fetch(request).map(Self.makeItem)
+        }
+    }
+
     public func delete(id: Item.ID) async throws {
         try await container.performBackgroundTaskWithDefaults { context in
             guard let row = try Self.fetchItemRow(id: id, in: context) else { return }
@@ -143,6 +176,7 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
         row.setValue(item.unit.rawValue, forKey: "unitRaw")
         row.setValue(item.expiresAt, forKey: "expiresAt")
         row.setValue(item.notes, forKey: "notes")
+        row.setValue(item.needsRestocking, forKey: "needsRestocking")
         row.setValue(item.createdAt, forKey: "createdAt")
         row.setValue(stampUpdatedAt ? Date() : item.updatedAt, forKey: "updatedAt")
     }
@@ -205,6 +239,10 @@ public final class CoreDataItemRepository: ItemRepository, @unchecked Sendable {
             unit: Unit(rawValue: row.value(forKey: "unitRaw") as? String ?? "count"),
             expiresAt: row.value(forKey: "expiresAt") as? Date,
             notes: row.value(forKey: "notes") as? String,
+            // Issue #16: defaults to `false` for rows persisted before
+            // the column existed (CloudKit additive migration — the
+            // attribute is optional with `defaultValueString="NO"`).
+            needsRestocking: row.value(forKey: "needsRestocking") as? Bool ?? false,
             createdAt: row.value(forKey: "createdAt") as? Date ?? Date(),
             updatedAt: row.value(forKey: "updatedAt") as? Date ?? Date()
         )

--- a/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
+++ b/Packages/Core/Sources/NakedPantreePersistence/Model/NakedPantree.xcdatamodeld/NakedPantree.xcdatamodel/contents
@@ -20,6 +20,7 @@
         <attribute name="expiresAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="needsRestocking" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="notes" optional="YES" attributeType="String"/>
         <attribute name="quantity" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="unitRaw" optional="YES" attributeType="String" defaultValueString="count"/>


### PR DESCRIPTION
## Summary

Stacked on **PR #145** (foundation). Wires the user-facing surface for issue #16 onto the schema + repository contract that PR shipped.

> **Review order**: review and merge #145 first; this PR's diff against `main` only makes sense after the foundation is in place. The base of this PR is the foundation branch, not `main`.

### What this PR adds

**Sidebar entry**
- `SmartList.needsRestocking` case with the `cart` symbol. Renders in the existing `SidebarView` `ForEach(SmartList.allCases)` — no list-rendering changes.
- Sidebar diagram in `ARCHITECTURE.md` §7 updated per `AGENTS.md` §2 hard rule.

**Smart-list view** (`NeedsRestockingView.swift`)
- Same shape as `AllItemsView` / `RecentlyAddedView`. Loads via `ItemRepository.needsRestocking(in:)`, reloads on the remote-change tick.
- Empty state: "Pantry's stocked." with `checkmark.seal` (issue suggested this copy).
- Rows hint *why* an item appears: `Out of stock`, `Flagged`, or both.

**Swipe action** (`RestockSwipeButton.swift`)
- Reusable leading-edge swipe button on every items list — per-location `ItemsView`, `AllItemsView`, `ExpiringSoonView`, `RecentlyAddedView`, `SearchResultsView`, and `NeedsRestockingView` itself.
- Label flips between **Restock** (`cart.badge.plus`) and **Got it** (`checkmark.circle`) — Apple Mail's "Mark as Read" / "Mark as Unread" pattern.
- Each list persists via the partial-update `setNeedsRestocking` path, so a burst of taps can't race an edit-form save (#118-style protection from PR #145).

**Detail-view toggle** (`RestockSection.swift`)
- Extracted into a subview to keep `ItemDetailView` under SwiftLint's `type_body_length` ceiling.
- Optimistic local `@State` mirror plus a `setNeedsRestocking` Task — same fail-soft shape as `QuantityStepperControl`.

### Voice / accessibility check

Every new string per `DESIGN_GUIDELINES.md` §10:
- "Needs Restocking" (sidebar / nav title) — short, useful
- "Pantry's stocked." (empty state) — calm, brand-shaped, not a sync-failure context
- "Items you flag for restocking will show up here." (empty description)
- "Out of stock" / "Flagged" (row hints) — informational, no personality
- "Restock" / "Got it" (swipe labels) — short verbs, icon + text per §10
- "Restock" (detail section) / "Needs restocking" (toggle) — direct
- Toggle accessibility identifier: `itemDetail.needsRestocking`

### Out of scope

Per the issue's stretch list:
- `Item.restockThreshold: Int32?` — deferred
- Apple Reminders push (`ARCHITECTURE.md` §12 line item) — separate feature
- Item-form integration (set the flag at create time) — the issue ACs only require detail-view + swipe-action toggling

## Test plan

- [x] Existing unit + repository contract tests still green (31 tests across 4 suites)
- [x] App builds clean for the iOS Simulator with the new files added
- [x] `swift-format --strict` + swiftlint clean
- [ ] Reviewer: poke the sidebar entry, the swipe action on at least two list surfaces, and the detail toggle. Confirm the empty state copy reads right and the row hints appear when expected (zero-qty + flagged).
- [ ] Reviewer: remember to add the `needsRestocking` Boolean column to the CloudKit dev schema in the Dashboard before merging — production Phase 7 deploys gate on schema parity (issue #16 ACs flagged this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)