### PR TITLE
feat(items): allow moving an item between locations from edit form (#134)

### DIFF
--- a/NakedPantreeApp/Features/Items/ItemFormSaveCoordinator.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormSaveCoordinator.swift
@@ -9,6 +9,12 @@ import NakedPantreeDomain
 /// affordance: the coordinator collapses them into the optional
 /// `Item.expiresAt` exactly the way the view used to.
 struct ItemFormDraft {
+    /// Issue #134: target location for the item. On the create branch
+    /// this seeds from the mode's `locationID` and may be reassigned
+    /// by the form's location picker; on the edit branch this is the
+    /// picker's current value, which can differ from the original
+    /// item's `locationID` when the user is moving the item.
+    var locationID: Location.ID
     var name: String
     var quantity: Int32
     var unit: NakedPantreeDomain.Unit
@@ -63,9 +69,13 @@ enum ItemFormSaveCoordinator {
 
         let saved: Item
         switch mode {
-        case .create(let locationID):
+        case .create:
+            // Issue #134: the mode carries an initial `locationID` that
+            // seeds the form's picker, but the picker's final value
+            // (`draft.locationID`) is what gets saved — the user may
+            // have changed it.
             let item = Item(
-                locationID: locationID,
+                locationID: draft.locationID,
                 name: trimmedName,
                 quantity: draft.quantity,
                 unit: draft.unit,
@@ -76,6 +86,13 @@ enum ItemFormSaveCoordinator {
             saved = item
         case .edit(let original):
             var updated = original
+            // Issue #134: edit mode now writes the picker's locationID
+            // back, letting users reassign an item to a new location
+            // without losing its history (id, createdAt, photos,
+            // notes, expiry). `attachLocation` in the repository
+            // re-points the relationship; cross-household moves are
+            // not supported (see `Item.locationID` doc).
+            updated.locationID = draft.locationID
             updated.name = trimmedName
             updated.quantity = draft.quantity
             updated.unit = draft.unit

--- a/NakedPantreeApp/Features/Items/ItemFormView.swift
+++ b/NakedPantreeApp/Features/Items/ItemFormView.swift
@@ -29,6 +29,16 @@ struct ItemFormView: View {
     @State private var notes: String = ""
     @State private var isSaving = false
     @State private var saveError: String?
+    /// Issue #134: target location. Seeded from the mode in `prefill()`
+    /// (create → passed-in id; edit → existing item's id) and rebound
+    /// by the location picker. Optional so the section's empty-load
+    /// state and the picker's "no selection" rendering converge.
+    @State private var selectedLocationID: Location.ID?
+    /// Issue #134: locations the picker chooses from. Loaded once on
+    /// appear via `repositories.location.locations(in:)`. Empty array
+    /// (load not yet completed, or single-location household) hides
+    /// the picker — there's nowhere to move the item to.
+    @State private var locations: [Location] = []
 
     private let unitOptions: [NakedPantreeDomain.Unit] = [
         .count, .gram, .kilogram, .ounce, .pound,
@@ -52,6 +62,25 @@ struct ItemFormView: View {
                         ForEach(unitOptions, id: \.self) { option in
                             Text(option.pickerLabel).tag(option)
                         }
+                    }
+                }
+
+                // Issue #134: Location picker. Hidden when the
+                // household has zero or one locations — single-
+                // location users have nowhere to move to, and the
+                // initial-load case (locations not yet fetched)
+                // shouldn't flash an empty picker. The non-optional
+                // tag below pairs with `Location.ID?` selection so
+                // the no-selection state is representable.
+                if locations.count > 1 {
+                    Section("Location") {
+                        Picker("Location", selection: $selectedLocationID) {
+                            ForEach(locations) { location in
+                                Label(location.name, systemImage: location.kind.systemImage)
+                                    .tag(Optional(location.id))
+                            }
+                        }
+                        .accessibilityIdentifier("itemForm.location.picker")
                     }
                 }
 
@@ -97,6 +126,7 @@ struct ItemFormView: View {
                 }
             }
             .onAppear(perform: prefill)
+            .task { await loadLocations() }
         }
     }
 
@@ -118,8 +148,30 @@ struct ItemFormView: View {
         ItemFormSaveCoordinator.isValid(name: name)
     }
 
+    /// Issue #134: canonical fallback for `selectedLocationID` if the
+    /// `prefill()` seed is ever clobbered (e.g. an async race that
+    /// nils `@State` between appear and save). Mirror of `prefill`'s
+    /// initial assignment — keep them in sync if the mode seeding
+    /// rules ever change.
+    private func defaultLocationID() -> Location.ID {
+        switch mode {
+        case .create(let id): id
+        case .edit(let item): item.locationID
+        }
+    }
+
     private func prefill() {
-        if case .edit(let item) = mode {
+        // Issue #134: seed the location picker from the mode. Create
+        // mode carries the entry-point's locationID (sidebar `+`
+        // already resolved a target via the picker / 1-location
+        // shortcut, or `ItemsView`'s per-location `+` passes its
+        // current location). Edit mode prefills from the existing
+        // item's current location.
+        switch mode {
+        case .create(let locationID):
+            selectedLocationID = locationID
+        case .edit(let item):
+            selectedLocationID = item.locationID
             name = item.name
             quantity = item.quantity
             unit = item.unit
@@ -131,12 +183,36 @@ struct ItemFormView: View {
         }
     }
 
+    /// Issue #134: fetches the current household's locations so the
+    /// picker has options. Same swallow-on-fail pattern as
+    /// `SidebarView.reload` / `LocationsSection.reload` — if the
+    /// load errors, the picker stays hidden (single-location
+    /// fallback) and save still works against `selectedLocationID`
+    /// from `prefill()`.
+    @MainActor
+    private func loadLocations() async {
+        do {
+            let household = try await repositories.household.currentHousehold()
+            locations = try await repositories.location.locations(in: household.id)
+        } catch {
+            // Silent — picker stays hidden, original locationID still
+            // saves through fine.
+        }
+    }
+
     @MainActor
     private func save() async {
         // Issue #117: persistence + post-save scheduling now live in
         // `ItemFormSaveCoordinator`. The view stays responsible for the
         // SwiftUI surface (saving spinner, error banner, dismiss).
+        // Issue #134: `selectedLocationID` is seeded by `prefill()`
+        // before the form can be interacted with, so the `??` fallback
+        // is defensive — if it ever fires, fall back to the mode's
+        // canonical id (create's seed, or the item's current location
+        // on edit).
+        let resolvedLocationID = selectedLocationID ?? defaultLocationID()
         let draft = ItemFormDraft(
+            locationID: resolvedLocationID,
             name: name,
             quantity: quantity,
             unit: unit,

--- a/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
+++ b/NakedPantreeTests/Forms/FormSaveCoordinatorTests.swift
@@ -36,6 +36,7 @@ struct ItemFormSaveCoordinatorTests {
         let locationID = UUID()
 
         let draft = ItemFormDraft(
+            locationID: locationID,
             name: "  Sourdough  ",
             quantity: 2,
             unit: .count,
@@ -77,6 +78,7 @@ struct ItemFormSaveCoordinatorTests {
         // and the "add" branch runs.
         let future = Date.now.addingTimeInterval(60 * 60 * 24 * 30)
         let draft = ItemFormDraft(
+            locationID: locationID,
             name: "Tomatoes",
             quantity: 1,
             unit: .count,
@@ -108,6 +110,7 @@ struct ItemFormSaveCoordinatorTests {
         let locationID = UUID()
 
         let draft = ItemFormDraft(
+            locationID: locationID,
             name: "Tinned tuna",
             quantity: 4,
             unit: .count,
@@ -153,6 +156,10 @@ struct ItemFormSaveCoordinatorTests {
         let scheduler = NotificationScheduler(servicing: center)
 
         let draft = ItemFormDraft(
+            // Same locationID as the original — this test pins the
+            // edit-without-move case. Issue #134's move-on-edit case
+            // is covered separately in `editReassignsLocationID`.
+            locationID: original.locationID,
             name: "  Sourdough  ",
             quantity: 3,
             unit: .package,
@@ -188,6 +195,63 @@ struct ItemFormSaveCoordinatorTests {
         #expect(removedFlat.contains(expected))
     }
 
+    /// Issue #134: edit-mode save honours the draft's `locationID` —
+    /// the picker can move an item between locations. Pins the
+    /// behavior that #134 added so a future refactor that drops
+    /// the line `updated.locationID = draft.locationID` (it would
+    /// be easy to overlook in a sweep) fails the test rather than
+    /// silently sending every move-edit back to the original
+    /// location.
+    @Test("Edit — draft locationID overrides the original (move between locations)")
+    func editReassignsLocationID() async throws {
+        let oldLocation = UUID()
+        let newLocation = UUID()
+        let original = Item(
+            id: UUID(),
+            locationID: oldLocation,
+            name: "Chili",
+            quantity: 1,
+            unit: .count,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let repo = InMemoryItemRepository(initial: [original])
+        let center = StubNotificationCenter()
+        let scheduler = NotificationScheduler(servicing: center)
+
+        let draft = ItemFormDraft(
+            // The draft says "save into the new location" — the
+            // edit branch must respect that, not fall back to
+            // `original.locationID`.
+            locationID: newLocation,
+            name: "Chili",
+            quantity: 1,
+            unit: .count,
+            hasExpiry: false,
+            expiresAt: .now,
+            notes: ""
+        )
+
+        let saved = try await ItemFormSaveCoordinator.save(
+            mode: .edit(original),
+            draft: draft,
+            repository: repo,
+            scheduler: scheduler
+        )
+
+        #expect(saved.id == original.id, "Move must preserve item identity.")
+        #expect(saved.createdAt == original.createdAt, "Move must preserve createdAt.")
+        #expect(saved.locationID == newLocation, "Move must reassign locationID.")
+
+        // Repo round-trip: the item lives at the new location now,
+        // not the old one. `items(in:)` is the surface UI uses to
+        // populate per-location lists, so this is the contract that
+        // makes the sidebar list show the moved item correctly.
+        let fromOldLocation = try await repo.items(in: oldLocation)
+        let fromNewLocation = try await repo.items(in: newLocation)
+        #expect(fromOldLocation.isEmpty, "Old location should no longer contain the item.")
+        #expect(fromNewLocation.contains(where: { $0.id == original.id }))
+    }
+
     @Test("Repository error — propagates and scheduler is never called")
     func repositoryErrorPropagates() async throws {
         let repo = ThrowingItemRepository()
@@ -195,6 +259,7 @@ struct ItemFormSaveCoordinatorTests {
         let scheduler = NotificationScheduler(servicing: center)
 
         let draft = ItemFormDraft(
+            locationID: UUID(),
             name: "Bread",
             quantity: 1,
             unit: .count,

--- a/NakedPantreeTests/Persistence/RepositoryContractTests.swift
+++ b/NakedPantreeTests/Persistence/RepositoryContractTests.swift
@@ -450,6 +450,53 @@ struct ItemRepositoryContractTests {
         #expect(after.updatedAt > Date(timeIntervalSince1970: 2))
     }
 
+    /// Issue #134: an `update` whose item carries a different
+    /// `locationID` reassigns the item to that location. Pins the
+    /// repository contract that `ItemFormSaveCoordinator` relies on
+    /// to power the move-on-edit UX. CoreData mutates the
+    /// `location` relationship via `attachLocation`; the in-memory
+    /// repo replaces the row by id.
+    @Test(
+        "update with a new locationID moves the item between locations (#134)",
+        arguments: RepositoryFactory.all)
+    func updateReassignsLocation(factory: RepositoryFactory) async throws {
+        let bundle = factory.make()
+        let household = bundle.household
+        let locationRepo = bundle.location
+        let itemRepo = bundle.item
+        let house = try await household.currentHousehold()
+        let pantry = Location(householdID: house.id, name: "Pantry")
+        let freezer = Location(householdID: house.id, name: "Garage Freezer", kind: .freezer)
+        try await locationRepo.create(pantry)
+        try await locationRepo.create(freezer)
+
+        var chili = Item(locationID: pantry.id, name: "Chili", quantity: 1, unit: .count)
+        try await itemRepo.create(chili)
+
+        // Sanity-check the create landed in pantry; the move test
+        // depends on starting state being correct.
+        let beforePantry = try await itemRepo.items(in: pantry.id)
+        #expect(beforePantry.map(\.id) == [chili.id])
+
+        chili.locationID = freezer.id
+        try await itemRepo.update(chili)
+
+        // After the move: the item shows up under freezer and is
+        // gone from pantry. Both halves matter — a half-finished
+        // implementation that copies the row instead of moving
+        // would leave duplicates at the old location.
+        let afterPantry = try await itemRepo.items(in: pantry.id)
+        let afterFreezer = try await itemRepo.items(in: freezer.id)
+        #expect(afterPantry.isEmpty, "Item should no longer appear under the old location.")
+        #expect(afterFreezer.map(\.id) == [chili.id])
+
+        // Identity / history preserved: same id, same createdAt.
+        let fetched = try #require(try await itemRepo.item(id: chili.id))
+        #expect(fetched.id == chili.id)
+        #expect(fetched.locationID == freezer.id)
+        #expect(fetched.createdAt == chili.createdAt)
+    }
+
     @Test(
         "updateQuantity changes only quantity, leaves name and expiresAt untouched (#118)",
         arguments: RepositoryFactory.all)

--- a/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/Entities.swift
@@ -48,7 +48,14 @@ public struct Location: Sendable, Hashable, Identifiable {
 /// — callers should not set it directly. See `ItemRepository.update(_:)`.
 public struct Item: Sendable, Hashable, Identifiable {
     public let id: UUID
-    public let locationID: Location.ID
+    /// `var` so an item can be reassigned to a different location within
+    /// the same household — issue #134. Real pantry items move (the
+    /// chili that was in the outdoor freezer comes inside; the package
+    /// in the garage shelf moves to the pantry). Cross-household moves
+    /// are intentionally not supported — callers must keep
+    /// `Location.householdID` consistent or the repository's
+    /// scope-routing breaks.
+    public var locationID: Location.ID
     public var name: String
     public var quantity: Int32
     public var unit: Unit


### PR DESCRIPTION
## Summary

Real pantry items move — the chili in the outdoor freezer comes inside; the package on the garage shelf moves to the pantry. Before #134, an item's location was fixed at creation: users had to delete and recreate to move, losing history (`id`, `createdAt`, notes, photos, expiry).

This PR adds a Location picker to `ItemFormView` and threads the picker's selection through `ItemFormSaveCoordinator` so edit-mode saves can reassign `Item.locationID`. CoreData and in-memory repositories both already round-trip the new id correctly through `update` — pinned by a new parameterized contract test.

## Changes

| Layer | Change |
|---|---|
| `Item` | `locationID` is now `var`. Cross-household moves remain unsupported (must keep `Location.householdID` consistent or repo scope routing breaks). |
| `ItemFormDraft` | New `locationID: Location.ID` field. |
| `ItemFormSaveCoordinator.save` | Edit branch now writes `draft.locationID` into `updated.locationID` before `repository.update(_:)`. |
| `ItemFormView` | New Location picker section (only when household has 2+ locations). Seeds from mode in `prefill`; fetches options via `loadLocations`. |
| `CoreDataItemRepository.update` | No change — `attachLocation` already re-points the relationship. Verified. |
| `InMemoryItemRepository.update` | No change — already replaces row by id. Verified. |

## Tests

- **`ItemFormSaveCoordinatorTests.editReassignsLocationID`** — pins the move-on-edit contract end-to-end: `id` and `createdAt` preserved, `locationID` reassigned, item gone from old location, present under new via `items(in:)`.
- **`ItemRepositoryContractTests.updateReassignsLocation`** (parameterized) — same contract at the repository layer, runs against InMemory + CoreData factories.
- Existing `ItemFormSaveCoordinatorTests` updated to include `locationID` in their drafts.

## Out of scope (per issue)

- Bulk move (multi-select)
- Drag-and-drop between sidebar locations
- Move history / audit log
- Cross-household move

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] All 9 `ItemFormSaveCoordinator` tests pass locally (including new move-on-edit)
- [x] All `ItemRepository contract` tests pass for InMemory + CoreData (including new `update with a new locationID moves the item between locations (#134)`)
- [x] Core SPM tests pass (`swift test` — 12 tests across 3 suites)
- [x] `BootstrapUITests` + `NewItemTabUITests` still pass (no UI regression)
- [ ] CI green
- [ ] **Manual smoke (please do during review):**
  - Open existing item in a household with 2+ locations → form shows Location picker
  - Pick a different location → save → item appears under new location, gone from old
  - Item id, notes, photos, expiry, created date all preserved
  - Single-location household: Location picker hidden (nowhere to move to)
  - Notification reschedules correctly across move (same id, expiry-based scheduler call)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)