### PR TITLE
Tidy Reminders item notes — location only, sentinel last

### DIFF
--- a/Packages/Core/Sources/NakedPantreeDomain/RemindersReconciler.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/RemindersReconciler.swift
@@ -23,8 +23,9 @@ import Foundation
 ///   crossed it off; we don't resurrect it. (If the flag stays true,
 ///   the user can clear-and-reflag in the app to push a fresh copy.)
 /// - No existing reminder → queue a `Create` with title = item.name,
-///   notes = `[NP-ID:<UUID>]\n<qty> <unit> — <location>`, url =
-///   `nakedpantree://item/<UUID>`.
+///   notes = `<location>\n\n[NP-ID:<UUID>]` (location-only body
+///   above a blank-line-separated parser anchor; sentinel-only when
+///   no location resolves), url = `nakedpantree://item/<UUID>`.
 ///
 /// For each existing reminder whose `nakedPantreeID` resolves to an
 /// `Item.id` that's **not** on the current Needs Restocking list (the
@@ -137,26 +138,41 @@ public enum RemindersReconciler {
     /// tests can pin the payload shape (title / notes / url) directly,
     /// and so the adapter can reuse the encoder when the reconciler
     /// queues a create.
+    ///
+    /// **Notes shape (revisited).** Earlier the body led with quantity
+    /// + unit + location (`"1 — Old Garage Pantry"`) and the sentinel
+    /// went *first*, before the body. A user looking at the reminder
+    /// in Apple's Reminders.app saw the `[NP-ID:UUID]` line as the
+    /// primary content with a confusing `"1 — Old Garage Pantry"`
+    /// underneath — quantity in our domain means "how many I have,"
+    /// which has no useful interpretation as a shopping-list line.
+    ///
+    /// The current shape:
+    /// - body = the location name only, when one resolves
+    /// - sentinel goes at the *end* of the notes after a blank line
+    /// - sentinel-only notes when no location resolves
+    ///
+    /// The sentinel STRING (`[NP-ID:<UUID>]`) is unchanged — it's the
+    /// notes-fallback parser anchor and changing it would orphan
+    /// already-pushed reminders. Only its placement moves.
+    ///
+    /// `unitFormatter` is retained as a parameter for source/test
+    /// compatibility, but the new body doesn't reference units; tests
+    /// can drop their formatter argument or keep passing the default.
     public static func payload(
         for item: Item,
         locationsByID: [Location.ID: Location],
         unitFormatter: @Sendable (Unit) -> String = defaultUnitFormatter
     ) -> ReminderPayload {
+        _ = unitFormatter  // retained for API compatibility; see doc.
         let locationName = locationsByID[item.locationID]?.name
-        let body = notesBody(
-            for: item,
-            locationName: locationName,
-            unitFormatter: unitFormatter
-        )
+        let body = notesBody(locationName: locationName)
         let sentinel = ReminderTag.notesSentinel(for: item.id)
-        // Sentinel on its own line, then a blank line, then the user-
-        // facing body. Preserves the user's ability to edit the body
-        // without nuking the parser anchor.
         let notes: String
         if body.isEmpty {
             notes = sentinel
         } else {
-            notes = "\(sentinel)\n\(body)"
+            notes = "\(body)\n\n\(sentinel)"
         }
         return ReminderPayload(
             title: item.name,
@@ -166,29 +182,12 @@ public enum RemindersReconciler {
         )
     }
 
-    /// User-friendly notes body — `"<qty> <unit> — <locationName>"`.
-    /// Drops segments that would render as empty so we never write
-    /// `"0  — Kitchen"` or `"3 ct — "`. If everything's empty (an
-    /// untyped `.count` unit with no location lookup) the body is `""`
-    /// and the caller emits sentinel-only notes.
-    private static func notesBody(
-        for item: Item,
-        locationName: String?,
-        unitFormatter: @Sendable (Unit) -> String
-    ) -> String {
-        let unitLabel = unitFormatter(item.unit)
-        let quantityAndUnit: String
-        if unitLabel.isEmpty {
-            quantityAndUnit = "\(item.quantity)"
-        } else {
-            quantityAndUnit = "\(item.quantity) \(unitLabel)"
-        }
-        let trimmedLocation =
-            locationName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if trimmedLocation.isEmpty {
-            return quantityAndUnit
-        }
-        return "\(quantityAndUnit) — \(trimmedLocation)"
+    /// User-facing notes body — currently the trimmed location name,
+    /// or `""` when no location resolves. Centralised so the format
+    /// can be changed in one place without the test surface drifting
+    /// out of sync.
+    private static func notesBody(locationName: String?) -> String {
+        locationName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 }
 

--- a/Packages/Core/Tests/NakedPantreeDomainTests/RemindersReconcilerTests.swift
+++ b/Packages/Core/Tests/NakedPantreeDomainTests/RemindersReconcilerTests.swift
@@ -93,10 +93,15 @@ struct RemindersReconcilerTests {
         #expect(payload.title == "Sourdough")
         #expect(payload.nakedPantreeID == item.id)
         #expect(payload.url == ReminderTag.url(for: item.id))
-        // Notes contain the sentinel and the user-friendly body.
+        // Notes contain the sentinel and the user-facing body
+        // (location-only, post-format-revisit).
         #expect(payload.notes.contains(ReminderTag.notesSentinel(for: item.id)))
         #expect(payload.notes.contains("Kitchen Pantry"))
-        #expect(payload.notes.contains("2"))
+        // Quantity must NOT leak into the notes — earlier we wrote
+        // "1 — Kitchen Pantry" and that read as confusing on the
+        // device. The body is the location only.
+        #expect(!payload.notes.contains(" — Kitchen Pantry"))
+        #expect(!payload.notes.contains("2 ct"))
     }
 
     @Test("Multiple creates are sorted by title for determinism")
@@ -111,32 +116,29 @@ struct RemindersReconcilerTests {
         #expect(plan.creates.map(\.payload.title) == ["Apple", "Zebra"])
     }
 
-    @Test("Unit .count omits the empty label so notes don't read '2  — Kitchen'")
-    func notesOmitEmptyUnitLabel() {
+    @Test("Notes are formatted as 'location\\n\\nsentinel' when location resolves")
+    func notesPlaceLocationFirstAndSentinelLast() {
         let item = Self.makeItem(name: "Apples", quantity: 2, unit: .count)
         let payload = RemindersReconciler.payload(
             for: item,
             locationsByID: Self.locationsByID
         )
-        // Should be "[NP-ID:UUID]\n2 — Kitchen Pantry", not "2  — ...".
-        #expect(payload.notes.contains("2 — Kitchen Pantry"))
-        #expect(!payload.notes.contains("2  —"))
+        let sentinel = ReminderTag.notesSentinel(for: item.id)
+        let expected = "Kitchen Pantry\n\n\(sentinel)"
+        #expect(payload.notes == expected)
     }
 
-    @Test("Missing location resolves to body without the location segment")
-    func notesOmitMissingLocation() {
+    @Test("Missing location resolves to sentinel-only notes")
+    func notesAreSentinelOnlyWithoutLocation() {
         let item = Self.makeItem(name: "Mystery", quantity: 1, unit: .count)
         let payload = RemindersReconciler.payload(
             for: item,
             // Empty lookup — location id won't resolve.
             locationsByID: [:]
         )
-        let stripped = payload.notes.replacingOccurrences(
-            of: ReminderTag.notesSentinel(for: item.id),
-            with: ""
-        )
-        let body = stripped.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        #expect(body == "1")
+        // Sentinel-only — no leading body, no trailing whitespace
+        // around it.
+        #expect(payload.notes == ReminderTag.notesSentinel(for: item.id))
     }
 
     // MARK: Leave / title-update branch


### PR DESCRIPTION
A user-installed TestFlight build of the #155 reminders push showed
the rendered reminder item with the `[NP-ID:UUID]` sentinel as the
first line of notes, followed by `1 — Old Garage Pantry`. The "1"
was the item's quantity — meaningless in a shopping-list context
where quantity in our domain means "how many I have," not "how
many to buy." The sentinel above the body read as ID noise.

## Before / after

Before:
```
[NP-ID:E1EB1499-4004-4364-903F-2C64FE069F42]
1 — Old Garage Pantry
```

After:
```
Old Garage Pantry

[NP-ID:E1EB1499-4004-4364-903F-2C64FE069F42]
```

When the location can't be resolved, notes are sentinel-only.

## Compatibility

- Sentinel string (`[NP-ID:<UUID>]`) is unchanged. The notes-fallback
  parser anchor still matches; reminders pushed before this change
  resolve correctly via URL primary, sentinel fallback.
- Existing reminders keep their old format until they're rewritten
  for some other reason (rename, etc.) — that's acceptable cosmetic
  carryover, not a correctness bug.
- `unitFormatter` parameter on `RemindersReconciler.payload` retained
  for source compatibility; the new body doesn't reference units.

## Test plan

- [x] `swift test` for Core: 42/42 pass
- [x] Reconciler tests assert exact notes shape (`"<location>\n\n<sentinel>"`)
      and sentinel-only fallback
- [ ] Install TestFlight build → push to Reminders → tap a reminder → notes read
      `Old Garage Pantry` first, sentinel underneath

🤖 Generated with [Claude Code](https://claude.com/claude-code)