### PR TITLE
Probe: isolate Reminders picker sheet to test multi-sheet theory (#162)

### DIFF
--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -97,21 +97,17 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            // Build #52 fix: present the LocationsSection's
-            // create/edit form here, at the NavigationStack level,
-            // rather than from inside the Form's Section. Section-
-            // attached `.sheet(item:)` made SwiftUI dismiss the
-            // entire sheet stack on present. The section flips
-            // `locationFormMode` via its parent-owned binding; this
-            // modifier renders the actual sheet.
-            .sheet(item: $locationFormMode) { mode in
-                LocationFormView(mode: mode) {
-                    // No-op — `LocationsSection.onChange(of: formMode)`
-                    // catches the dismiss edge and triggers its own
-                    // reload. Keeping that local to the section
-                    // avoids threading another callback through.
-                }
-            }
+            // PROBE (issue #162) — temporarily commented out to verify
+            // multi-sheet conflict theory. SwiftUI seems to allow only
+            // one `.sheet` modifier per container; stacking three on
+            // the NavigationStack may be why the Reminders picker
+            // auto-dismisses ~553ms after presentation. If commenting
+            // out the location-form and prepared-share sheets makes
+            // the picker stay open, we'll fold all three into a
+            // single `.sheet(item:)` driven by an enum.
+            // .sheet(item: $locationFormMode) { mode in
+            //     LocationFormView(mode: mode) { }
+            // }
             // Issue #155: Reminders list re-pick. Lifted to the
             // NavigationStack level for the same reason the location
             // form is — section-attached sheets collapse the stack
@@ -138,19 +134,17 @@ struct SettingsView: View {
             } message: { message in
                 Text(message)
             }
-            .sheet(item: $preparedShare) { prepared in
-                // Issue #90: by the time this closure fires, the share
-                // is already a real `CKShare` resolved by
-                // `ShareSheetPreparation`. The controller uses
-                // `init(share:container:)` and renders participant UI
-                // immediately — no more lazy preparation handler.
-                CloudSharingControllerView(
-                    share: prepared.share,
-                    container: prepared.container,
-                    onCompletion: { preparedShare = nil }
-                )
-                .ignoresSafeArea()
-            }
+            // PROBE (issue #162) — see note above. Temporarily
+            // disabled so only the Reminders picker sheet is active
+            // on this view, isolating the multi-sheet conflict.
+            // .sheet(item: $preparedShare) { prepared in
+            //     CloudSharingControllerView(
+            //         share: prepared.share,
+            //         container: prepared.container,
+            //         onCompletion: { preparedShare = nil }
+            //     )
+            //     .ignoresSafeArea()
+            // }
             .alert(item: $shareError) { wrapper in
                 Alert(
                     title: Text("Couldn't share"),

--- a/NakedPantreeApp/Integrations/Reminders/RemindersListPickerSheet.swift
+++ b/NakedPantreeApp/Integrations/Reminders/RemindersListPickerSheet.swift
@@ -1,5 +1,6 @@
 import NakedPantreeDomain
 import SwiftUI
+import os
 
 /// Issue #155 — picker UI for the Reminders list a push lands in.
 /// Presented in two contexts:
@@ -22,6 +23,14 @@ struct RemindersListPickerSheet: View {
     let onPick: (RemindersListSummary) -> Void
     let onCancel: () -> Void
 
+    /// Issue #162 probe: confirm whether the picker actually mounts
+    /// (and how many rows it sees) before SwiftUI tears it back down.
+    /// Same subsystem/category as `EventKitRemindersService`.
+    private static let logger = Logger(
+        subsystem: "cc.mnmlst.nakedpantree",
+        category: "reminders"
+    )
+
     var body: some View {
         NavigationStack {
             Group {
@@ -39,6 +48,17 @@ struct RemindersListPickerSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { onCancel() }
                 }
+            }
+            .onAppear {
+                let count = lists.count
+                Self.logger.notice(
+                    "RemindersListPickerSheet.onAppear: rendering count=\(count, privacy: .public)"
+                )
+            }
+            .onDisappear {
+                Self.logger.notice(
+                    "RemindersListPickerSheet.onDisappear"
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

Cheap probe before committing to the enum-unification refactor for #162.

The iter-2 logging trace (PR #164) showed:
- `requestAccess: granted=true` ✅
- `availableLists: writable.count=8` ✅
- All 8 calendars enumerated correctly ✅
- `loadRemindersListsAndPresent: presenting picker` ✅
- The picker is set to `isPresentingRemindersListPicker = true` ✅
- ...but the picker visibly mounts and disappears within ~553ms.

Suspected cause: three `.sheet` modifiers stacked on the SettingsView
NavigationStack (`locationFormMode`, `isPresentingRemindersListPicker`,
`preparedShare`) violate SwiftUI's one-sheet-per-container rule.

This PR is **not for merge**. It just disables the other two sheets
and adds onAppear/onDisappear logging to the picker so we can read
the device's response on TestFlight.

## What's in this build

- `.sheet(item: \$locationFormMode)` — commented out (LocationsSection
  still binds to it, but the modifier is inert)
- `.sheet(item: \$preparedShare)` — commented out (Share Household
  flow won't present anything for this build)
- `RemindersListPickerSheet` — adds `.onAppear` / `.onDisappear`
  logging on the same subsystem/category.

## Test plan
- [ ] Install on TestFlight
- [ ] Open Settings → tap "Pick a list" or "Change list"
- [ ] Capture the trace from Console.app:
      `subsystem:cc.mnmlst.nakedpantree category:reminders`
- [ ] Read the trace:
  - `RemindersListPickerSheet.onAppear: rendering count=8` + sheet
    stays open → multi-sheet conflict confirmed → ship enum refactor
  - `onAppear` absent or `onDisappear` fires within ~500ms →
    multi-sheet theory wrong, pivot

🤖 Generated with [Claude Code](https://claude.com/claude-code)