### PR TITLE
Embed deep-link URL inline in reminder notes (#155 follow-up)

### DIFF
--- a/Packages/Core/Sources/NakedPantreeDomain/RemindersReconciler.swift
+++ b/Packages/Core/Sources/NakedPantreeDomain/RemindersReconciler.swift
@@ -139,26 +139,46 @@ public enum RemindersReconciler {
     /// and so the adapter can reuse the encoder when the reconciler
     /// queues a create.
     ///
-    /// **Notes shape (revisited).** Earlier the body led with quantity
-    /// + unit + location (`"1 — Old Garage Pantry"`) and the sentinel
-    /// went *first*, before the body. A user looking at the reminder
-    /// in Apple's Reminders.app saw the `[NP-ID:UUID]` line as the
-    /// primary content with a confusing `"1 — Old Garage Pantry"`
-    /// underneath — quantity in our domain means "how many I have,"
-    /// which has no useful interpretation as a shopping-list line.
+    /// **Notes shape (revisited again — issue #155 follow-up).** A user
+    /// reported that the URL chip on the dedicated URL row of pushed
+    /// reminders renders blank in Apple's Reminders.app, even though
+    /// `EKReminder.url` is set on save (confirmed via `url-post-save`
+    /// log) and even though the `nakedpantree://` scheme is registered
+    /// (PR #168). A manually-pasted URL into the same field on a
+    /// hand-edited reminder *does* persist + render — proving the
+    /// field accepts the scheme, but our writes don't survive the
+    /// iCloud round-trip (or the chip render) for reasons we haven't
+    /// fully isolated.
+    ///
+    /// Workaround: embed the deep-link URL inline in the notes body.
+    /// Reminders.app auto-detects URLs anywhere in notes and renders
+    /// them as tappable chips inline — that path *does* persist for
+    /// our writes (notes are surviving the round-trip; the original
+    /// "Garage" body screenshot proved it). We still write
+    /// `EKReminder.url` too so the dedicated-row chip lights up the
+    /// day Apple/iCloud sorts out whatever's stripping it on our path.
     ///
     /// The current shape:
-    /// - body = the location name only, when one resolves
-    /// - sentinel goes at the *end* of the notes after a blank line
-    /// - sentinel-only notes when no location resolves
+    /// ```
+    /// <location>
     ///
-    /// The sentinel STRING (`[NP-ID:<UUID>]`) is unchanged — it's the
-    /// notes-fallback parser anchor and changing it would orphan
-    /// already-pushed reminders. Only its placement moves.
+    /// nakedpantree://item/<UUID>
+    ///
+    /// [NP-ID:<UUID>]
+    /// ```
+    /// - location body line drops if no location resolves
+    /// - URL line is always present (item.id is always known)
+    /// - sentinel always last for the parser anchor
+    /// - blank lines between sections so each renders as its own
+    ///   visual block
+    ///
+    /// The sentinel STRING (`[NP-ID:<UUID>]`) is unchanged — orphaning
+    /// already-pushed reminders by changing the anchor would force
+    /// duplicate creates. Same belt-and-suspenders rationale as before.
     ///
     /// `unitFormatter` is retained as a parameter for source/test
-    /// compatibility, but the new body doesn't reference units; tests
-    /// can drop their formatter argument or keep passing the default.
+    /// compatibility but isn't referenced — units don't make it into
+    /// the body.
     public static func payload(
         for item: Item,
         locationsByID: [Location.ID: Location],
@@ -166,14 +186,18 @@ public enum RemindersReconciler {
     ) -> ReminderPayload {
         _ = unitFormatter  // retained for API compatibility; see doc.
         let locationName = locationsByID[item.locationID]?.name
-        let body = notesBody(locationName: locationName)
+        let location = notesBody(locationName: locationName)
+        let deepLink = ReminderTag.url(for: item.id)?.absoluteString
         let sentinel = ReminderTag.notesSentinel(for: item.id)
-        let notes: String
-        if body.isEmpty {
-            notes = sentinel
-        } else {
-            notes = "\(body)\n\n\(sentinel)"
-        }
+        // Order: location (optional) → deep-link URL → sentinel. Each
+        // section separated by a blank line so Reminders.app treats
+        // them as distinct visual blocks.
+        let sections = [
+            location.isEmpty ? nil : location,
+            deepLink,
+            sentinel,
+        ].compactMap { $0 }
+        let notes = sections.joined(separator: "\n\n")
         return ReminderPayload(
             title: item.name,
             notes: notes,

--- a/Packages/Core/Tests/NakedPantreeDomainTests/RemindersReconcilerTests.swift
+++ b/Packages/Core/Tests/NakedPantreeDomainTests/RemindersReconcilerTests.swift
@@ -93,13 +93,18 @@ struct RemindersReconcilerTests {
         #expect(payload.title == "Sourdough")
         #expect(payload.nakedPantreeID == item.id)
         #expect(payload.url == ReminderTag.url(for: item.id))
-        // Notes contain the sentinel and the user-facing body
-        // (location-only, post-format-revisit).
+        // Notes contain the sentinel, the location, and the deep-link
+        // URL (auto-linked by Reminders.app — the dedicated URL row
+        // doesn't render the chip for our writes; #155 follow-up).
         #expect(payload.notes.contains(ReminderTag.notesSentinel(for: item.id)))
         #expect(payload.notes.contains("Kitchen Pantry"))
+        let expectedURL = ReminderTag.url(for: item.id)?.absoluteString ?? ""
+        #expect(!expectedURL.isEmpty)
+        #expect(payload.notes.contains(expectedURL))
         // Quantity must NOT leak into the notes — earlier we wrote
         // "1 — Kitchen Pantry" and that read as confusing on the
-        // device. The body is the location only.
+        // device. The body is the location only (plus the deep-link
+        // line and sentinel).
         #expect(!payload.notes.contains(" — Kitchen Pantry"))
         #expect(!payload.notes.contains("2 ct"))
     }
@@ -116,29 +121,34 @@ struct RemindersReconcilerTests {
         #expect(plan.creates.map(\.payload.title) == ["Apple", "Zebra"])
     }
 
-    @Test("Notes are formatted as 'location\\n\\nsentinel' when location resolves")
-    func notesPlaceLocationFirstAndSentinelLast() {
+    @Test("Notes are formatted as 'location\\n\\nurl\\n\\nsentinel' when location resolves")
+    func notesArrangeLocationDeepLinkSentinel() {
         let item = Self.makeItem(name: "Apples", quantity: 2, unit: .count)
         let payload = RemindersReconciler.payload(
             for: item,
             locationsByID: Self.locationsByID
         )
         let sentinel = ReminderTag.notesSentinel(for: item.id)
-        let expected = "Kitchen Pantry\n\n\(sentinel)"
+        let url = ReminderTag.url(for: item.id)?.absoluteString ?? ""
+        let expected = "Kitchen Pantry\n\n\(url)\n\n\(sentinel)"
         #expect(payload.notes == expected)
     }
 
-    @Test("Missing location resolves to sentinel-only notes")
-    func notesAreSentinelOnlyWithoutLocation() {
+    @Test("Missing location resolves to 'url\\n\\nsentinel' notes")
+    func notesAreDeepLinkAndSentinelWithoutLocation() {
         let item = Self.makeItem(name: "Mystery", quantity: 1, unit: .count)
         let payload = RemindersReconciler.payload(
             for: item,
             // Empty lookup — location id won't resolve.
             locationsByID: [:]
         )
-        // Sentinel-only — no leading body, no trailing whitespace
-        // around it.
-        #expect(payload.notes == ReminderTag.notesSentinel(for: item.id))
+        // No leading location body, but the deep-link line + sentinel
+        // are still present so Reminders.app autolinks the URL inline
+        // and the notes-fallback parser still finds the anchor.
+        let sentinel = ReminderTag.notesSentinel(for: item.id)
+        let url = ReminderTag.url(for: item.id)?.absoluteString ?? ""
+        let expected = "\(url)\n\n\(sentinel)"
+        #expect(payload.notes == expected)
     }
 
     // MARK: Leave / title-update branch


### PR DESCRIPTION
The dedicated URL row on pushed reminders renders blank in Apple's
Reminders.app, even though we set `EKReminder.url` and the
`nakedpantree://` scheme is registered. A manually-pasted URL on a
hand-edited reminder *does* persist + render in the same field —
proving the field accepts the scheme. Our writes silently disappear
on the round-trip (PR #169's diag confirmed `url-post-save` is set;
later fetches see `<nil>` for our reminders, but the manual-paste
one shows the URL).

The cleanest immediately-shippable fix: embed the deep-link URL
inline in the notes body. Notes auto-link in Reminders.app, become
tappable chips, and — critically — notes survive the round-trip for
our writes (the location body has been rendering correctly for
weeks). The dedicated URL row stays written too, in case Apple/iCloud
ever sorts out whatever's stripping it on our path.

## Before / after

Before:
```
Garage

[NP-ID:UUID]
```
URL row: empty (silently dropped)

After:
```
Garage

nakedpantree://item/UUID

[NP-ID:UUID]
```
URL row: still set (pending), URL chip in notes: tappable, opens app.

## Compatibility

- Sentinel string unchanged → notes-fallback resolver still matches
  reminders pushed under the prior format.
- `payload.url` still set → write-side stays the same; only notes
  shape changes.
- Existing reminders that were pushed before this PR don't get a
  notes update unless the reconciler queues an unrelated change for
  them. That's acceptable cosmetic carryover.

## Test plan
- [x] 15/15 reconciler tests pass; pin exact notes shape for both
      location-present and no-location branches
- [ ] Install on TestFlight
- [ ] Push reminders → tap one in Reminders.app → notes show
      `<location>` line, then `nakedpantree://item/UUID` (rendered
      as a tappable chip), then sentinel
- [ ] Tap the inline URL → app opens to the item

🤖 Generated with [Claude Code](https://claude.com/claude-code)