### PR TITLE
fix(sharing): surface share-accept failures as alert + add tests (#105)

### DIFF
--- a/NakedPantreeApp/App/AppLauncher.swift
+++ b/NakedPantreeApp/App/AppLauncher.swift
@@ -123,6 +123,10 @@ struct LiveDependencies {
     let remoteChangeMonitor: RemoteChangeMonitor
     let accountStatusMonitor: AccountStatusMonitor
     let householdSharing: (any HouseholdSharingService)?
+    /// Issue #105: app-layer wrapper around `CloudShareAcceptance` that
+    /// routes accept errors into a user-visible alert. RootView observes
+    /// it via `\.shareAcceptanceCoordinator`.
+    let shareAcceptanceCoordinator: ShareAcceptanceCoordinator
     let notificationScheduler: NotificationScheduler
     let notificationRouting: NotificationRoutingService
     let notificationSettings: NotificationSettings
@@ -153,6 +157,9 @@ extension AppLauncher {
                 remoteChangeMonitor: RemoteChangeMonitor(),
                 accountStatusMonitor: AccountStatusMonitor(),
                 householdSharing: nil,
+                shareAcceptanceCoordinator: ShareAcceptanceCoordinator(
+                    service: NoOpShareAcceptanceService()
+                ),
                 notificationScheduler: NotificationScheduler(),
                 notificationRouting: routing,
                 notificationSettings: NotificationSettings()
@@ -176,6 +183,9 @@ extension AppLauncher {
                 remoteChangeMonitor: RemoteChangeMonitor(),
                 accountStatusMonitor: AccountStatusMonitor(),
                 householdSharing: sharing,
+                shareAcceptanceCoordinator: ShareAcceptanceCoordinator(
+                    service: NoOpShareAcceptanceService()
+                ),
                 notificationScheduler: NotificationScheduler(),
                 notificationRouting: routing,
                 notificationSettings: NotificationSettings()
@@ -192,12 +202,26 @@ extension AppLauncher {
                 remoteChangeMonitor: RemoteChangeMonitor(),
                 accountStatusMonitor: AccountStatusMonitor(),
                 householdSharing: nil,
+                shareAcceptanceCoordinator: ShareAcceptanceCoordinator(
+                    service: NoOpShareAcceptanceService()
+                ),
                 notificationScheduler: NotificationScheduler(),
                 notificationRouting: routing,
                 notificationSettings: NotificationSettings()
             )
         }
 
+        return try makeLiveProductionDependencies(routing: routing)
+    }
+
+    /// Production CloudKit-backed branch. Lifted out of
+    /// `makeProductionDependencies` so the parent stays under
+    /// SwiftLint's `function_body_length` ceiling once issue #105's
+    /// share-acceptance coordinator wiring landed.
+    @MainActor
+    private static func makeLiveProductionDependencies(
+        routing: NotificationRoutingService
+    ) throws -> LiveDependencies {
         // Phase 2.1: production stack is CloudKit-mirrored. Phase 3
         // adds the sharing service against the same container.
         let container = try CoreDataStack.cloudKitContainer()
@@ -216,26 +240,23 @@ extension AppLauncher {
             container: container,
             cloudKitContainer: cloudKitContainer
         )
-        // Phase 3.2: hand the share-acceptance service to the
-        // delegate so `application(_:userDidAcceptCloudKitShareWith:)`
-        // can import shared records when a recipient taps an
-        // invite. The delegate is instantiated by the system before
-        // this init runs, so a static var is the simplest seam.
-        NakedPantreeAppDelegate.wireShareAcceptance(
-            CloudShareAcceptance(container: container)
+        // Phase 3.2 / Issue #105: hand the share-acceptance coordinator
+        // to the delegate so `application(_:userDidAcceptCloudKitShareWith:)`
+        // can import shared records when a recipient taps an invite —
+        // and surface failures via the coordinator's `lastErrorMessage`
+        // alert state instead of swallowing them in `print`.
+        let shareAcceptanceCoordinator = ShareAcceptanceCoordinator(
+            service: CloudShareAcceptance(container: container)
         )
-        // Phase 9.3: persisted reminder time, constructed before
-        // the scheduler so it can read `settings.hourOfDay` /
-        // `.minute` when scheduling and when bundling same-day
-        // expiries (Phase 9.4 integration).
+        NakedPantreeAppDelegate.wireShareAcceptanceCoordinator(shareAcceptanceCoordinator)
         let notificationSettings = NotificationSettings(defaults: .standard)
         let notificationScheduler = NotificationScheduler(
             center: .current(),
             settings: notificationSettings
         )
         // Phase 4.2: the delegate routes notification taps into this
-        // service. Same static-var pattern as `shareAcceptance` —
-        // delegate construction precedes app init, so the seam is a
+        // service. Same static-var seam as the share-acceptance one —
+        // delegate construction precedes app init, so the wire-up is a
         // post-hoc handoff.
         NakedPantreeAppDelegate.wireNotificationRouting(routing)
 
@@ -244,6 +265,7 @@ extension AppLauncher {
             remoteChangeMonitor: remoteChangeMonitor,
             accountStatusMonitor: accountStatusMonitor,
             householdSharing: householdSharing,
+            shareAcceptanceCoordinator: shareAcceptanceCoordinator,
             notificationScheduler: notificationScheduler,
             notificationRouting: routing,
             notificationSettings: notificationSettings

--- a/NakedPantreeApp/App/NakedPantreeApp.swift
+++ b/NakedPantreeApp/App/NakedPantreeApp.swift
@@ -38,6 +38,10 @@ struct NakedPantreeApp: App {
                     .environment(\.remoteChangeMonitor, dependencies.remoteChangeMonitor)
                     .environment(\.accountStatusMonitor, dependencies.accountStatusMonitor)
                     .environment(\.householdSharing, dependencies.householdSharing)
+                    .environment(
+                        \.shareAcceptanceCoordinator,
+                        dependencies.shareAcceptanceCoordinator
+                    )
                     .environment(\.notificationScheduler, dependencies.notificationScheduler)
                     .environment(\.notificationRouting, dependencies.notificationRouting)
                     .environment(\.notificationSettings, dependencies.notificationSettings)

--- a/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
+++ b/NakedPantreeApp/App/NakedPantreeAppDelegate.swift
@@ -27,10 +27,15 @@ final class NakedPantreeAppDelegate:
     /// Production sinks. Pre-#108, these were assigned directly by
     /// `NakedPantreeApp.init` and the delegate methods above
     /// silently dropped events delivered before init ran. Now use
-    /// `wireShareAcceptance(_:)` / `wireNotificationRouting(_:)`
+    /// `wireShareAcceptanceCoordinator(_:)` / `wireNotificationRouting(_:)`
     /// which both assign the seam **and** drain any pre-init
     /// queued events.
-    nonisolated(unsafe) static var shareAcceptance: CloudShareAcceptance?
+    ///
+    /// Issue #105: the share-acceptance sink moved from the bare
+    /// `CloudShareAcceptance` service to the app-layer
+    /// `ShareAcceptanceCoordinator`, which surfaces failures via
+    /// `lastErrorMessage` instead of swallowing them in `print`.
+    nonisolated(unsafe) static var shareAcceptanceCoordinator: ShareAcceptanceCoordinator?
     nonisolated(unsafe) static var notificationRouting: NotificationRoutingService?
 
     /// Pre-init event queues (issue #108). iOS can deliver the
@@ -52,17 +57,19 @@ final class NakedPantreeAppDelegate:
     /// before this call. Replace the previous `Self.shareAcceptance =
     /// acceptance` direct assignment with this method to recover
     /// pre-init events.
-    static func wireShareAcceptance(_ acceptance: CloudShareAcceptance) {
-        shareAcceptance = acceptance
+    ///
+    /// Issue #105: we now hand the delegate a coordinator (not the
+    /// bare service) so failures land in `lastErrorMessage` for
+    /// `RootView` to surface, instead of being swallowed in `print`.
+    /// `Task { @MainActor in ... }` because the coordinator is
+    /// MainActor-isolated.
+    static func wireShareAcceptanceCoordinator(_ coordinator: ShareAcceptanceCoordinator) {
+        shareAcceptanceCoordinator = coordinator
         let pending = pendingShareMetadata
         pendingShareMetadata = []
         for metadata in pending {
-            Task {
-                do {
-                    try await acceptance.acceptShare(metadata: metadata)
-                } catch {
-                    print("CloudKit share acceptance failed (drain): \(error)")
-                }
+            Task { @MainActor in
+                await coordinator.accept(metadata: metadata)
             }
         }
     }
@@ -103,22 +110,17 @@ final class NakedPantreeAppDelegate:
         // #108: queue if the seam isn't wired yet. iOS may deliver
         // share-accept during cold launch *before*
         // `NakedPantreeApp.init` has assigned the sink — the queue is
-        // drained by `wireShareAcceptance(_:)` once init runs.
-        guard let acceptance = Self.shareAcceptance else {
+        // drained by `wireShareAcceptanceCoordinator(_:)` once init
+        // runs.
+        guard let coordinator = Self.shareAcceptanceCoordinator else {
             Self.pendingShareMetadata.append(metadata)
             return
         }
-        Task {
-            do {
-                try await acceptance.acceptShare(metadata: metadata)
-            } catch {
-                // The recipient already tapped Accept — there's no
-                // user-actionable surface here without a separate UI
-                // pass. RemoteChangeMonitor will tick once the import
-                // lands; if it doesn't, that's an integration bug to
-                // chase, not a per-tap retry.
-                print("CloudKit share acceptance failed: \(error)")
-            }
+        // Issue #105: route through the coordinator so failures
+        // surface in `RootView`'s alert instead of getting swallowed.
+        // `@MainActor` hop because the coordinator is MainActor-isolated.
+        Task { @MainActor in
+            await coordinator.accept(metadata: metadata)
         }
     }
 

--- a/NakedPantreeApp/App/ShareAcceptanceCoordinator.swift
+++ b/NakedPantreeApp/App/ShareAcceptanceCoordinator.swift
@@ -1,0 +1,146 @@
+import CloudKit
+import NakedPantreePersistence
+import SwiftUI
+import os
+
+/// Issue #105: app-layer wrapper around `ShareAcceptanceService` that
+/// observes import errors and surfaces them as user-visible alert state.
+/// Replaces the silent `print()` failure path that #105 flagged as a
+/// Phase 3.2 blocker.
+///
+/// The coordinator owns the service so SwiftUI views can hold a single
+/// `@Observable` reference rather than threading both a service and an
+/// error sink through the environment. `@MainActor` because the alert
+/// state binds straight into a SwiftUI `.alert(...)` and SwiftUI reads
+/// observable state from the main actor.
+///
+/// **Layering:** `@Observable` deliberately doesn't live in
+/// `NakedPantreePersistence` — the persistence package stays pure
+/// throws-on-error, and the UI-facing wrapper lives here.
+@Observable
+@MainActor
+final class ShareAcceptanceCoordinator {
+    /// Body of the user-facing alert when the most recent
+    /// `accept(metadata:)` failed. `nil` while no error is in flight,
+    /// either because nothing has thrown yet or because the user
+    /// dismissed / retried successfully.
+    private(set) var lastErrorMessage: String?
+
+    /// Last failed accept captured as a closure so the user's "Try
+    /// Again" tap on the alert can re-attempt without re-receiving the
+    /// system invite. Stored as a closure (rather than the raw
+    /// `CKShare.Metadata`) because `CKShare.Metadata.init()` is
+    /// `unavailable`, so tests can't construct one to drive the retry
+    /// path — exposing the closure-based seam (`runFallible(_:)`)
+    /// gives tests a way in without resorting to runtime tricks. See
+    /// `ShareAcceptanceCoordinatorTests` for the test-side usage.
+    private var lastFailedOperation: (@MainActor @Sendable () async throws -> Void)?
+
+    private let service: any ShareAcceptanceService
+
+    /// Trace lines come out under the same subsystem/category as the
+    /// rest of the share path so a single Console.app filter captures
+    /// the full flow.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "sharing"
+    )
+
+    /// `nonisolated` so SwiftUI's `@Entry` macro can construct the
+    /// default coordinator from the synthesized environment-key
+    /// `defaultValue`, which is synchronous and not MainActor-isolated.
+    /// The init only assigns the (`Sendable`) service to a stored
+    /// property — no MainActor state is touched.
+    nonisolated init(service: any ShareAcceptanceService) {
+        self.service = service
+    }
+
+    /// Imports the share. On failure, populates `lastErrorMessage` so
+    /// the alert in `RootView` presents and remembers the failed
+    /// attempt so `retry()` can re-attempt. On success, clears any
+    /// prior error state — successive accepts shouldn't carry over a
+    /// stale alert.
+    func accept(metadata: CKShare.Metadata) async {
+        let service = self.service
+        await runFallible {
+            try await service.acceptShare(metadata: metadata)
+        }
+    }
+
+    /// Re-attempts the most recent failed accept. No-op when there's
+    /// nothing to retry — the alert binding only renders the button
+    /// when `lastErrorMessage != nil`, so the guard exists for safety
+    /// rather than a real reachable case.
+    func retry() async {
+        guard let operation = lastFailedOperation else { return }
+        await runFallible(operation)
+    }
+
+    /// Clears the alert state without re-attempting. Bound to the
+    /// alert's "Dismiss" button.
+    func dismissError() {
+        lastErrorMessage = nil
+        lastFailedOperation = nil
+    }
+
+    /// `internal` test seam: runs `operation`, publishes a user-visible
+    /// message on throw, clears state on success, and captures the
+    /// throwing closure so `retry()` can replay it. Production routes
+    /// here from `accept(metadata:)`; tests use it directly so they
+    /// can pin the publish / retry / clear-on-success contract
+    /// without constructing a `CKShare.Metadata` (whose `init()` is
+    /// `unavailable`).
+    internal func runFallible(
+        _ operation: @escaping @MainActor @Sendable () async throws -> Void
+    ) async {
+        do {
+            try await operation()
+            Self.logger.notice("ShareAcceptanceCoordinator: accept succeeded")
+            lastErrorMessage = nil
+            lastFailedOperation = nil
+        } catch {
+            Self.logger.error(
+                "ShareAcceptanceCoordinator: accept failed: \(error.localizedDescription, privacy: .public)"
+            )
+            lastErrorMessage = Self.userMessage(for: error)
+            lastFailedOperation = operation
+        }
+    }
+
+    /// Voice-rule §9 copy: sync failures stay plain. The `.localizedDescription`
+    /// from a `CKError` is often technical ("CKErrorDomain error 7" /
+    /// "Couldn't communicate with a helper application") so we map to a
+    /// short, useful, user-readable line. The underlying error still
+    /// goes to the unified log above for diagnosis.
+    private static func userMessage(for error: Error) -> String {
+        if let cloudShareError = error as? CloudShareAcceptanceError {
+            switch cloudShareError {
+            case .sharedStoreUnavailable:
+                return
+                    "Couldn't import that household — iCloud isn't ready yet. Try again in a moment."
+            }
+        }
+        return
+            "Couldn't import that household. Try again — if it keeps happening, ask the sender to re-share."
+    }
+}
+
+/// No-op `ShareAcceptanceService` for previews and tests. Lives in the
+/// app target (alongside `ShareAcceptanceCoordinator`) so the env-value
+/// default doesn't need to spin up a `CloudShareAcceptance`.
+struct NoOpShareAcceptanceService: ShareAcceptanceService {
+    func acceptShare(metadata: CKShare.Metadata) async throws {
+        // Intentionally empty — the `@Environment` default coordinator
+        // is the only consumer, and it should never be called from a
+        // preview / test surface.
+    }
+}
+
+extension EnvironmentValues {
+    /// Default coordinator wraps the no-op service so previews / tests
+    /// don't construct a real CloudKit container. Production replaces
+    /// this via `AppLauncher.makeProductionDependencies`.
+    @Entry var shareAcceptanceCoordinator = ShareAcceptanceCoordinator(
+        service: NoOpShareAcceptanceService()
+    )
+}

--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -30,6 +30,10 @@ struct RootView: View {
     @Environment(\.notificationRouting) private var notificationRouting
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
     @Environment(\.notificationScheduler) private var notificationScheduler
+    /// Issue #105: surfaces share-acceptance failures via the alert
+    /// below. Default in `EnvironmentValues` wraps a no-op service so
+    /// previews / tests render without a real CloudKit container.
+    @Environment(\.shareAcceptanceCoordinator) private var shareAcceptanceCoordinator
 
     var body: some View {
         Group {
@@ -113,6 +117,39 @@ struct RootView: View {
         .alert("That item is gone.", isPresented: $isShowingMissingItemAlert) {
             Button("OK", role: .cancel) {}
         }
+        // Issue #105: share-accept failures used to land in `print()`;
+        // now they land here, where the user can retry or dismiss.
+        // The retry path replays the last failed `CKShare.Metadata`
+        // through the same coordinator, so a transient network hiccup
+        // is one tap away from a working import.
+        .alert(
+            "Couldn't import that household.",
+            isPresented: shareErrorBinding,
+            presenting: shareAcceptanceCoordinator.lastErrorMessage
+        ) { _ in
+            Button("Try Again") {
+                Task { await shareAcceptanceCoordinator.retry() }
+            }
+            Button("Dismiss", role: .cancel) {
+                shareAcceptanceCoordinator.dismissError()
+            }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    /// Issue #105: bridges the coordinator's optional `lastErrorMessage`
+    /// to a `Bool` binding the `.alert(isPresented:)` modifier wants.
+    /// Same shape as `photoErrorBinding` in `ItemDetailView`.
+    private var shareErrorBinding: Binding<Bool> {
+        Binding(
+            get: { shareAcceptanceCoordinator.lastErrorMessage != nil },
+            set: { newValue in
+                if !newValue {
+                    shareAcceptanceCoordinator.dismissError()
+                }
+            }
+        )
     }
 
     private func runBootstrap() async {

--- a/NakedPantreeTests/AppLauncherTests.swift
+++ b/NakedPantreeTests/AppLauncherTests.swift
@@ -164,6 +164,9 @@ extension LiveDependencies {
             remoteChangeMonitor: RemoteChangeMonitor(),
             accountStatusMonitor: AccountStatusMonitor(),
             householdSharing: nil,
+            shareAcceptanceCoordinator: ShareAcceptanceCoordinator(
+                service: NoOpShareAcceptanceService()
+            ),
             notificationScheduler: NotificationScheduler(),
             notificationRouting: NotificationRoutingService(),
             notificationSettings: NotificationSettings()

--- a/NakedPantreeTests/NakedPantreeAppDelegatePreInitTests.swift
+++ b/NakedPantreeTests/NakedPantreeAppDelegatePreInitTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// `userDidAcceptCloudKitShareWith` and notification taps before
 /// `NakedPantreeApp.init` runs and assigns the seam vars; pre-#108
 /// those events were silently dropped. Now they queue and drain
-/// once `wireShareAcceptance(_:)` / `wireNotificationRouting(_:)`
+/// once `wireShareAcceptanceCoordinator(_:)` / `wireNotificationRouting(_:)`
 /// is called.
 ///
 /// **Test scope.** These tests pin the queue + drain mechanic
@@ -28,7 +28,7 @@ struct NakedPantreeAppDelegatePreInitTests {
     /// independence holds. Static vars in the delegate carry across
     /// test instances otherwise.
     private func resetStaticState() {
-        NakedPantreeAppDelegate.shareAcceptance = nil
+        NakedPantreeAppDelegate.shareAcceptanceCoordinator = nil
         NakedPantreeAppDelegate.notificationRouting = nil
         NakedPantreeAppDelegate.pendingShareMetadata = []
         NakedPantreeAppDelegate.pendingNotificationItemIDs = []

--- a/NakedPantreeTests/Persistence/CloudShareAcceptanceTests.swift
+++ b/NakedPantreeTests/Persistence/CloudShareAcceptanceTests.swift
@@ -1,0 +1,76 @@
+import CloudKit
+import CoreData
+import Foundation
+import Testing
+
+@testable import NakedPantreePersistence
+
+/// Issue #105: pin the documented failure-mode contract on
+/// `CloudShareAcceptance` that the production app relies on.
+///
+/// **What we test here**: the `sharedStoreUnavailable` branch — the
+/// only `CloudShareAcceptance` code path reachable in CI without an
+/// iCloud account. The happy path and CK-side failures (network,
+/// revoked invite, partial-failure import) require a live iCloud
+/// account to drive `acceptShareInvitations(from:into:)` and so live
+/// in `ShareAcceptanceCoordinatorTests` against a stub conformer
+/// instead.
+///
+/// The test calls into `resolveSharedStore()` (`internal` for exactly
+/// this reason) rather than `acceptShare(metadata:)` — that lets the
+/// throw be exercised without constructing a `CKShare.Metadata`, which
+/// has no public initializer for tests to reach.
+@Suite("CloudShareAcceptance")
+struct CloudShareAcceptanceTests {
+    /// Builds a single-store SQLite container backed by `/dev/null` —
+    /// matches the pattern in `HouseholdSharingServiceTests`. Returns
+    /// without attaching `cloudKitContainerOptions`, so the container
+    /// has neither a `-private.sqlite` nor a `-shared.sqlite` URL and
+    /// `CoreDataStack.sharedCloudKitStore(in:)` returns nil. This is
+    /// the exact code path that fires when `CloudShareAcceptance` is
+    /// constructed in a test or preview surface that didn't load a
+    /// shared store — the contract under test is "throw, don't
+    /// silently accept".
+    private static func makeSingleStoreContainer() throws -> NSPersistentCloudKitContainer {
+        let container = NSPersistentCloudKitContainer(
+            name: "NakedPantree",
+            managedObjectModel: CoreDataStack.model
+        )
+        let description = NSPersistentStoreDescription()
+        description.type = NSSQLiteStoreType
+        description.url = URL(fileURLWithPath: "/dev/null")
+        description.shouldAddStoreAsynchronously = false
+        description.cloudKitContainerOptions = nil
+        container.persistentStoreDescriptions = [description]
+        var loadError: Error?
+        container.loadPersistentStores { _, error in loadError = error }
+        if let loadError {
+            throw loadError
+        }
+        return container
+    }
+
+    @Test("resolveSharedStore throws sharedStoreUnavailable on a single-store container")
+    func sharedStoreUnavailable() throws {
+        let container = try Self.makeSingleStoreContainer()
+        let acceptance = CloudShareAcceptance(container: container)
+        // The single-store container has no `-shared.sqlite` URL, so
+        // `sharedCloudKitStore(in:)` returns nil and the gate throws.
+        // Tests that drive the happy path live in
+        // `ShareAcceptanceCoordinatorTests` — Apple's
+        // `acceptShareInvitations(from:into:)` requires an actual
+        // iCloud account, which CI doesn't have.
+        #expect(throws: CloudShareAcceptanceError.sharedStoreUnavailable) {
+            _ = try acceptance.resolveSharedStore()
+        }
+    }
+
+    @Test("CloudShareAcceptance conforms to ShareAcceptanceService")
+    func conformance() {
+        // Compile-time check: if the protocol seam breaks, this test
+        // fails to type-check. Mirrors the pattern in
+        // `HouseholdSharingServiceTests.conformance`.
+        let metatype: any ShareAcceptanceService.Type = CloudShareAcceptance.self
+        _ = metatype
+    }
+}

--- a/NakedPantreeTests/ShareAcceptanceCoordinatorTests.swift
+++ b/NakedPantreeTests/ShareAcceptanceCoordinatorTests.swift
@@ -1,0 +1,153 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import NakedPantree
+@testable import NakedPantreePersistence
+
+/// Issue #105: contract tests for `ShareAcceptanceCoordinator`. Drives
+/// the coordinator's publish-on-throw / clear-on-success / retry
+/// machinery through the internal `runFallible(_:)` seam — the public
+/// `accept(metadata:)` entry point requires a `CKShare.Metadata`, and
+/// `CKShare.Metadata.init()` is marked `unavailable` ("Obtain
+/// `CKShareMetadata` from `CKFetchShareMetadataOperation` or
+/// platform-specific scene / app delegate callbacks"). Going through
+/// `runFallible` lets us pin the contract without runtime tricks to
+/// fabricate a metadata.
+///
+/// `CloudShareAcceptance`'s own throw-path test lives in
+/// `CloudShareAcceptanceTests` — it uses an internal seam
+/// (`resolveSharedStore`) for the same reason.
+@MainActor
+@Suite("ShareAcceptanceCoordinator")
+struct ShareAcceptanceCoordinatorTests {
+    @Test("Happy path — successful operation clears any prior alert state")
+    func happyPathClearsAlert() async throws {
+        let coordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+
+        var callCount = 0
+        await coordinator.runFallible {
+            callCount += 1
+        }
+
+        #expect(coordinator.lastErrorMessage == nil)
+        #expect(callCount == 1)
+    }
+
+    @Test("Failure path — error surfaces in lastErrorMessage")
+    func failurePublishesError() async throws {
+        // Sentinel error per advisor guidance: don't fake a real
+        // `CKError.partialFailure` from memory — its userInfo shape is
+        // specific and a mis-shaped stand-in produces a test that
+        // passes for the wrong reason. The coordinator's contract
+        // ("any throw → user-visible message") is what we're pinning.
+        let coordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+
+        await coordinator.runFallible {
+            throw SentinelTestError.boom
+        }
+
+        let message = try #require(coordinator.lastErrorMessage)
+        #expect(!message.isEmpty)
+    }
+
+    @Test("Sharing-store-unavailable maps to its dedicated copy variant")
+    func sharedStoreUnavailableHasItsOwnCopy() async throws {
+        // The two failure shapes the coordinator distinguishes are
+        // (a) `CloudShareAcceptanceError.sharedStoreUnavailable` —
+        // "iCloud isn't ready yet, try again in a moment" — and
+        // (b) anything else — generic retry copy. Pin the contract
+        // here so a future error-mapping refactor can't silently
+        // collapse them into one message.
+        let dedicatedCoordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+        await dedicatedCoordinator.runFallible {
+            throw CloudShareAcceptanceError.sharedStoreUnavailable
+        }
+        let dedicated = try #require(dedicatedCoordinator.lastErrorMessage)
+        #expect(dedicated.contains("iCloud isn't ready yet"))
+
+        let genericCoordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+        await genericCoordinator.runFallible {
+            throw SentinelTestError.boom
+        }
+        let generic = try #require(genericCoordinator.lastErrorMessage)
+        #expect(!generic.contains("iCloud isn't ready yet"))
+    }
+
+    @Test("Retry replays the failed operation; success clears alert state")
+    func retryReplaysAndClearsOnSuccess() async throws {
+        let coordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+
+        // Counter shared between the operation closure and the test —
+        // the closure throws on its first invocation and succeeds on
+        // every subsequent one. `actor`-wrap not needed: this test
+        // is `@MainActor` so the closure runs serially with the
+        // assertions below.
+        let counter = CallCounter()
+        let operation: @MainActor @Sendable () async throws -> Void = {
+            await counter.increment()
+            if await counter.count == 1 {
+                throw SentinelTestError.boom
+            }
+        }
+
+        await coordinator.runFallible(operation)
+        // First attempt failed — alert is up.
+        #expect(coordinator.lastErrorMessage != nil)
+        await #expect(counter.count == 1)
+
+        await coordinator.retry()
+        // Second attempt succeeded — alert clears.
+        #expect(coordinator.lastErrorMessage == nil)
+        await #expect(counter.count == 2)
+    }
+
+    @Test("dismissError clears state without re-attempting")
+    func dismissErrorDoesNotRetry() async throws {
+        let coordinator = ShareAcceptanceCoordinator(
+            service: NoOpShareAcceptanceService()
+        )
+        let counter = CallCounter()
+
+        await coordinator.runFallible {
+            await counter.increment()
+            throw SentinelTestError.boom
+        }
+        #expect(coordinator.lastErrorMessage != nil)
+        await #expect(counter.count == 1)
+
+        coordinator.dismissError()
+        #expect(coordinator.lastErrorMessage == nil)
+
+        // After dismiss, a `retry()` is a no-op — no operation to
+        // replay. Counter stays at 1.
+        await coordinator.retry()
+        await #expect(counter.count == 1)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Actor-wrapped counter so the throwing operation closure (which has
+/// to be `@Sendable`) can mutate shared state without a data-race
+/// warning. Tests only read the count from the MainActor, so the
+/// actor's serial isolation is overkill but keeps the closure
+/// declaration trivial.
+private actor CallCounter {
+    private(set) var count = 0
+    func increment() { count += 1 }
+}
+
+private enum SentinelTestError: Error {
+    case boom
+}

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudShareAcceptance.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudShareAcceptance.swift
@@ -1,6 +1,20 @@
 import CloudKit
 import CoreData
 
+/// Protocol seam over the share-acceptance step. Mirrors
+/// `HouseholdSharingService` (the matching protocol over share
+/// preparation) so app-layer callers can hold `any ShareAcceptanceService`
+/// and unit tests can substitute a stub conformer without touching
+/// CloudKit. Issue #105.
+public protocol ShareAcceptanceService: Sendable {
+    /// Imports the shared records described by `metadata` into the
+    /// container's shared store. Implementations throw on the
+    /// shared-store-unavailable case (single-store containers, tests)
+    /// and on Core Data + CloudKit-level rejection (network issues,
+    /// revoked invites, partial-failure imports).
+    func acceptShare(metadata: CKShare.Metadata) async throws
+}
+
 /// Wraps `NSPersistentCloudKitContainer.acceptShareInvitations(from:into:completion:)`
 /// — the API the recipient calls when they tap an iCloud share invite.
 /// Phase 3.2 surfaces this through the app delegate's
@@ -10,7 +24,11 @@ import CoreData
 /// Records land in the shared store. Phase 3.3 routes new writes to
 /// the right store (private vs shared) based on the active household's
 /// ownership.
-public final class CloudShareAcceptance: @unchecked Sendable {
+///
+/// Conforms to `ShareAcceptanceService` (issue #105) so the app-layer
+/// `ShareAcceptanceCoordinator` can hold `any ShareAcceptanceService`
+/// and tests can drop in a stub.
+public final class CloudShareAcceptance: ShareAcceptanceService, @unchecked Sendable {
     private let container: NSPersistentCloudKitContainer
 
     public init(container: NSPersistentCloudKitContainer) {
@@ -22,13 +40,25 @@ public final class CloudShareAcceptance: @unchecked Sendable {
     /// loaded (single-store container, in-memory tests) or if Core
     /// Data + CloudKit reject the invitation.
     public func acceptShare(metadata: CKShare.Metadata) async throws {
-        guard let sharedStore = CoreDataStack.sharedCloudKitStore(in: container) else {
-            throw CloudShareAcceptanceError.sharedStoreUnavailable
-        }
+        let sharedStore = try resolveSharedStore()
         _ = try await container.acceptShareInvitations(
             from: [metadata],
             into: sharedStore
         )
+    }
+
+    /// `internal` so `CloudShareAcceptanceTests` can pin the
+    /// shared-store-unavailable contract without needing to construct a
+    /// `CKShare.Metadata` (which has no public initializer for tests
+    /// to reach). Issue #105: splitting the gate from the
+    /// `acceptShareInvitations` call makes the failure-path tests
+    /// purely about Core Data wiring rather than CloudKit, which is
+    /// the only branch we can drive in CI without an iCloud account.
+    internal func resolveSharedStore() throws -> NSPersistentStore {
+        guard let store = CoreDataStack.sharedCloudKitStore(in: container) else {
+            throw CloudShareAcceptanceError.sharedStoreUnavailable
+        }
+        return store
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 3.2's recipient-side share-accept path used to swallow every failure into a `print()` line — a user who tapped Accept on a household invite got no in-app signal when CloudKit / Core Data rejected the import. Issue #105 flagged this as a Phase 3.2 blocker.

This PR adds the user-visible signal and pins the contract under test, **intentionally narrow per advisor guidance**: alert + 3+ unit tests + sentinel-based stubbing. The richer "modal sheet during accept" UX from the originally-greenlit recommendation is deferred to a polish PR — the issue's actual ACs are alert + tests + user-visible signal, all of which land here.

### Architecture

**Protocol seam** (mirrors `HouseholdSharingService`):
- `ShareAcceptanceService` in `NakedPantreePersistence` — `CloudShareAcceptance` conforms.

**App-layer coordinator**:
- `ShareAcceptanceCoordinator` (`@Observable`, `@MainActor`) wraps the service.
- `accept(metadata:)` runs through a publish-on-throw / clear-on-success machinery, exposes `lastErrorMessage` for the UI, and stashes the failed attempt for `retry()`.
- `@Observable` deliberately stays in the **app target** — `NakedPantreePersistence` keeps its pure-throws shape.

**Wiring**:
- `LiveDependencies` carries the coordinator; `RootView` reads it via `\.shareAcceptanceCoordinator`.
- `NakedPantreeAppDelegate.shareAcceptance` (bare service) → `.shareAcceptanceCoordinator`. The pre-init drain queue from #108 routes through the coordinator now, so a pre-launch invite that fails still produces a user-visible alert instead of a swallowed `print`.

**Alert**:
- `.alert(...)` on `RootView` with "Try Again" (calls `coordinator.retry()`) and "Dismiss" (calls `coordinator.dismissError()`). Voice rule §9 copy. A dedicated message variant for `sharedStoreUnavailable` ("iCloud isn't ready yet — try again in a moment") so the user knows it's a load-state issue, not a permanent reject.

### Tests

Per advisor: **don't fake `CKError.partialFailure` from memory** — its userInfo shape is specific and a mis-shaped stand-in produces a test that passes for the wrong reason. Use a sentinel error.

- `CloudShareAcceptanceTests` (2 tests):
  - `sharedStoreUnavailable` branch on a single-store `/dev/null` SQLite container — same pattern as `HouseholdSharingServiceTests`.
  - Compile-time conformance check.
  - Both go through `internal func resolveSharedStore()` because `CKShare.Metadata.init()` is `unavailable` ("Obtain `CKShareMetadata` from `CKFetchShareMetadataOperation` or platform-specific scene / app delegate callbacks") — there's no way to construct one in tests.

- `ShareAcceptanceCoordinatorTests` (5 tests):
  - Happy path → `lastErrorMessage` clears.
  - Generic error publishes a non-empty user-visible message.
  - `sharedStoreUnavailable` maps to its dedicated copy variant; generic errors don't.
  - Retry replays the failed operation; success on retry clears the alert.
  - `dismissError` clears state without re-attempting.
  - All five drive the coordinator through the internal closure-based `runFallible(_:)` seam — same metadata-init constraint.

### What's deferred

- Modal sheet "Joining household…" during accept — polish PR
- Telemetry / analytics around accept failures — separate concern

## Test plan

- [x] `CloudShareAcceptanceTests` (2 tests) green locally
- [x] `ShareAcceptanceCoordinatorTests` (5 tests) green locally
- [x] Existing `AppLauncherTests`, `NakedPantreeAppDelegatePreInitTests` still green after the rename of `shareAcceptance` → `shareAcceptanceCoordinator`
- [x] `swift-format --strict` + swiftlint clean via `./scripts/lint.sh`
- [x] App builds clean for the iOS Simulator
- [ ] Reviewer end-to-end: ask a co-resident device to share a household to a TestFlight build, deny the iCloud network mid-import (airplane mode toggle), confirm the alert appears with "Try Again" / "Dismiss" and that "Try Again" eventually succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)