### PR TITLE
ux(items): show expired badge on every item list (#156)

### DIFF
--- a/NakedPantreeApp/Features/Items/AllItemsView.swift
+++ b/NakedPantreeApp/Features/Items/AllItemsView.swift
@@ -95,8 +95,12 @@ private struct AllItemsRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(item.name)
-                .font(.body)
+            HStack(spacing: 8) {
+                Text(item.name)
+                    .font(.body)
+                // Issue #156: shared expired badge across every list.
+                ItemExpiryBadge(expiresAt: item.expiresAt)
+            }
             HStack(spacing: 8) {
                 if let locationName {
                     Text(locationName)

--- a/NakedPantreeApp/Features/Items/Components/ItemExpiryBadge.swift
+++ b/NakedPantreeApp/Features/Items/Components/ItemExpiryBadge.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftUI
+
+/// Issue #156: shared "Expired" badge for item rows. Originally lived
+/// privately inside `ExpiringSoonRow`, where it was the only list to
+/// surface the past-date signal. Every other list (per-location,
+/// All Items, Recently Added, Search Results) showed the date in
+/// muted secondary text — indistinguishable from a future expiry, so
+/// users could miss two-week-stale items unless they happened to
+/// open the Expiring Soon view.
+///
+/// Centralising the badge here means the visual treatment, the
+/// `< Date()` comparison, and the accessibility-rule wording (icon
+/// + text per `DESIGN_GUIDELINES.md` §6 — never color alone) live in
+/// exactly one place. Future tweaks (e.g. "stale for >7 days" red vs
+/// yellow gradient) ship to every list automatically.
+///
+/// Renders nothing when `expiresAt` is `nil` or in the future, so
+/// callers can drop it into any HStack unconditionally without
+/// needing their own `if isExpired` guard.
+struct ItemExpiryBadge: View {
+    let expiresAt: Date?
+
+    var body: some View {
+        if isExpired {
+            Label("Expired", systemImage: "exclamationmark.triangle.fill")
+                .labelStyle(.titleAndIcon)
+                .font(.caption.bold())
+                .foregroundStyle(.red)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.red.opacity(0.12), in: Capsule())
+                .accessibilityIdentifier("item.expiredBadge")
+        }
+    }
+
+    private var isExpired: Bool {
+        guard let expiresAt else { return false }
+        return expiresAt < Date()
+    }
+}

--- a/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
+++ b/NakedPantreeApp/Features/Items/ExpiringSoonView.swift
@@ -121,9 +121,7 @@ private struct ExpiringSoonRow: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Text(item.name).font(.body)
-                if isExpired {
-                    expiredBadge
-                }
+                ItemExpiryBadge(expiresAt: item.expiresAt)
             }
             HStack(spacing: 8) {
                 if let locationName {
@@ -141,24 +139,6 @@ private struct ExpiringSoonRow: View {
         }
     }
 
-    private var isExpired: Bool {
-        guard let expiresAt = item.expiresAt else { return false }
-        return expiresAt < Date()
-    }
-
-    /// Icon + text — never color alone, per `DESIGN_GUIDELINES.md` §6
-    /// accessibility rule. The badge stays compact so the row layout
-    /// reads at a glance.
-    @ViewBuilder
-    private var expiredBadge: some View {
-        Label("Expired", systemImage: "exclamationmark.triangle.fill")
-            .labelStyle(.titleAndIcon)
-            .font(.caption.bold())
-            .foregroundStyle(.red)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(Color.red.opacity(0.12), in: Capsule())
-    }
 }
 
 #Preview {

--- a/NakedPantreeApp/Features/Items/ItemsView.swift
+++ b/NakedPantreeApp/Features/Items/ItemsView.swift
@@ -238,8 +238,15 @@ private struct ItemRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(item.name)
-                .font(.body)
+            HStack(spacing: 8) {
+                Text(item.name)
+                    .font(.body)
+                // Issue #156: surface expired state on every list, not
+                // just Expiring Soon. Renders nothing when the item is
+                // not expired so the row layout stays unchanged for
+                // the common case.
+                ItemExpiryBadge(expiresAt: item.expiresAt)
+            }
             HStack(spacing: 8) {
                 Text("\(item.quantity) \(item.unit.displayLabel)")
                 if let expiresAt = item.expiresAt {

--- a/NakedPantreeApp/Features/Items/NeedsRestockingView.swift
+++ b/NakedPantreeApp/Features/Items/NeedsRestockingView.swift
@@ -98,7 +98,13 @@ private struct NeedsRestockingRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(item.name).font(.body)
+            HStack(spacing: 8) {
+                Text(item.name).font(.body)
+                // Issue #156: shared expired badge across every list.
+                // An expired item that's also flagged for restock is
+                // exactly the case the user wants surfaced in red.
+                ItemExpiryBadge(expiresAt: item.expiresAt)
+            }
             HStack(spacing: 8) {
                 if let locationName {
                     Text(locationName)

--- a/NakedPantreeApp/Features/Items/RecentlyAddedView.swift
+++ b/NakedPantreeApp/Features/Items/RecentlyAddedView.swift
@@ -111,7 +111,11 @@ private struct RecentlyAddedRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(item.name).font(.body)
+            HStack(spacing: 8) {
+                Text(item.name).font(.body)
+                // Issue #156: shared expired badge across every list.
+                ItemExpiryBadge(expiresAt: item.expiresAt)
+            }
             HStack(spacing: 8) {
                 if let locationName {
                     Text(locationName)

--- a/NakedPantreeApp/Features/Items/SearchResultsView.swift
+++ b/NakedPantreeApp/Features/Items/SearchResultsView.swift
@@ -125,8 +125,12 @@ private struct SearchResultsRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text(item.name)
-                .font(.body)
+            HStack(spacing: 8) {
+                Text(item.name)
+                    .font(.body)
+                // Issue #156: shared expired badge across every list.
+                ItemExpiryBadge(expiresAt: item.expiresAt)
+            }
             HStack(spacing: 8) {
                 if let locationName {
                     Text(locationName)


### PR DESCRIPTION
## Summary

The red "Expired" badge only rendered on **Expiring Soon**. Every other list (per-location, All Items, Recently Added, Needs Restocking, Search Results) showed an expired item's date in muted secondary text — indistinguishable from a future expiry, so users could miss two-week-stale items unless they happened to open Expiring Soon.

This PR extracts the badge into a shared `ItemExpiryBadge` component and applies it to every row that shows an item's name. Renders nothing for non-expired items, so callers drop it into the title HStack unconditionally.

## Changes

- **New** `NakedPantreeApp/Features/Items/Components/ItemExpiryBadge.swift` — single source of truth for visual treatment, `< Date()` check, and DESIGN_GUIDELINES.md §6 accessibility wording (icon + text, never color alone).
- **Refactored** `ExpiringSoonView`'s inline `expiredBadge` + `isExpired` → uses the shared component.
- **Applied** badge to:
  - `ItemsView.ItemRow` (per-location)
  - `AllItemsView`'s inline row
  - `RecentlyAddedView.RecentlyAddedRow`
  - `NeedsRestockingView.NeedsRestockingRow` *(not called out in the issue but same row pattern; expired-and-flagged is exactly the case worth surfacing in red on the restock list)*
  - `SearchResultsView.SearchResultsRow`

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] `xcodebuild build` succeeds
- [x] `BootstrapUITests`, `ExpiringSoonTests`, `RecentlyAddedTests` all pass
- [ ] CI green
- [ ] **Manual smoke (please do during review):**
  - Add an item with `expiresAt` in the past → verify the badge appears on All Items, per-location, Recently Added, Needs Restocking, Search Results
  - Add an item with `expiresAt` in the future → verify no badge anywhere
  - Add an item with no expiry → verify no badge anywhere
  - Existing badge on Expiring Soon still renders correctly (refactor didn't change its visual)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)