### PR TITLE
fix(settings): Add Location sheet collapsing the entire stack (build #52)

### DIFF
--- a/NakedPantreeApp/Features/Settings/LocationsSection.swift
+++ b/NakedPantreeApp/Features/Settings/LocationsSection.swift
@@ -8,14 +8,26 @@ import SwiftUI
 /// "add location", and locations are a rare-action surface that
 /// doesn't deserve top-level real estate.
 ///
-/// The sibling issue (#132) repurposes the freed sidebar `+` slot as
-/// a "New Item" entry point. Until #132 lands, the sidebar has no
-/// primary toolbar action — that's the documented in-between state.
+/// **Why `formMode` is a parent-owned `@Binding`:** in the original
+/// implementation this section attached `.sheet(item: $formMode)`
+/// directly. That presented inside the outer Settings sheet's
+/// content, deep under a Form's Section. SwiftUI's presentation
+/// context resolution couldn't tell which sheet was being asked
+/// to present from a Section-attached `.sheet`, and would dismiss
+/// the entire sheet stack — including the parent Settings sheet —
+/// the moment the form tried to appear. Build #52 reproduced this
+/// every time. Fix: lift `formMode` and the `.sheet(item:)`
+/// modifier to `SettingsView`'s NavigationStack, where the
+/// presentation context is unambiguous. The section keeps its
+/// own state for delete-confirmation (a `confirmationDialog`,
+/// which is action-sheet-shaped and doesn't have the same
+/// presentation-context bug).
 ///
-/// **Reload semantics:** the `LocationFormView` callback and the
-/// delete handler both reload by re-fetching `locations(in:)` on
-/// completion. The sibling sidebar reloads on Settings sheet dismiss
-/// (no shared store needed, no cross-component callback).
+/// **Reload semantics:** when the form sheet dismisses (whether
+/// the user saved or cancelled), `formMode` flips back to nil.
+/// `.onChange(of: formMode)` catches that edge and re-fetches the
+/// locations list — that's why the parent doesn't need to thread
+/// an `onSaved` callback through.
 ///
 /// **Why a standalone view:** extracting this from `SettingsView`
 /// makes the load / form-callback / reload cycle unit-testable
@@ -29,10 +41,14 @@ struct LocationsSection: View {
     /// that case rather than a stale list against the wrong household.
     let householdID: Household.ID?
 
+    /// Form-mode state owned by `SettingsView` — see the type doc for
+    /// why this is a binding rather than `@State`. The section sets
+    /// it on Add / Edit taps; the parent renders the actual sheet.
+    @Binding var formMode: LocationFormView.Mode?
+
     @Environment(\.repositories) private var repositories
 
     @State private var locations: [Location] = []
-    @State private var formMode: LocationFormView.Mode?
     @State private var pendingDelete: Location?
     @State private var loadError: Error?
 
@@ -71,11 +87,6 @@ struct LocationsSection: View {
         } header: {
             Text("Locations")
         }
-        .sheet(item: $formMode) { mode in
-            LocationFormView(mode: mode) {
-                Task { await reload() }
-            }
-        }
         .confirmationDialog(
             deleteConfirmationTitle,
             isPresented: deleteDialogBinding,
@@ -92,6 +103,15 @@ struct LocationsSection: View {
             Text("This also removes every item inside it.")
         }
         .task(id: householdID) { await reload() }
+        // Reload when the parent-rendered form sheet dismisses
+        // (either via save or cancel — both flip formMode back to
+        // nil). This is the missing wire that the lifted `.sheet`
+        // would otherwise need an `onSaved` callback to do.
+        .onChange(of: formMode) { _, newValue in
+            if newValue == nil {
+                Task { await reload() }
+            }
+        }
     }
 
     private var deleteConfirmationTitle: String {

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -44,6 +44,15 @@ struct SettingsView: View {
     @State private var isPreparingShare = false
     @State private var shareError: ShareErrorAlert?
 
+    /// Build #52 bug fix: `LocationsSection`'s create/edit form sheet
+    /// state lives here (not in the section) so the `.sheet(item:)`
+    /// modifier can attach at the NavigationStack level. Attaching
+    /// the form sheet inside a Form's Section caused SwiftUI's
+    /// presentation-context resolution to dismiss the entire sheet
+    /// stack the moment the form tried to appear. See the section's
+    /// own type doc for the full root-cause writeup.
+    @State private var locationFormMode: LocationFormView.Mode?
+
     /// Trace for #90 (blank Share Household sheet on TestFlight).
     /// Same subsystem/category as `CloudSharingControllerView` and
     /// `CloudHouseholdSharingService` so a single Console.app filter
@@ -61,7 +70,10 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 householdSection
-                LocationsSection(householdID: household?.id)
+                LocationsSection(
+                    householdID: household?.id,
+                    formMode: $locationFormMode
+                )
                 expiryRemindersSection
             }
             .scrollContentBackground(.hidden)
@@ -71,6 +83,21 @@ struct SettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
+                }
+            }
+            // Build #52 fix: present the LocationsSection's
+            // create/edit form here, at the NavigationStack level,
+            // rather than from inside the Form's Section. Section-
+            // attached `.sheet(item:)` made SwiftUI dismiss the
+            // entire sheet stack on present. The section flips
+            // `locationFormMode` via its parent-owned binding; this
+            // modifier renders the actual sheet.
+            .sheet(item: $locationFormMode) { mode in
+                LocationFormView(mode: mode) {
+                    // No-op — `LocationsSection.onChange(of: formMode)`
+                    // catches the dismiss edge and triggers its own
+                    // reload. Keeping that local to the section
+                    // avoids threading another callback through.
                 }
             }
             .sheet(item: $preparedShare) { prepared in

--- a/NakedPantreeUITests/AddLocationFromSettingsUITests.swift
+++ b/NakedPantreeUITests/AddLocationFromSettingsUITests.swift
@@ -1,0 +1,135 @@
+import XCTest
+
+/// Bug regression: from build #52, opening **Settings → Add Location**
+/// briefly presents the `LocationFormView` sheet, which then immediately
+/// dismisses on its own and drops the user back to the sidebar. The
+/// form never gets a chance to be filled in, so users can't add
+/// locations from Settings — the only path to add them after #131
+/// moved create/edit/delete out of the sidebar.
+///
+/// **What this test pins:** after tapping `settings.locations.add`,
+/// the New Location form's `staticTexts["New Location"]` (its
+/// inline navigation title) must remain visible long enough to type
+/// a name. A flake-resistant 3-second observation window catches
+/// the auto-dismiss without depending on tap timing.
+///
+/// `EMPTY_STORE=1` is the same env used by `BootstrapUITests` /
+/// `NewItemTabUITests`. Bootstrap seeds Kitchen, but this test
+/// doesn't depend on that — it only needs Settings to load and the
+/// Locations section to render.
+@MainActor
+final class AddLocationFromSettingsUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testAddLocationSheetStaysPresented() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["EMPTY_STORE"] = "1"
+        app.launch()
+
+        // Wait for bootstrap before navigating into Settings — the
+        // Locations section reads from the same household repo and
+        // a too-fast tap pre-bootstrap would land on a sheet whose
+        // backing data is still nil.
+        XCTAssertTrue(
+            app.staticTexts["Kitchen"].firstMatch.waitForExistence(timeout: 10),
+            "First-launch bootstrap didn't populate the sidebar."
+        )
+
+        // Open Settings via the sidebar's gear (`settings.toolbar.entry`).
+        // On iPhone this lives in the secondary-action overflow menu;
+        // try several heuristics matching the pattern in
+        // `SharingUITests.testShareHouseholdSheetPopulatesContent`.
+        try openSettings(in: app)
+
+        // Confirm Settings opened by waiting for its household name row.
+        XCTAssertTrue(
+            app.staticTexts["settings.household.name"].waitForExistence(timeout: 5),
+            "Settings sheet didn't show the household-name row."
+        )
+
+        let addLocationButton = app.buttons["settings.locations.add"]
+        XCTAssertTrue(
+            addLocationButton.waitForExistence(timeout: 5),
+            "Add Location row missing from the Settings Locations section."
+        )
+        addLocationButton.tap()
+
+        // The form's inline navigation title is "New Location" on
+        // `.create` mode. Wait for it to appear — that's the
+        // happy-path "form did present" signal.
+        let formTitle = app.staticTexts["New Location"]
+        XCTAssertTrue(
+            formTitle.waitForExistence(timeout: 5),
+            "New Location form didn't appear after tapping Add Location."
+        )
+
+        // The bug: form appears for a moment, then auto-dismisses.
+        // Observe the title for 3 seconds — if the form genuinely
+        // stayed presented this is a no-op; if the form dismisses
+        // mid-window, `formTitle.exists` flips false and the
+        // assertion fails with the regression message.
+        let stillPresented = waitForElementToRemain(
+            element: formTitle,
+            forSeconds: 3
+        )
+        XCTAssertTrue(
+            stillPresented,
+            "New Location form auto-dismissed within 3 seconds — Settings → Add Location regression."
+        )
+    }
+
+    /// Polls `element.exists` every 0.25s for `forSeconds`. Returns
+    /// `false` the first time the element is gone — that's the
+    /// auto-dismiss signature. Returns `true` if the element stays
+    /// reachable through the entire window.
+    private func waitForElementToRemain(
+        element: XCUIElement,
+        forSeconds seconds: TimeInterval
+    ) -> Bool {
+        let pollInterval: TimeInterval = 0.25
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if !element.exists {
+                return false
+            }
+            Thread.sleep(forTimeInterval: pollInterval)
+        }
+        return element.exists
+    }
+
+    /// Reaches the gear button across iPhone / iPad layouts. Mirrors
+    /// the heuristic in `SharingUITests` — try the identifier
+    /// directly, then the localized "Settings" label, then the
+    /// overflow-menu candidates that iPhone uses to collapse
+    /// secondary toolbar actions.
+    private func openSettings(in app: XCUIApplication) throws {
+        let direct = app.buttons["settings.toolbar.entry"]
+        if direct.waitForExistence(timeout: 2) {
+            direct.tap()
+            return
+        }
+        let byLabel = app.buttons["Settings"]
+        if byLabel.waitForExistence(timeout: 1) {
+            byLabel.tap()
+            return
+        }
+        for candidate in ["More", "…", "More Options"] {
+            let button = app.buttons[candidate]
+            if button.waitForExistence(timeout: 1) {
+                button.tap()
+                break
+            }
+        }
+        if direct.waitForExistence(timeout: 5) {
+            direct.tap()
+            return
+        }
+        if byLabel.waitForExistence(timeout: 1) {
+            byLabel.tap()
+            return
+        }
+        XCTFail("Settings entry unreachable from current accessibility hierarchy.")
+    }
+}


### PR DESCRIPTION
## Bug

Build #52: tapping **Add Location** in Settings briefly showed the New Location form, then dismissed *both* the form and the Settings sheet, dropping the user back at the sidebar with nothing added. Beta testers couldn't add locations at all — the only path to add them after #131 moved create/edit/delete out of the sidebar.

## Root cause

`LocationsSection` attached `.sheet(item: $formMode)` to itself — i.e., to a SwiftUI `Section` view nested inside the Settings sheet's `Form`. When the form sheet tried to present, SwiftUI's presentation-context resolution couldn't disambiguate between the inner form sheet and the outer Settings sheet, so it dismissed *both*.

Section-attached `.sheet` modifiers don't behave well when the Section lives inside another modal — sheets need to attach to the NavigationStack root or top-level view of the modal content, not deep in a Form's child tree.

## Fix

Lift `formMode` and the `.sheet(item:)` modifier up to `SettingsView`'s NavigationStack, where the presentation context is unambiguous (and where the existing share sheet already lives). `LocationsSection` exposes `formMode` upward as a `@Binding` and keeps its other state (`pendingDelete`, `locations`) local.

Reload-after-dismiss no longer needs an `onSaved` callback — the section's `.onChange(of: formMode)` catches the nil-edge and triggers its own `reload()`. Cleaner than threading another callback through.

The delete `.confirmationDialog` stays inside `LocationsSection`. It's an action-sheet, not a `.sheet`, and doesn't have the same presentation-context issue. Will lift if it ever bites us.

## Test plan

- [x] **Reproduced bug locally** by writing `AddLocationFromSettingsUITests.testAddLocationSheetStaysPresented` against the broken code — test failed at the form-appearance check (form auto-dismissed faster than XCUITest's wait window)
- [x] **Confirmed fix** by re-running the same test against the fixed code — green
- [x] `BootstrapUITests` still passes (sidebar populates Kitchen)
- [x] `NewItemTabUITests` still passes (sidebar `+` opens Item form unchanged)
- [x] `./scripts/lint.sh` clean
- [ ] CI green
- [ ] **Manual smoke (please do during review):**
  - Open Settings → tap Add Location → form opens and stays open
  - Type a name → tap Add → form dismisses, location appears in section
  - Tap an existing location row → edit form opens and stays open
  - Swipe-to-delete still works with confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)