### PR TITLE
diag(reminders): logging-only branch to capture EKEventStore state for #162

### DIFF
--- a/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
+++ b/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
@@ -1,6 +1,7 @@
 import EventKit
 import Foundation
 import NakedPantreeDomain
+import os
 
 /// Issue #155 — production binding for `RemindersService`. The only
 /// file in the codebase that imports EventKit. App-target placement
@@ -32,6 +33,17 @@ import NakedPantreeDomain
 final class EventKitRemindersService: RemindersService, @unchecked Sendable {
     private let store: EKEventStore
 
+    /// Issue #162 diagnostic log. Tagged with subsystem
+    /// `cc.mnmlst.nakedpantree` and category `reminders` so a single
+    /// Console.app filter — `subsystem:cc.mnmlst.nakedpantree
+    /// category:reminders` — captures the full picker-empty-state
+    /// trace. Lifetime: keep until #162 closes; then trim to whatever
+    /// is genuinely load-bearing.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "reminders"
+    )
+
     /// Construct against a shared `EKEventStore`. Production builds
     /// pass `EKEventStore()`; tests can pass a stub subclass if they
     /// need to (none of our current tests do — the reconciler tests
@@ -47,8 +59,17 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
         // access (we read existing reminders to dedupe and write new
         // ones). The older write-only API would force a different
         // reconciliation path — not worth it for the v1 surface.
+        let preStatus = EKEventStore.authorizationStatus(for: .reminder).rawValue
+        Self.logger.notice(
+            "requestAccess: pre-grant authorizationStatus=\(preStatus, privacy: .public)"
+        )
         do {
             let granted = try await store.requestFullAccessToReminders()
+            let postStatus = EKEventStore.authorizationStatus(for: .reminder).rawValue
+            Self.logger.notice(
+                // swiftlint:disable:next line_length
+                "requestAccess: granted=\(granted, privacy: .public) postStatus=\(postStatus, privacy: .public)"
+            )
             if granted {
                 // TestFlight build 58 bug: `EKEventStore` caches its
                 // source list at construction time. Our store is
@@ -63,6 +84,7 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
                 // already in sync) and removes the order-of-init
                 // pitfall. See `EKEventStore.reset()` headerdoc.
                 store.reset()
+                Self.logger.notice("requestAccess: store.reset() called")
             }
             return granted ? .granted : .denied
         } catch {
@@ -70,25 +92,43 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
             // present that as `.denied` (the UI flow is identical) and
             // let the caller's `.denied` branch surface the deep link
             // to Settings.
+            Self.logger.error(
+                "requestAccess: threw — \(error.localizedDescription, privacy: .public)"
+            )
             return .denied
         }
     }
 
     func availableLists() async throws -> [RemindersListSummary] {
         try requireAccess()
+        let sources = store.sources
         let calendars = store.calendars(for: .reminder)
-        return
-            calendars
-            // Subscribed / read-only calendars surface in EventKit but
-            // throw on save. Filtering them here means the picker
-            // only offers lists we can actually write into.
-            .filter { $0.allowsContentModifications }
-            .map { calendar in
-                RemindersListSummary(
-                    id: calendar.calendarIdentifier,
-                    title: calendar.title
-                )
-            }
+        Self.logger.notice(
+            // swiftlint:disable:next line_length
+            "availableLists: sources.count=\(sources.count, privacy: .public) calendars.count=\(calendars.count, privacy: .public)"
+        )
+        for (index, source) in sources.enumerated() {
+            Self.logger.notice(
+                // swiftlint:disable:next line_length
+                "availableLists: source[\(index, privacy: .public)] title='\(source.title, privacy: .public)' sourceType=\(source.sourceType.rawValue, privacy: .public)"
+            )
+        }
+        for (index, calendar) in calendars.enumerated() {
+            Self.logger.notice(
+                // swiftlint:disable:next line_length
+                "availableLists: calendar[\(index, privacy: .public)] title='\(calendar.title, privacy: .public)' allowsContentModifications=\(calendar.allowsContentModifications, privacy: .public) sourceTitle='\(calendar.source?.title ?? "<nil>", privacy: .public)' sourceType=\(calendar.source?.sourceType.rawValue ?? -1, privacy: .public)"
+            )
+        }
+        let writable = calendars.filter { $0.allowsContentModifications }
+        Self.logger.notice(
+            "availableLists: writable.count=\(writable.count, privacy: .public)"
+        )
+        return writable.map { calendar in
+            RemindersListSummary(
+                id: calendar.calendarIdentifier,
+                title: calendar.title
+            )
+        }
     }
 
     func snapshots(in listID: String) async throws -> [ReminderSnapshot] {


### PR DESCRIPTION
## Summary

PR #162's `store.reset()` fix was supposed to make the Reminders list picker non-empty after first-time permission grant; user reports the same bug on TestFlight. Before iterating again, this PR adds **diagnostic-only logging** — no behavior change — so the next TestFlight install gives us actual data on what `EKEventStore` is returning.

## What's logged

`Logger(subsystem: "cc.mnmlst.nakedpantree", category: "reminders")` traces the picker flow:

- `requestAccess`: pre- and post-grant `authorizationStatus`, whether the request returned `true`, throw path
- `availableLists`: 
  - `store.sources.count` (catches "no iCloud account surfaced" — a different failure mode than cache staleness)
  - `store.calendars(for: .reminder).count` *before* any filter
  - per-source: title, `sourceType.rawValue`
  - per-calendar: title, `allowsContentModifications`, source title, source type
  - writable count (after the `allowsContentModifications` filter)

## How to use

1. Land + auto-build to TestFlight
2. Install the new build, tap "Push to Reminders"
3. Open Console.app on a Mac with the iPhone connected
4. Filter: `subsystem:cc.mnmlst.nakedpantree category:reminders`
5. Tap Allow on the prompt; capture the trace

The logs discriminate between three different failure modes:

| Symptom | Likely cause |
|---------|--------------|
| `sources.count == 0` | iCloud account hasn't surfaced — different bug than cache |
| `calendars.count > 0` but `writable.count == 0` | Filter is wrong (iOS 17+ source-type semantics) |
| `calendars.count == 0` after `reset()` | Cache invalidation isn't enough — need a fresh store |

## Test plan

- [x] `./scripts/lint.sh` clean
- [x] `xcodebuild build` clean
- [ ] Install TestFlight build, capture logs

## Cleanup

Logger is bounded — strip it (or demote `notice` → `debug`) once #162's actual cause lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)