### PR TITLE
diag(reminders): iter-2 logging — entry/exit on every picker code path (#162)

### DIFF
--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -76,6 +76,14 @@ struct SettingsView: View {
         category: "sharing"
     )
 
+    /// Issue #162 trace. Same subsystem so a single Console filter
+    /// covers the whole picker flow; category `reminders` lets the
+    /// share-flow logger above stay independent.
+    private static let remindersLogger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "reminders"
+    )
+
     var body: some View {
         @Bindable var settings = settings
         NavigationStack {
@@ -284,17 +292,33 @@ struct SettingsView: View {
     /// - other EventKit errors → present the error message in an
     ///   alert and let the user retry
     private func loadRemindersListsAndPresent() async {
+        Self.remindersLogger.notice("settings.loadRemindersListsAndPresent: entry")
         do {
             let access = try await remindersService.requestAccess()
+            Self.remindersLogger.notice(
+                // swiftlint:disable:next line_length
+                "settings.loadRemindersListsAndPresent: requestAccess returned \(String(describing: access), privacy: .public)"
+            )
             guard access == .granted else {
+                Self.remindersLogger.notice(
+                    "settings.loadRemindersListsAndPresent: not granted, bailing"
+                )
                 remindersListPickerError =
                     "Turn on Reminders for Naked Pantree in Settings, then try again."
                 return
             }
             let lists = try await remindersService.availableLists()
+            Self.remindersLogger.notice(
+                // swiftlint:disable:next line_length
+                "settings.loadRemindersListsAndPresent: got \(lists.count, privacy: .public) lists, presenting"
+            )
             remindersListPickerLists = lists
             isPresentingRemindersListPicker = true
         } catch {
+            Self.remindersLogger.error(
+                // swiftlint:disable:next line_length
+                "settings.loadRemindersListsAndPresent: caught \(error.localizedDescription, privacy: .public)"
+            )
             remindersListPickerError = error.localizedDescription
         }
     }

--- a/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
+++ b/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
@@ -100,7 +100,13 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
     }
 
     func availableLists() async throws -> [RemindersListSummary] {
-        try requireAccess()
+        Self.logger.notice("availableLists: entry")
+        do {
+            try requireAccess()
+        } catch {
+            Self.logger.error("availableLists: requireAccess threw — bailing")
+            throw error
+        }
         let sources = store.sources
         let calendars = store.calendars(for: .reminder)
         Self.logger.notice(
@@ -170,6 +176,9 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
 
     private func requireAccess() throws {
         let status = EKEventStore.authorizationStatus(for: .reminder)
+        Self.logger.notice(
+            "requireAccess: status=\(status.rawValue, privacy: .public)"
+        )
         switch status {
         case .fullAccess, .writeOnly:
             return

--- a/NakedPantreeApp/Integrations/Reminders/PushToRemindersCoordinator.swift
+++ b/NakedPantreeApp/Integrations/Reminders/PushToRemindersCoordinator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import NakedPantreeDomain
 import SwiftUI
+import os
 
 /// Issue #155 — orchestrates the "Push to Reminders" flow from the
 /// `NeedsRestockingView` toolbar button. Pulled out of the view body
@@ -99,14 +100,25 @@ final class PushToRemindersCoordinator {
         items: [Item],
         locationsByID: [Location.ID: Location]
     ) async {
-        if case .running = state { return }
+        if case .running = state {
+            Self.logger.notice("coordinator.requestPush: already running, ignoring")
+            return
+        }
+        Self.logger.notice(
+            "coordinator.requestPush: entry, items.count=\(items.count, privacy: .public)"
+        )
         state = .running
 
         do {
             // 1. Permission.
             let access = try await service.requestAccess()
+            Self.logger.notice(
+                // swiftlint:disable:next line_length
+                "coordinator.requestPush: requestAccess returned \(String(describing: access), privacy: .public)"
+            )
             guard access == .granted else {
                 state = .permissionDenied
+                Self.logger.notice("coordinator.requestPush: -> permissionDenied")
                 return
             }
 
@@ -114,7 +126,13 @@ final class PushToRemindersCoordinator {
             let listID: String
             let listTitle: String
             if let stored = preference.listID {
+                Self.logger.notice(
+                    "coordinator.requestPush: have stored listID, fetching availableLists"
+                )
                 let lists = try await service.availableLists()
+                Self.logger.notice(
+                    "coordinator.requestPush: availableLists returned \(lists.count, privacy: .public)"
+                )
                 if let match = lists.first(where: { $0.id == stored }) {
                     listID = match.id
                     listTitle = match.title
@@ -123,12 +141,22 @@ final class PushToRemindersCoordinator {
                     // — don't silently fall back. Spec: "surface a
                     // one-time 'Pick a new list' prompt and don't
                     // silently fall back."
+                    Self.logger.notice(
+                        "coordinator.requestPush: stored list missing, clearing and re-prompting"
+                    )
                     preference.listID = nil
                     state = .needsListPick(lists: lists)
                     return
                 }
             } else {
+                Self.logger.notice(
+                    "coordinator.requestPush: no stored listID, fetching availableLists for picker"
+                )
                 let lists = try await service.availableLists()
+                Self.logger.notice(
+                    // swiftlint:disable:next line_length
+                    "coordinator.requestPush: availableLists returned \(lists.count, privacy: .public) lists -> needsListPick"
+                )
                 state = .needsListPick(lists: lists)
                 return
             }
@@ -153,11 +181,27 @@ final class PushToRemindersCoordinator {
                 )
             )
         } catch let error as RemindersServiceError {
+            Self.logger.error(
+                // swiftlint:disable:next line_length
+                "coordinator.requestPush: caught RemindersServiceError -> \(String(describing: error), privacy: .public)"
+            )
             state = .failed(message: Self.message(for: error))
         } catch {
+            Self.logger.error(
+                "coordinator.requestPush: caught \(error.localizedDescription, privacy: .public)"
+            )
             state = .failed(message: error.localizedDescription)
         }
     }
+
+    /// Issue #162 trace. Same subsystem/category as the EventKit
+    /// adapter so a single Console filter
+    /// (`subsystem:cc.mnmlst.nakedpantree category:reminders`) covers
+    /// the entire push pipeline.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "reminders"
+    )
 
     /// Map predictable `RemindersServiceError` cases to short user-
     /// facing strings. Falls through to the localized description for


### PR DESCRIPTION
## Summary

Iter-2 of the diagnostic logging for #162. PR #163 (now merged) added EventKit-side traces; user shared a Settings flow log showing \`requestAccess\` running cleanly but \`availableLists\` never logging at all. That means the function either was never called, or threw before its entry log fired. This iteration adds enough breadcrumbs to discriminate.

## What's instrumented

- \`EventKitRemindersService.requireAccess\` — logs the static \`authorizationStatus\` it queries; this is the one place that could throw silently between \`requestAccess\` returning and \`availableLists\` running.
- \`EventKitRemindersService.availableLists\` — entry log before \`requireAccess\`; error log if \`requireAccess\` throws.
- \`PushToRemindersCoordinator.requestPush\` — entry, every state transition, catch-arm errors.
- \`SettingsView.loadRemindersListsAndPresent\` — entry, every return branch, catch-arm errors.

User reports they tapped the Settings "Pick a list" row, so the SettingsView trace is load-bearing for this iteration; the coordinator instrumentation is added preemptively.

## Test plan

- [x] \`./scripts/lint.sh\` clean
- [x] \`xcodebuild build\` clean
- [ ] Install TestFlight build, tap "Pick a list" in Settings, capture full trace

Console filter unchanged: \`subsystem:cc.mnmlst.nakedpantree category:reminders\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)