### PR TITLE
ux(sidebar): move New Location out of toolbar into Settings (#131)

### DIFF
--- a/NakedPantreeApp/Features/Settings/LocationsSection.swift
+++ b/NakedPantreeApp/Features/Settings/LocationsSection.swift
@@ -1,0 +1,143 @@
+import NakedPantreeDomain
+import SwiftUI
+
+/// Issue #131: Settings-screen section that owns the create / edit /
+/// delete affordances for the household's locations. Lives in
+/// `SettingsView` instead of the sidebar toolbar — beta testers
+/// consistently misread the sidebar's `+` as "add item" rather than
+/// "add location", and locations are a rare-action surface that
+/// doesn't deserve top-level real estate.
+///
+/// The sibling issue (#132) repurposes the freed sidebar `+` slot as
+/// a "New Item" entry point. Until #132 lands, the sidebar has no
+/// primary toolbar action — that's the documented in-between state.
+///
+/// **Reload semantics:** the `LocationFormView` callback and the
+/// delete handler both reload by re-fetching `locations(in:)` on
+/// completion. The sibling sidebar reloads on Settings sheet dismiss
+/// (no shared store needed, no cross-component callback).
+///
+/// **Why a standalone view:** extracting this from `SettingsView`
+/// makes the load / form-callback / reload cycle unit-testable
+/// without standing up the whole Settings screen. Mirrors the
+/// existing `RestockSection` pattern in `ItemDetailView`.
+struct LocationsSection: View {
+    /// Household whose locations this section manages. Settings
+    /// resolves the household once (same `loadHousehold()` it uses for
+    /// the household name row) and hands the ID down. `nil` while the
+    /// load is in flight or if it failed — section renders nothing in
+    /// that case rather than a stale list against the wrong household.
+    let householdID: Household.ID?
+
+    @Environment(\.repositories) private var repositories
+
+    @State private var locations: [Location] = []
+    @State private var formMode: LocationFormView.Mode?
+    @State private var pendingDelete: Location?
+    @State private var loadError: Error?
+
+    var body: some View {
+        Section {
+            if let householdID {
+                if locations.isEmpty {
+                    Text("No locations yet — tap Add Location to set one up.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("settings.locations.empty")
+                }
+                ForEach(locations) { location in
+                    Button {
+                        formMode = .edit(location)
+                    } label: {
+                        Label(location.name, systemImage: location.kind.systemImage)
+                            .foregroundStyle(.primary)
+                    }
+                    .accessibilityIdentifier("settings.location.\(location.name)")
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            pendingDelete = location
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+                Button {
+                    formMode = .create(householdID: householdID)
+                } label: {
+                    Label("Add Location", systemImage: "plus.circle.fill")
+                }
+                .accessibilityIdentifier("settings.locations.add")
+            }
+        } header: {
+            Text("Locations")
+        }
+        .sheet(item: $formMode) { mode in
+            LocationFormView(mode: mode) {
+                Task { await reload() }
+            }
+        }
+        .confirmationDialog(
+            deleteConfirmationTitle,
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible,
+            presenting: pendingDelete
+        ) { location in
+            Button("Delete", role: .destructive) {
+                Task { await delete(location) }
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: { _ in
+            Text("This also removes every item inside it.")
+        }
+        .task(id: householdID) { await reload() }
+    }
+
+    private var deleteConfirmationTitle: String {
+        if let pendingDelete {
+            return "Delete \(pendingDelete.name)?"
+        }
+        return ""
+    }
+
+    /// `.confirmationDialog(isPresented:)` wants a `Bool` binding;
+    /// we drive it off the optional `pendingDelete` so dismissing
+    /// the dialog clears the row in one place.
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { newValue in
+                if !newValue { pendingDelete = nil }
+            }
+        )
+    }
+
+    /// Same swallow-and-fail-soft pattern as `SettingsView.loadHousehold`
+    /// and `SidebarView.reload`: location reads are not user-fatal —
+    /// the row count just stays stale. A real error banner is a
+    /// follow-up if location operations ever surface failures we
+    /// want the user to act on.
+    private func reload() async {
+        guard let householdID else {
+            locations = []
+            return
+        }
+        do {
+            locations = try await repositories.location.locations(in: householdID)
+            loadError = nil
+        } catch {
+            loadError = error
+        }
+    }
+
+    private func delete(_ location: Location) async {
+        pendingDelete = nil
+        do {
+            try await repositories.location.delete(id: location.id)
+            await reload()
+        } catch {
+            loadError = error
+        }
+    }
+}

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -61,6 +61,7 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 householdSection
+                LocationsSection(householdID: household?.id)
                 expiryRemindersSection
             }
             .scrollContentBackground(.hidden)

--- a/NakedPantreeApp/Features/Sidebar/SidebarView.swift
+++ b/NakedPantreeApp/Features/Sidebar/SidebarView.swift
@@ -3,16 +3,21 @@ import SwiftUI
 
 /// Two-section sidebar from `ARCHITECTURE.md` §7. Smart Lists are the
 /// fixed top section; Locations is data-driven from `LocationRepository`.
+///
+/// **Issue #131:** location create / edit / delete affordances moved
+/// out of the sidebar into Settings. Beta testers consistently misread
+/// the sidebar's `+` as "add item" rather than "add location", and
+/// locations are a rare-action surface. The toolbar now only owns the
+/// Settings entry point until #132 repurposes the freed primary slot
+/// as a "New Item" entry. The sidebar keeps the locations list for
+/// navigation; mutations live exclusively in Settings.
 struct SidebarView: View {
     @Binding var selection: SidebarSelection?
     @Environment(\.repositories) private var repositories
     @Environment(\.remoteChangeMonitor) private var remoteChangeMonitor
 
     @State private var locations: [Location] = []
-    @State private var householdID: Household.ID?
     @State private var loadError: Error?
-    @State private var formMode: LocationFormView.Mode?
-    @State private var pendingDelete: Location?
     @State private var isPresentingSettings = false
 
     var body: some View {
@@ -30,8 +35,10 @@ struct SidebarView: View {
                     // Phase 6.4: icon + text for the empty-state row so
                     // the sidebar matches the rest of the app's empty-
                     // state pattern (`DESIGN_GUIDELINES.md` §10 / Phase 6
-                    // exit criterion).
-                    Label("No locations yet. Tap + to add one.", systemImage: "tray")
+                    // exit criterion). Issue #131 repointed the copy
+                    // away from the (removed) toolbar `+` toward the
+                    // gear icon — Settings now owns location creation.
+                    Label("No locations yet — tap the gear to add one.", systemImage: "tray")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 } else {
@@ -39,19 +46,6 @@ struct SidebarView: View {
                         Label(location.name, systemImage: location.kind.systemImage)
                             .tag(SidebarSelection.location(location.id))
                             .accessibilityIdentifier("sidebar.location.\(location.name)")
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                Button(role: .destructive) {
-                                    pendingDelete = location
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
-                                Button {
-                                    formMode = .edit(location)
-                                } label: {
-                                    Label("Edit", systemImage: "pencil")
-                                }
-                                .tint(.indigo)
-                            }
                     }
                 }
             }
@@ -60,20 +54,11 @@ struct SidebarView: View {
         .background(Color.surface)
         .navigationTitle("Naked Pantree")
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    if let householdID {
-                        formMode = .create(householdID: householdID)
-                    }
-                } label: {
-                    Label("New Location", systemImage: "plus")
-                }
-                .disabled(householdID == nil)
-            }
             // Phase 9.3 introduced the Settings entry point in the
             // secondary toolbar slot. Phase 10.1 (#60) folded household
-            // sharing into Settings, so this is now the sidebar's only
-            // secondary action. Always available — even in previews /
+            // sharing into Settings; #131 folded location management in
+            // alongside it, retiring the primary "New Location"
+            // toolbar item. Always available — even in previews /
             // tests, where the no-op `NotificationSettings` default
             // lets the screen render without a real UserDefaults
             // backing.
@@ -86,68 +71,43 @@ struct SidebarView: View {
                 .accessibilityIdentifier("settings.toolbar.entry")
             }
         }
-        .sheet(item: $formMode) { mode in
-            LocationFormView(mode: mode) {
-                Task { await reload() }
-            }
-        }
         .sheet(isPresented: $isPresentingSettings) {
             SettingsView()
         }
-        .confirmationDialog(
-            deleteConfirmationTitle,
-            isPresented: deleteDialogBinding,
-            titleVisibility: .visible,
-            presenting: pendingDelete
-        ) { location in
-            Button("Delete", role: .destructive) {
-                Task { await delete(location) }
-            }
-            Button("Cancel", role: .cancel) {
-                pendingDelete = nil
-            }
-        } message: { _ in
-            Text("This also removes every item inside it.")
-        }
+        // Cross-device reload: `RemoteChangeMonitor` skips local-author
+        // writes, so this only fires when another device (or a freshly-
+        // imported share) bumps the token.
         .task(id: remoteChangeMonitor.changeToken) { await reload() }
-    }
-
-    private var deleteConfirmationTitle: String {
-        if let pendingDelete {
-            return "Delete \(pendingDelete.name)?"
+        // Same-device reload: Settings now owns location create/edit/
+        // delete (#131), so the local-author skip above means the
+        // sidebar wouldn't otherwise reflect changes made in the
+        // sheet. Reload when Settings dismisses so the user comes
+        // back to a fresh list. If a deleted location was the active
+        // selection, snap back to All Items so the content column
+        // doesn't render against a stale ID.
+        .onChange(of: isPresentingSettings) { _, newValue in
+            guard !newValue else { return }
+            Task { await reloadAndReconcileSelection() }
         }
-        return ""
-    }
-
-    private var deleteDialogBinding: Binding<Bool> {
-        Binding(
-            get: { pendingDelete != nil },
-            set: { newValue in
-                if !newValue { pendingDelete = nil }
-            }
-        )
     }
 
     private func reload() async {
         do {
             let house = try await repositories.household.currentHousehold()
-            householdID = house.id
             locations = try await repositories.location.locations(in: house.id)
         } catch {
             loadError = error
         }
     }
 
-    private func delete(_ location: Location) async {
-        pendingDelete = nil
-        if case .location(let selectedID) = selection, selectedID == location.id {
+    /// Reload + drop the active selection if the user deleted the
+    /// currently-selected location from Settings.
+    private func reloadAndReconcileSelection() async {
+        await reload()
+        if case .location(let selectedID) = selection,
+            !locations.contains(where: { $0.id == selectedID })
+        {
             selection = .smartList(.allItems)
-        }
-        do {
-            try await repositories.location.delete(id: location.id)
-            await reload()
-        } catch {
-            loadError = error
         }
     }
 }


### PR DESCRIPTION
## Summary

- Moves location **create / edit / delete** out of the sidebar toolbar and into the Settings screen.
- Extracts a `LocationsSection` SwiftUI view (mirrors the `RestockSection` pattern) for clean wiring + a future testability seam.
- Reuses `LocationFormView` unchanged.
- Sidebar now exposes only the Settings gear; the locations list there stays read-only for navigation.

The change is the user-experience fix for beta feedback: testers consistently misread the sidebar's `+` as "add item." Locations are a rare-action surface — a couple set up once, rarely touched again — so they belong in Settings next to household management, not in primary toolbar real estate.

## ⚠️ Heads-up on merge order

This PR **alone** leaves the sidebar with no primary toolbar action — that's the documented in-between state. Sibling [#132](https://github.com/ellisandy/NakedPantree/issues/132) repurposes the freed slot as a quick "New Item" entry point. The issue specifies they should land together so the toolbar isn't broken in between releases.

**Recommended merge order:**
- Hold merging this PR until [#132](https://github.com/ellisandy/NakedPantree/issues/132) is open and ready, then merge both back-to-back.
- Or merge this PR now and bump the next TestFlight only after #132 lands.

I'll stack #132 on top of this branch and open it as a follow-up PR.

## Sidebar diff details

- Drops `ToolbarItem(placement: .primaryAction)` and its `LocationFormView` sheet.
- Drops row-level swipe `Edit` / `Delete` actions (per issue #131 recommendation: all mutations live in Settings now).
- Empty-state copy: `"No locations yet. Tap + to add one."` → `"No locations yet — tap the gear to add one."`
- Keeps `task(id: remoteChangeMonitor.changeToken)` for **cross-device** reload.
- Adds `onChange(of: isPresentingSettings)` edge for **same-device** reload — `RemoteChangeMonitor` filters out local-author writes by design (#28), so the dismiss-edge is required to reflect Settings-driven edits without changing cross-device semantics.
- Reconciles `selection`: if the active sidebar location was deleted in Settings, snap back to `All Items` so the content column doesn't render against a stale ID.

## Settings diff details

- New `LocationsSection` between the Household and Expiry Reminders sections.
- Lists existing locations, tap to edit, swipe-to-delete with the same destructive confirmation copy as the old sidebar dialog (`"This also removes every item inside it."`).
- "Add Location" row triggers `LocationFormView` in `.create(householdID:)` mode.
- Item count column intentionally skipped — issue marks it as "maybe" and adding it pulls in a new repository method or client-side fan-out fetch. Defer to a follow-up if it ever matters.

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] `BootstrapUITests.testFirstLaunchShowsKitchen` passes (sidebar still renders Kitchen row + gear)
- [x] Full unit suite passes locally (the only "failures" are pre-existing local-only crashes from CK-touching tests without entitlements; CI signs and passes)
- [ ] CI green
- [ ] **Manual smoke (please do during review):** Settings → Add Location → save → sidebar reflects after dismiss
- [ ] **Manual smoke:** Settings → swipe-delete a location → confirm → sidebar reflects + selection snaps to All Items if that location was selected
- [ ] **Manual smoke:** edit existing location name in Settings → sidebar row updates after dismiss

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)