### PR TITLE
Fix #162: collapse SettingsView sheets + EventKit cold-cache wait

### DIFF
--- a/NakedPantreeApp/Features/Settings/LocationsSection.swift
+++ b/NakedPantreeApp/Features/Settings/LocationsSection.swift
@@ -8,31 +8,44 @@ import SwiftUI
 /// "add location", and locations are a rare-action surface that
 /// doesn't deserve top-level real estate.
 ///
-/// **Why `formMode` is a parent-owned `@Binding`:** in the original
-/// implementation this section attached `.sheet(item: $formMode)`
-/// directly. That presented inside the outer Settings sheet's
-/// content, deep under a Form's Section. SwiftUI's presentation
-/// context resolution couldn't tell which sheet was being asked
-/// to present from a Section-attached `.sheet`, and would dismiss
-/// the entire sheet stack — including the parent Settings sheet —
-/// the moment the form tried to appear. Build #52 reproduced this
-/// every time. Fix: lift `formMode` and the `.sheet(item:)`
+/// **Why the section can't present its own form sheet (build #52
+/// regression).** The original implementation attached
+/// `.sheet(item: $formMode)` directly to the section, deep under a
+/// Form's Section. SwiftUI's presentation-context resolution couldn't
+/// tell which sheet was being asked to present from a Section-attached
+/// `.sheet` and would dismiss the entire sheet stack — including the
+/// parent Settings sheet — the moment the form tried to appear. Build
+/// #52 reproduced this every time. Fix: lift the `.sheet(item:)`
 /// modifier to `SettingsView`'s NavigationStack, where the
 /// presentation context is unambiguous. The section keeps its
 /// own state for delete-confirmation (a `confirmationDialog`,
 /// which is action-sheet-shaped and doesn't have the same
 /// presentation-context bug).
 ///
-/// **Reload semantics:** when the form sheet dismisses (whether
-/// the user saved or cancelled), `formMode` flips back to nil.
-/// `.onChange(of: formMode)` catches that edge and re-fetches the
-/// locations list — that's why the parent doesn't need to thread
-/// an `onSaved` callback through.
+/// **Why a callback rather than a binding (issue #162).** Earlier
+/// the section took `@Binding var formMode` and wrote into it on Add
+/// / Edit taps; the parent watched that binding to drive its sheet.
+/// That works in isolation but means the parent has to expose
+/// `formMode` as a sheet driver — and once Settings grew a third
+/// sheet (the Reminders picker), three independent `.sheet` modifiers
+/// were stacked on the NavigationStack and SwiftUI could no longer
+/// resolve the unique presentation. The probe in PR #165 confirmed
+/// the picker auto-dismissed within ~553 ms. Issue #162 folded all
+/// three presentations through a single `.sheet(item: $presentedSheet)`
+/// in the parent. The section now hands a `LocationFormView.Mode` up
+/// via the `presentForm` callback, and the parent maps that into the
+/// shared sheet enum.
+///
+/// **Reload semantics.** With the binding removed the section can no
+/// longer observe its own `formMode` going nil to re-fetch. Instead
+/// the parent bumps `reloadToken` after `presentedSheet` flips back to
+/// nil with the form having been the last presented sheet; the
+/// section's `.onChange(of: reloadToken)` triggers the reload.
 ///
 /// **Why a standalone view:** extracting this from `SettingsView`
-/// makes the load / form-callback / reload cycle unit-testable
-/// without standing up the whole Settings screen. Mirrors the
-/// existing `RestockSection` pattern in `ItemDetailView`.
+/// keeps the load / form-callback / reload cycle decoupled from the
+/// Settings screen as a whole. Mirrors the existing `RestockSection`
+/// pattern in `ItemDetailView`.
 struct LocationsSection: View {
     /// Household whose locations this section manages. Settings
     /// resolves the household once (same `loadHousehold()` it uses for
@@ -41,10 +54,16 @@ struct LocationsSection: View {
     /// that case rather than a stale list against the wrong household.
     let householdID: Household.ID?
 
-    /// Form-mode state owned by `SettingsView` — see the type doc for
-    /// why this is a binding rather than `@State`. The section sets
-    /// it on Add / Edit taps; the parent renders the actual sheet.
-    @Binding var formMode: LocationFormView.Mode?
+    /// Issue #162 — request the parent to present the create/edit
+    /// form sheet for the given mode. Replaces the prior `@Binding`
+    /// pattern; see the type doc for the full root-cause writeup.
+    let presentForm: (LocationFormView.Mode) -> Void
+
+    /// Issue #162 — bumped by the parent any time the section should
+    /// re-fetch (specifically: after the lifted form sheet dismisses).
+    /// Replaces the prior self-observed `.onChange(of: formMode)`
+    /// trigger.
+    let reloadToken: Int
 
     @Environment(\.repositories) private var repositories
 
@@ -63,7 +82,7 @@ struct LocationsSection: View {
                 }
                 ForEach(locations) { location in
                     Button {
-                        formMode = .edit(location)
+                        presentForm(.edit(location))
                     } label: {
                         Label(location.name, systemImage: location.kind.systemImage)
                             .foregroundStyle(.primary)
@@ -78,7 +97,7 @@ struct LocationsSection: View {
                     }
                 }
                 Button {
-                    formMode = .create(householdID: householdID)
+                    presentForm(.create(householdID: householdID))
                 } label: {
                     Label("Add Location", systemImage: "plus.circle.fill")
                 }
@@ -103,14 +122,12 @@ struct LocationsSection: View {
             Text("This also removes every item inside it.")
         }
         .task(id: householdID) { await reload() }
-        // Reload when the parent-rendered form sheet dismisses
-        // (either via save or cancel — both flip formMode back to
-        // nil). This is the missing wire that the lifted `.sheet`
-        // would otherwise need an `onSaved` callback to do.
-        .onChange(of: formMode) { _, newValue in
-            if newValue == nil {
-                Task { await reload() }
-            }
+        // Issue #162: parent bumps `reloadToken` after the lifted form
+        // sheet dismisses. We reload regardless of whether the user
+        // saved or cancelled — same belt-and-suspenders behaviour as
+        // before the binding was removed.
+        .onChange(of: reloadToken) { _, _ in
+            Task { await reload() }
         }
     }
 

--- a/NakedPantreeApp/Features/Settings/SettingsView.swift
+++ b/NakedPantreeApp/Features/Settings/SettingsView.swift
@@ -22,6 +22,19 @@ import os
 /// configuration moment, not a permission flow. Copy stays plain and
 /// useful so users in a hurry can scan it without rolling their eyes
 /// (§10 checklist), with a single light brand-consistent line.
+///
+/// **Multi-sheet conflict (issue #162).** SwiftUI's `.sheet` modifier
+/// resolves at most one presentation per view. Earlier this file had
+/// three (`locationFormMode`, `isPresentingRemindersListPicker`,
+/// `preparedShare`) stacked on the NavigationStack. Probe build #165
+/// proved that stacking caused the Reminders picker to mount and
+/// auto-dismiss within ~553 ms — SwiftUI couldn't decide which sheet
+/// the view was asking for and tore everything down. The fix is to
+/// fold all three presentations through a single `.sheet(item:)`
+/// driven by `SettingsSheet`. Per-sheet payloads (form mode, picker
+/// lists, prepared share) stay on separate state vars so the enum
+/// itself can be a thin tag without dragging non-Equatable
+/// CloudKit types through Equatable synthesis.
 struct SettingsView: View {
     @Environment(\.notificationSettings) private var settings
     @Environment(\.repositories) private var repositories
@@ -36,33 +49,44 @@ struct SettingsView: View {
     /// whole screen — the share action doesn't depend on the name.
     @State private var household: Household?
 
-    /// Issue #90: share preparation state machine. Prep runs *before*
-    /// the sheet presents so `UICloudSharingController(share:container:)`
-    /// can be constructed against an already-resolved share — the
-    /// non-deprecated path. `preparedShare != nil` drives the sheet;
+    /// Issue #162: single source of truth for which sheet is on
+    /// screen. Set at the call sites (Add Location button, Pick a
+    /// list button, Share Household button); reset to nil whenever
+    /// the user dismisses the sheet (gesture, save, cancel). The
+    /// `.onChange` watcher on this clears the matching payload vars
+    /// below.
+    @State private var presentedSheet: SettingsSheet?
+
+    /// Form mode payload for `SettingsSheet.locationForm`. Held
+    /// separately so the enum can be a thin tag and so the
+    /// `LocationsSection` can write here via the `presentForm`
+    /// callback below.
+    @State private var locationFormMode: LocationFormView.Mode?
+
+    /// Issue #90: prepared share payload for `SettingsSheet.shareHousehold`.
     /// `isPreparingShare` drives the spinner; `shareError` drives the
-    /// alert.
+    /// alert. Kept separate from the enum because `CKShare` /
+    /// `CKContainer` aren't `Equatable` and folding them inline would
+    /// block automatic Equatable synthesis on `SettingsSheet`.
     @State private var preparedShare: ShareSheetPreparation.PreparedShare?
     @State private var isPreparingShare = false
     @State private var shareError: ShareErrorAlert?
-
-    /// Build #52 bug fix: `LocationsSection`'s create/edit form sheet
-    /// state lives here (not in the section) so the `.sheet(item:)`
-    /// modifier can attach at the NavigationStack level. Attaching
-    /// the form sheet inside a Form's Section caused SwiftUI's
-    /// presentation-context resolution to dismiss the entire sheet
-    /// stack the moment the form tried to appear. See the section's
-    /// own type doc for the full root-cause writeup.
-    @State private var locationFormMode: LocationFormView.Mode?
 
     /// Issue #155: re-pick state for the Reminders list. Settings
     /// owns the picker presentation here (not the row) so the same
     /// SwiftUI presentation-context fix from build #52 applies — a
     /// `.sheet(isPresented:)` inside a Form's Section can collapse
     /// the whole sheet stack on present.
-    @State private var isPresentingRemindersListPicker = false
     @State private var remindersListPickerLists: [RemindersListSummary] = []
     @State private var remindersListPickerError: String?
+
+    /// Issue #162 — signal channel for `LocationsSection` to refresh
+    /// after the form sheet dismisses. The lifted `.sheet(item:)`
+    /// pattern means the section can no longer observe its own
+    /// `formMode` going nil; instead the parent bumps this token in
+    /// `.onChange(of: presentedSheet)`. `&+=` is overflow-safe so a
+    /// long-running view session never traps.
+    @State private var locationsReloadToken = 0
 
     /// Trace for #90 (blank Share Household sheet on TestFlight).
     /// Same subsystem/category as `CloudSharingControllerView` and
@@ -91,7 +115,11 @@ struct SettingsView: View {
                 householdSection
                 LocationsSection(
                     householdID: household?.id,
-                    formMode: $locationFormMode
+                    presentForm: { mode in
+                        locationFormMode = mode
+                        presentedSheet = .locationForm
+                    },
+                    reloadToken: locationsReloadToken
                 )
                 expiryRemindersSection
                 remindersListSection
@@ -105,35 +133,27 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            // Build #52 fix: present the LocationsSection's
-            // create/edit form here, at the NavigationStack level,
-            // rather than from inside the Form's Section. Section-
-            // attached `.sheet(item:)` made SwiftUI dismiss the
-            // entire sheet stack on present. The section flips
-            // `locationFormMode` via its parent-owned binding; this
-            // modifier renders the actual sheet.
-            .sheet(item: $locationFormMode) { mode in
-                LocationFormView(mode: mode) {
-                    // No-op — `LocationsSection.onChange(of: formMode)`
-                    // catches the dismiss edge and triggers its own
-                    // reload. Keeping that local to the section
-                    // avoids threading another callback through.
-                }
+            // Issue #162: single presentation point. Stacking three
+            // `.sheet` modifiers on this NavigationStack let SwiftUI
+            // race them; the loser tore the winner back down. One
+            // modifier, one source of truth — the sheet stays put.
+            .sheet(item: $presentedSheet) { sheet in
+                presentedSheetContent(for: sheet)
             }
-            // Issue #155: Reminders list re-pick. Lifted to the
-            // NavigationStack level for the same reason the location
-            // form is — section-attached sheets collapse the stack
-            // on present (build #52 root cause).
-            .sheet(isPresented: $isPresentingRemindersListPicker) {
-                RemindersListPickerSheet(
-                    lists: remindersListPickerLists,
-                    currentListID: remindersListPreference.listID,
-                    onPick: { picked in
-                        remindersListPreference.listID = picked.id
-                        isPresentingRemindersListPicker = false
-                    },
-                    onCancel: { isPresentingRemindersListPicker = false }
-                )
+            .onChange(of: presentedSheet) { oldValue, newValue in
+                guard newValue == nil else { return }
+                // Sheet just dismissed (gesture / save / cancel). Clear
+                // the per-sheet payload, and bump the locations reload
+                // token if the form was the one that closed.
+                switch oldValue {
+                case .locationForm:
+                    locationFormMode = nil
+                    locationsReloadToken &+= 1
+                case .shareHousehold:
+                    preparedShare = nil
+                case .remindersListPicker, .none:
+                    break
+                }
             }
             .alert(
                 "Couldn't load Reminders lists.",
@@ -146,19 +166,6 @@ struct SettingsView: View {
             } message: { message in
                 Text(message)
             }
-            .sheet(item: $preparedShare) { prepared in
-                // Issue #90: by the time this closure fires, the share
-                // is already a real `CKShare` resolved by
-                // `ShareSheetPreparation`. The controller uses
-                // `init(share:container:)` and renders participant UI
-                // immediately — no more lazy preparation handler.
-                CloudSharingControllerView(
-                    share: prepared.share,
-                    container: prepared.container,
-                    onCompletion: { preparedShare = nil }
-                )
-                .ignoresSafeArea()
-            }
             .alert(item: $shareError) { wrapper in
                 Alert(
                     title: Text("Couldn't share"),
@@ -167,6 +174,50 @@ struct SettingsView: View {
                 )
             }
             .task { await loadHousehold() }
+        }
+    }
+
+    /// Sheet content router. Pulled out of the modifier so the body
+    /// stays scannable and the switch can grow another case without
+    /// a giant inline closure.
+    @ViewBuilder
+    private func presentedSheetContent(for sheet: SettingsSheet) -> some View {
+        switch sheet {
+        case .locationForm:
+            if let mode = locationFormMode {
+                LocationFormView(mode: mode) {
+                    // No-op — `.onChange(of: presentedSheet)` above
+                    // bumps `locationsReloadToken` when this sheet
+                    // closes, which triggers `LocationsSection` to
+                    // refresh. Keeping the save callback empty here
+                    // means save / cancel / drag-down all share the
+                    // same dismissal path.
+                }
+            }
+        case .remindersListPicker:
+            RemindersListPickerSheet(
+                lists: remindersListPickerLists,
+                currentListID: remindersListPreference.listID,
+                onPick: { picked in
+                    remindersListPreference.listID = picked.id
+                    presentedSheet = nil
+                },
+                onCancel: { presentedSheet = nil }
+            )
+        case .shareHousehold:
+            if let prepared = preparedShare {
+                // Issue #90: by the time this closure fires, the share
+                // is already a real `CKShare` resolved by
+                // `ShareSheetPreparation`. The controller uses
+                // `init(share:container:)` and renders participant UI
+                // immediately — no more lazy preparation handler.
+                CloudSharingControllerView(
+                    share: prepared.share,
+                    container: prepared.container,
+                    onCompletion: { presentedSheet = nil }
+                )
+                .ignoresSafeArea()
+            }
         }
     }
 
@@ -244,6 +295,7 @@ struct SettingsView: View {
                 )
             }
             .accessibilityIdentifier("settings.remindersList.change")
+            .disabled(isLoadingRemindersLists)
             if remindersListPreference.listID != nil {
                 Button(role: .destructive) {
                     remindersListPreference.listID = nil
@@ -251,6 +303,14 @@ struct SettingsView: View {
                     Label("Clear chosen list", systemImage: "xmark.circle")
                 }
                 .accessibilityIdentifier("settings.remindersList.clear")
+            }
+            if isLoadingRemindersLists {
+                HStack(spacing: 12) {
+                    ProgressView()
+                    Text("Loading your Reminders lists…")
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityIdentifier("settings.remindersList.loading")
             }
         } header: {
             Text("Reminders")
@@ -285,6 +345,15 @@ struct SettingsView: View {
         )
     }
 
+    /// Issue #162: spinner gate for the Reminders-list load. Right
+    /// after a fresh permission grant `EKEventStore`'s iCloud sources
+    /// can take ~10s to populate; `EventKitRemindersService` blocks
+    /// inside `availableLists` until they do (or the timeout fires).
+    /// During that window the row should read as in-flight rather
+    /// than silently spin — users were tapping again and re-entering
+    /// the same wait, then assumed the feature was broken.
+    @State private var isLoadingRemindersLists = false
+
     /// Fetch available Reminders lists, then present the picker.
     /// Failure modes:
     /// - permission denied → friendly alert with the Settings deep
@@ -293,6 +362,8 @@ struct SettingsView: View {
     ///   alert and let the user retry
     private func loadRemindersListsAndPresent() async {
         Self.remindersLogger.notice("settings.loadRemindersListsAndPresent: entry")
+        isLoadingRemindersLists = true
+        defer { isLoadingRemindersLists = false }
         do {
             let access = try await remindersService.requestAccess()
             Self.remindersLogger.notice(
@@ -313,7 +384,7 @@ struct SettingsView: View {
                 "settings.loadRemindersListsAndPresent: got \(lists.count, privacy: .public) lists, presenting"
             )
             remindersListPickerLists = lists
-            isPresentingRemindersListPicker = true
+            presentedSheet = .remindersListPicker
         } catch {
             Self.remindersLogger.error(
                 // swiftlint:disable:next line_length
@@ -404,10 +475,24 @@ struct SettingsView: View {
         switch result {
         case .success(let payload):
             preparedShare = payload
+            presentedSheet = .shareHousehold
         case .failure(let error):
             shareError = ShareErrorAlert(message: error.localizedDescription)
         }
     }
+}
+
+/// Issue #162 — single tag for whichever sheet `SettingsView` has
+/// presented. Per-sheet payloads (form mode, picker lists, prepared
+/// share) live on separate `@State` vars so this enum can stay thin
+/// and `Hashable` without dragging non-`Equatable` CloudKit types
+/// (`CKShare`, `CKContainer`) into automatic synthesis.
+private enum SettingsSheet: String, Identifiable, Hashable {
+    case locationForm
+    case remindersListPicker
+    case shareHousehold
+
+    var id: String { rawValue }
 }
 
 /// `Identifiable` wrapper so `.alert(item:)` can drive on a single

--- a/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
+++ b/NakedPantreeApp/Integrations/Reminders/EventKitRemindersService.swift
@@ -107,8 +107,42 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
             Self.logger.error("availableLists: requireAccess threw — bailing")
             throw error
         }
+        // Issue #162 cold-cache mitigation. The user reported tapping
+        // "Pick a list" right after granting permission and seeing the
+        // picker render with zero lists, then a few minutes later
+        // re-tapping and seeing all eight. EKEventStore's iCloud
+        // sources are populated asynchronously; on a fresh grant the
+        // first read of `calendars(for: .reminder)` returns an empty
+        // array even though the user demonstrably has lists.
+        //
+        // Apple ships two relevant hooks:
+        //
+        // - `refreshSourcesIfNecessary()` — initiates a sync if one is
+        //   due. No-op when the cache is already warm.
+        // - `EKEventStoreChangedNotification` — fires when the store's
+        //   data changes, including after a permission grant or a
+        //   completed sync.
+        //
+        // Strategy: refresh, read, and if empty wait up to 10s for
+        // the change notification then re-read. 10s is the hard cap —
+        // anything longer reads as "broken" and the user's instinct
+        // is to tap again, which lands them in a worse state. The
+        // Settings row presents a spinner during the wait so the
+        // gap doesn't feel silent.
+        store.refreshSourcesIfNecessary()
+        var calendars = store.calendars(for: .reminder)
+        if calendars.isEmpty {
+            Self.logger.notice(
+                "availableLists: cold-cache, awaiting EKEventStoreChanged (10s cap)"
+            )
+            await Self.waitForStoreChangeOrTimeout(seconds: 10)
+            calendars = store.calendars(for: .reminder)
+            let postWaitCount = calendars.count
+            Self.logger.notice(
+                "availableLists: post-wait calendars.count=\(postWaitCount, privacy: .public)"
+            )
+        }
         let sources = store.sources
-        let calendars = store.calendars(for: .reminder)
         Self.logger.notice(
             // swiftlint:disable:next line_length
             "availableLists: sources.count=\(sources.count, privacy: .public) calendars.count=\(calendars.count, privacy: .public)"
@@ -286,5 +320,71 @@ final class EventKitRemindersService: RemindersService, @unchecked Sendable {
                 message: error.localizedDescription
             )
         }
+    }
+
+    /// Issue #162 — block until EventKit posts an
+    /// `EKEventStoreChangedNotification` or `seconds` elapse,
+    /// whichever comes first. Used by `availableLists()` to wait out
+    /// the iCloud cold-cache window after a fresh permission grant.
+    ///
+    /// Implementation: an `AsyncStream` wraps a one-shot block-based
+    /// observer; the stream's `onTermination` removes the observer so
+    /// neither the change-wait task nor the timeout task can leak it.
+    /// A task group races the two; whichever finishes first cancels
+    /// the other. `static` so the closure passed to
+    /// `addObserver(forName:object:queue:using:)` doesn't capture
+    /// `self` (the class is `@unchecked Sendable` and the observer
+    /// callback runs on whatever queue NotificationCenter chooses —
+    /// keeping `self` out of the closure removes that contract).
+    ///
+    /// **Why the `ObserverBox` class:** `NSObjectProtocol` (the type
+    /// `addObserver` returns) isn't `Sendable`. To carry the observer
+    /// reference into the `@Sendable onTermination` closure we wrap
+    /// it in a tiny `@unchecked Sendable` box. The box is written
+    /// exactly once (synchronously, inside the `AsyncStream`
+    /// initializer) and read exactly once (in `onTermination`, which
+    /// fires after the stream terminates) — no concurrent access, so
+    /// `@unchecked` is honest here.
+    private static func waitForStoreChangeOrTimeout(
+        seconds: TimeInterval
+    ) async {
+        let timeoutNanos = UInt64(seconds * 1_000_000_000)
+        let center = NotificationCenter.default
+        let box = ObserverBox()
+
+        let stream = AsyncStream<Void> { continuation in
+            box.observer = center.addObserver(
+                forName: .EKEventStoreChanged,
+                object: nil,
+                queue: nil
+            ) { _ in
+                continuation.yield(())
+            }
+            continuation.onTermination = { [box] _ in
+                if let observer = box.observer {
+                    center.removeObserver(observer)
+                }
+            }
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                for await _ in stream {
+                    return
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanos)
+            }
+            _ = await group.next()
+            group.cancelAll()
+        }
+    }
+
+    /// See `waitForStoreChangeOrTimeout` — just a reference cell so
+    /// the non-Sendable `NSObjectProtocol` can transit a `@Sendable`
+    /// closure boundary without spurious warnings.
+    private final class ObserverBox: @unchecked Sendable {
+        var observer: NSObjectProtocol?
     }
 }


### PR DESCRIPTION
Closes #162.

The probe in #165 isolated two independent issues behind the
"Reminders picker shows empty / auto-dismisses" report. This PR fixes
both.

## Multi-sheet conflict

`SettingsView` had three `.sheet` modifiers stacked on its
`NavigationStack` (Location form, Reminders list picker, Share
Household). SwiftUI's `.sheet` resolves at most one presentation per
view; the probe demonstrated the picker mounted then auto-dismissed
within ~553 ms while the others were live.

Fix: one `.sheet(item: \$presentedSheet)` driven by a thin
`SettingsSheet` enum tag, with per-sheet payloads kept on separate
`@State` vars so non-`Equatable` CloudKit types don't block the
enum's `Hashable` synthesis. Lifecycle (clear payload + bump
section reload) flows through one `.onChange(of: presentedSheet)`.

`LocationsSection` lost its `@Binding var formMode` — the parent
is now the only writer of presentation state. The section takes a
`presentForm: (LocationFormView.Mode) -> Void` callback instead, and
observes a `reloadToken: Int` bumped by the parent after the form
sheet dismisses.

## Cold-cache empty list

Right after a fresh permission grant, `EKEventStore.calendars(for: .reminder)`
returns empty even when the user has iCloud-synced lists — sources
populate asynchronously. The user reported the picker showing zero
lists on first try, then all eight after re-tapping a few minutes later.

Fix in `EventKitRemindersService.availableLists`:

- Call `refreshSourcesIfNecessary()` (Apple's documented sync hook).
- Read calendars once. If empty, await the next
  `EKEventStoreChangedNotification` with a 10s hard cap, then re-read.
- The Settings row presents a spinner during the wait so the gap
  doesn't feel silent.

The notification race uses an `AsyncStream` wrapping a one-shot
block-based observer; `onTermination` removes the observer so neither
race branch can leak it.

## Test plan
- [ ] Install on TestFlight
- [ ] Settings → Pick a list → picker stays open and renders the user's lists (no auto-dismiss; no empty list on first try after permission grant)
- [ ] Settings → Add Location → form sheet stays open until saved or cancelled (regression check for build #52 + #162)
- [ ] Settings → Share Household → share controller presents successfully (regression check for #90)
- [ ] Console.app filter `subsystem:cc.mnmlst.nakedpantree category:reminders` shows `availableLists` post-wait calendars.count > 0 on cold-cache path

🤖 Generated with [Claude Code](https://claude.com/claude-code)