### PR TITLE
fix(reminders): reset EKEventStore after first-grant so picker sees lists

### DIFF
--- a/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
+++ b/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
@@ -49,6 +49,21 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
         // reconciliation path — not worth it for the v1 surface.
         do {
             let granted = try await store.requestFullAccessToReminders()
+            if granted {
+                // TestFlight build 58 bug: `EKEventStore` caches its
+                // source list at construction time. Our store is
+                // built at `LiveDependencies` boot, before TCC is
+                // granted. After the first-time grant the cache
+                // still reads as empty, so `calendars(for: .reminder)`
+                // returns `[]` and the picker renders "No Reminders
+                // lists" even though the user has lists. Apple
+                // documents `reset()` as the way to invalidate cached
+                // state after an authorization change; calling it on
+                // every grant is safe (no-op when the store was
+                // already in sync) and removes the order-of-init
+                // pitfall. See `EKEventStore.reset()` headerdoc.
+                store.reset()
+            }
             return granted ? .granted : .denied
         } catch {
             // EventKit can throw if the user has previously denied —


### PR DESCRIPTION
## Summary

Fixes a TestFlight build 0.1.0 (58) bug where tapping "Push to Reminders" for the first time prompts for permission, the user grants Allow, the picker sheet opens — and shows zero lists. The user verified lists exist in Reminders.app.

## Root cause

`EKEventStore` caches its source list at construction time. We build the store at `LiveDependencies.makeProductionDependencies` time (app launch, before TCC is granted) and hold it for the app's lifetime. After the first-time grant, the cache is still the pre-grant snapshot — `calendars(for: .reminder)` returns `[]` and the picker renders the "No Reminders lists" empty state.

The console log from the user's device confirms exactly this:
- `Access request result: 3` → `.fullAccess` granted
- Coordinator transitions to `.needsListPick(lists: [])` (empty)
- Picker renders `ContentUnavailableView` empty state

## Fix

One line: `store.reset()` after `requestFullAccessToReminders` returns `true`. Apple's headerdoc on `EKEventStore.reset()` says it invalidates cached state after authorization changes — exactly our case. The call is a no-op when the store was already in sync, so it's safe on every grant regardless of whether the transition was a fresh grant or a re-grant.

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] `xcodebuild build` clean
- [x] `PushToRemindersCoordinatorTests` (9 cases) still pass — the stub service is unaffected
- [ ] Verify on TestFlight: tap Push to Reminders, grant access, picker shows lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)