### PR TITLE
diag(sharing): log share state at prep + handoff + delegate callbacks

### DIFF
--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -45,6 +45,19 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
     )
 
     func makeUIViewController(context: Context) -> UICloudSharingController {
+        // Diag (post-#90 follow-up) — answer "what state is the share
+        // in at the moment we hand it to the system controller?" The
+        // Messages link-preview hang is most plausibly explained by
+        // `share.url` being nil here; the system controller would
+        // then hand a nil URL to the Messages share extension. Log
+        // the full state so the trace ends the speculation.
+        let urlString = share.url?.absoluteString ?? "<nil>"
+        let recordName = share.recordID.recordName
+        let participantCount = share.participants.count
+        Self.logger.notice(
+            // swiftlint:disable:next line_length
+            "makeUIViewController: share state url='\(urlString, privacy: .public)' recordName='\(recordName, privacy: .public)' participants.count=\(participantCount, privacy: .public)"
+        )
         Self.logger.notice(
             "makeUIViewController: creating UICloudSharingController(share:container:)"
         )
@@ -68,8 +81,14 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
             self.onCompletion = onCompletion
         }
 
+        nonisolated private static let logger = Logger(
+            subsystem: "cc.mnmlst.nakedpantree",
+            category: "sharing"
+        )
+
         func itemTitle(for csc: UICloudSharingController) -> String? {
-            "Naked Pantree"
+            Self.logger.notice("delegate.itemTitle requested")
+            return "Naked Pantree"
         }
 
         func cloudSharingController(
@@ -79,14 +98,25 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
             // `UICloudSharingController` shows its own alert for the
             // failure before dismissing; we just propagate the
             // dismissal up so the sheet binding clears.
+            Self.logger.error(
+                "delegate.failedToSaveShare: \(error.localizedDescription, privacy: .public)"
+            )
             onCompletion()
         }
 
         func cloudSharingControllerDidSaveShare(_ csc: UICloudSharingController) {
+            // Post-save the share's `url` should be populated by
+            // CloudKit. Log it so a trace from a successful invite +
+            // a hanging-Messages invite can be compared side by side.
+            let urlString = csc.share?.url?.absoluteString ?? "<nil>"
+            Self.logger.notice(
+                "delegate.didSaveShare: post-save url='\(urlString, privacy: .public)'"
+            )
             onCompletion()
         }
 
         func cloudSharingControllerDidStopSharing(_ csc: UICloudSharingController) {
+            Self.logger.notice("delegate.didStopSharing")
             onCompletion()
         }
     }

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
@@ -87,12 +87,15 @@ public final class CloudHouseholdSharingService: HouseholdSharingService, @unche
         // new-share branch; for the existing-share branch there's no
         // `share(_:to:)` result to extract from, so fall back to the
         // injected `cloudKitContainer`.
+        Self.logger.notice("checking for existing share")
         if let existing = try existingShare(matching: objectID) {
             Self.logger.notice("returning existing share")
             existing[CKShare.SystemFieldKey.title] = "Naked Pantree"
+            Self.logShareState(existing, label: "existing")
             Self.logger.notice("prepareShare complete")
             return (existing, cloudKitContainer)
         }
+        Self.logger.notice("no existing share found")
 
         Self.logger.notice("calling NSPersistentCloudKitContainer.share")
         // Resolve the object on the viewContext's main queue (Apple's
@@ -114,8 +117,38 @@ public final class CloudHouseholdSharingService: HouseholdSharingService, @unche
         Self.logger.notice("container.share returned a new CKShare")
         let (share, resolvedContainer) = result
         share[CKShare.SystemFieldKey.title] = "Naked Pantree"
+        Self.logShareState(share, label: "new")
         Self.logger.notice("prepareShare complete")
         return (share, resolvedContainer)
+    }
+
+    /// Diag (post-#90 follow-up). Logs the bits of CKShare state most
+    /// likely to explain the Messages-link-preview hang the user is
+    /// seeing: whether `share.url` has been populated by CloudKit yet,
+    /// how many participants the share has, and what role/acceptance
+    /// they're in. If `share.url` is nil at this point, that's the
+    /// smoking gun — `UICloudSharingController` will hand a nil/empty
+    /// URL to the Messages share extension and Messages's link-preview
+    /// fetch will fail or stall.
+    private static func logShareState(_ share: CKShare, label: String) {
+        let urlString = share.url?.absoluteString ?? "<nil>"
+        let recordName = share.recordID.recordName
+        let zoneName = share.recordID.zoneID.zoneName
+        let participantCount = share.participants.count
+        Self.logger.notice(
+            // swiftlint:disable:next line_length
+            "share(\(label, privacy: .public)) state: url='\(urlString, privacy: .public)' recordName='\(recordName, privacy: .public)' zone='\(zoneName, privacy: .public)' participants.count=\(participantCount, privacy: .public)"
+        )
+        for (index, participant) in share.participants.enumerated() {
+            // Identity is omitted — the lookupInfo can leak userRecordID
+            // / emailAddress; role + acceptance is enough to diagnose.
+            let role = participant.role.rawValue
+            let acceptance = participant.acceptanceStatus.rawValue
+            Self.logger.notice(
+                // swiftlint:disable:next line_length
+                "share(\(label, privacy: .public)) participant[\(index, privacy: .public)] role=\(role, privacy: .public) acceptance=\(acceptance, privacy: .public)"
+            )
+        }
     }
 
     /// Resolves the household domain id to its `NSManagedObjectID` on


### PR DESCRIPTION
**Diagnostic-only.** No behaviour change.

User reports Share Household → Messages hangs forever on the
link-preview spinner. The trace they sent shows our existing logs
through `prepareShare start` + `got household objectID`, then nothing
from our code until the CloudSharingUI scene activates 78 ms later
— every notice log inside `prepareShare` (the existing-share branch,
the new-share branch, the `prepareShare complete` line) and
`makeUIViewController` is absent. Either os_log dropped them under
load or something genuinely bypasses them. Either way, we can't
currently distinguish:

- (a) `share.url` is nil when handed to the system controller
      (CloudKit propagation lag, or the share isn't fully saved) →
      Messages tries to preview a nil URL → spinner hangs.
- (b) `share.url` is set, but Messages's `LPMetadataProvider`
      can't fetch metadata for the iCloud share URL.

This PR adds the logs that answer (a) vs (b):

- Bracket `existingShare(matching:)` with `checking for existing
  share` / `no existing share found`.
- After resolution (existing branch + new branch), log
  `share.url`, `share.recordID.recordName`, `share.recordID.zoneID.zoneName`,
  `share.participants.count`, and per-participant role +
  acceptanceStatus.
- Same state log inside `CloudSharingControllerView.makeUIViewController`
  at handoff to the system controller.
- Delegate callbacks (`itemTitle`, `didSaveShare`, `failedToSaveShare`,
  `didStopSharing`) log entry + the post-save URL.

All under existing channel:
```
subsystem:cc.mnmlst.nakedpantree category:sharing
```

## Test plan

- [ ] Install on TestFlight
- [ ] Open Settings → tap Share Household → tap Messages
- [ ] Wait at least 30 s on the spinner before exporting the trace —
      we need the *during-hang* events, not just the run-up.
- [ ] Broaden the Console filter to capture system processes too:
      `subsystem:cc.mnmlst.nakedpantree OR subsystem:com.apple.cloudkit OR subsystem:com.apple.linkpresentation OR process:nsurlsessiond OR process:cloudd`

Reading the trace:
- `share(<branch>) state: url='<nil>'` → branch (a). Fix: poll/wait
  for `share.url` to populate, or save the share via
  `CKModifyRecordsOperation` before handing to the controller.
- `share(<branch>) state: url='https://www.icloud.com/share/...'`
  + during the hang the system trace shows
  `linkpresentation`/`nsurlsessiond` retries against `icloud.com` →
  branch (b). That's outside our process; fix path is to bypass
  `UICloudSharingController` and use a custom share-URL flow
  (`UIActivityViewController` with the URL directly, or
  `ShareLink` + `CKShareTransferRepresentation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)