### PR TITLE
Register nakedpantree:// URL scheme + handle deep links

### DIFF
--- a/NakedPantreeApp/Features/Root/RootView.swift
+++ b/NakedPantreeApp/Features/Root/RootView.swift
@@ -114,6 +114,20 @@ struct RootView: View {
                 await applyDeepLink(itemID: id)
             }
         }
+        // Issue #155 follow-up: a tap on a pushed reminder's URL
+        // chip in Apple's Reminders.app delivers
+        // `nakedpantree://item/<UUID>` here. Funnel into
+        // `notificationRouting.pendingItemID` so cold-launch (URL
+        // arrives during `.loading` and gets buffered by SwiftUI
+        // until this view appears) and warm-tap (app already
+        // running) both flow through the same `applyDeepLink` path
+        // wired above. URLs that don't match our shape silently
+        // drop — `ReminderTag.itemID(fromURL:)` returns nil for
+        // hand-typed `https://` and similar.
+        .onOpenURL { url in
+            guard let itemID = ReminderTag.itemID(fromURL: url) else { return }
+            notificationRouting.pendingItemID = itemID
+        }
         .alert("That item is gone.", isPresented: $isShowingMissingItemAlert) {
             Button("OK", role: .cancel) {}
         }

--- a/NakedPantreeApp/Notifications/NotificationRoutingService.swift
+++ b/NakedPantreeApp/Notifications/NotificationRoutingService.swift
@@ -18,8 +18,8 @@ func notificationItemID(from userInfo: [AnyHashable: Any]) -> Item.ID? {
     return UUID(uuidString: raw)
 }
 
-/// Bridges notification taps from the `UIApplicationDelegate` layer to
-/// the `RootView` navigation state.
+/// Bridges notification taps and URL deep-links from the system layer
+/// to the `RootView` navigation state.
 ///
 /// Tap handling can't live directly in the view layer:
 /// `UNUserNotificationCenter.delegate` must be assigned **before**
@@ -30,13 +30,24 @@ func notificationItemID(from userInfo: [AnyHashable: Any]) -> Item.ID? {
 /// bootstrap completes (cold-launch path) before clearing it back to
 /// nil.
 ///
+/// **Dual-purpose (#155 follow-up).** The same channel also carries
+/// item ids parsed from `nakedpantree://item/<UUID>` deep-links — a
+/// tap on a pushed reminder's URL chip in Apple's Reminders.app
+/// drops the URL into `RootView.onOpenURL`, which forwards the
+/// resolved `Item.ID` here. Sharing the channel keeps the
+/// bootstrap-aware cold/warm-tap dance to a single code path; the
+/// publisher source doesn't matter once the id has been parsed. If
+/// future surfaces need to distinguish the source (e.g. for
+/// analytics) they can layer on top, not here.
+///
 /// Same architectural placement as `RemoteChangeMonitor` /
 /// `NotificationScheduler`: app layer, not behind a Domain protocol.
 /// `UNUserNotificationCenter` is iOS-specific.
 @Observable
 @MainActor
 final class NotificationRoutingService {
-    /// Set by the notification delegate when the user taps a banner.
+    /// Set by the notification delegate (banner tap) or by
+    /// `RootView.onOpenURL` (deep-link tap from Reminders.app, etc.).
     /// `RootView` resolves the item, navigates, then clears this back
     /// to nil. Cleared value avoids re-routing on subsequent unrelated
     /// changeToken bumps.

--- a/NakedPantreeApp/Resources/Info.plist
+++ b/NakedPantreeApp/Resources/Info.plist
@@ -51,6 +51,35 @@
     <string>Take photos of items in your pantry so you can spot them at a glance.</string>
     <key>NSRemindersFullAccessUsageDescription</key>
     <string>So Naked Pantree can drop your restock list into Reminders when you ask.</string>
+    <!--
+        Issue #155 follow-up — register `nakedpantree://` so the URL we
+        attach to each pushed reminder (`nakedpantree://item/<UUID>`)
+        becomes a tappable chip in Apple's Reminders.app. Without
+        registering, Reminders treats the URL field as something it
+        doesn't know how to open and renders it blank — the user sees
+        an empty URL row even though the data is there.
+
+        `CFBundleURLName` uses reverse-DNS to namespace the scheme to
+        this app, matching `cc.mnmlst.nakedpantree`. The single scheme
+        entry is enough; we don't anticipate a second app claiming
+        `nakedpantree://` so the array stays one-deep.
+
+        The actual route handling lives in `RootView.onOpenURL` —
+        parse the URL via `ReminderTag.itemID(fromURL:)`, publish to
+        the existing notification-routing channel, and re-use the
+        bootstrap-aware deep-link path.
+    -->
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>cc.mnmlst.nakedpantree.deeplink</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>nakedpantree</string>
+            </array>
+        </dict>
+    </array>
     <key>UIApplicationSceneManifest</key>
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
The URL field on each pushed reminder rendered blank in Apple's
Reminders.app even though the reconciler was writing
`nakedpantree://item/<UUID>` to it. Without the scheme registered,
iOS doesn't know which app owns the URL and treats the row as
inactionable.

## What changes

1. **Register `nakedpantree://`** in `Info.plist` via
   `CFBundleURLTypes`. With the scheme registered, Reminders.app
   renders the URL row as a tappable chip and tapping launches us.
2. **Handle the URL in `RootView`** via `.onOpenURL`. Parses the URL
   through `ReminderTag.itemID(fromURL:)` and forwards the resolved
   `Item.ID` into `notificationRouting.pendingItemID`. The existing
   bootstrap-aware cold-launch / warm-tap path for notification
   taps re-applies — we don't carry two parallel deep-link paths.
3. **Update `NotificationRoutingService`'s type doc** to flag the
   dual-purpose channel.

URLs that don't match the shape silently drop —
`ReminderTag.itemID(fromURL:)` returns nil for anything that isn't
`nakedpantree://item/<UUID>`.

## Test plan

- [ ] Install on TestFlight
- [ ] Push a fresh batch of reminders (or open an already-pushed one)
- [ ] Tap into the reminder's details → URL row now reads
      `nakedpantree://item/<UUID>` as a tappable chip
- [ ] Tap the chip → app launches and lands on the corresponding item

🤖 Generated with [Claude Code](https://claude.com/claude-code)