### PR TITLE
diag(sharing): print() fallback alongside Logger.notice

### DIFF
--- a/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
+++ b/NakedPantreeApp/Sharing/CloudSharingControllerView.swift
@@ -54,6 +54,14 @@ struct CloudSharingControllerView: UIViewControllerRepresentable {
         let urlString = share.url?.absoluteString ?? "<nil>"
         let recordName = share.recordID.recordName
         let participantCount = share.participants.count
+        // print() fallback — the prior two share traces had our
+        // Logger.notice entries silently dropping in this exact window
+        // (between prepareShare and Messages activation). stderr
+        // survives os_log batching / Console de-dup, so we get a hard
+        // answer to "did UICloudSharingController see a populated URL?"
+        print(
+            "[NP-MAKEVC] url=\(urlString) recordName=\(recordName) participants=\(participantCount)"
+        )
         Self.logger.notice(
             // swiftlint:disable:next line_length
             "makeUIViewController: share state url='\(urlString, privacy: .public)' recordName='\(recordName, privacy: .public)' participants.count=\(participantCount, privacy: .public)"

--- a/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
+++ b/Packages/Core/Sources/NakedPantreePersistence/CloudHouseholdSharingService.swift
@@ -93,6 +93,16 @@ public final class CloudHouseholdSharingService: HouseholdSharingService, @unche
             existing[CKShare.SystemFieldKey.title] = "Naked Pantree"
             Self.logShareState(existing, label: "existing")
             Self.logger.notice("prepareShare complete")
+            // print() fallback alongside Logger.notice — the previous two
+            // share traces showed our os_log entries silently dropping in
+            // the critical window between `prepareShare` and Messages
+            // activation. stderr survives os_log batching / Console.app
+            // de-dup, so this gives a hard answer to "what URL did our
+            // code actually see?" before we commit to a fix path.
+            print(
+                // swiftlint:disable:next line_length
+                "[NP-PREP] existing share: url=\(existing.url?.absoluteString ?? "nil") participants=\(existing.participants.count)"
+            )
             return (existing, cloudKitContainer)
         }
         Self.logger.notice("no existing share found")
@@ -119,6 +129,12 @@ public final class CloudHouseholdSharingService: HouseholdSharingService, @unche
         share[CKShare.SystemFieldKey.title] = "Naked Pantree"
         Self.logShareState(share, label: "new")
         Self.logger.notice("prepareShare complete")
+        // See comment on the existing-share branch above for why we're
+        // belt-and-bracing with print() here.
+        print(
+            // swiftlint:disable:next line_length
+            "[NP-PREP] new share: url=\(share.url?.absoluteString ?? "nil") participants=\(share.participants.count)"
+        )
         return (share, resolvedContainer)
     }
 


### PR DESCRIPTION
## Summary

- Third (and final) diagnostic iteration on the Messages link-preview hang. PR #171 added `Logger.notice` calls bracketing `prepareShare` and `makeUIViewController`, but in two consecutive share traces the entries between handoff and Messages activation silently dropped — leaving us without direct evidence of `share.url` at the critical moment.
- Adds `print()` lines at each `prepareShare` return (`[NP-PREP]`) and at the top of `CloudSharingControllerView.makeUIViewController` (`[NP-MAKEVC]`), each emitting `share.url` and `participants.count`. stderr survives `os_log` batching / Console.app de-dup, so this captures the data even if the unified-log entries continue to ghost.
- No production behaviour change — only adds two `print()` calls behind the existing `Logger.notice` calls.

## Why a separate, last diagnostic instead of jumping to a fix

Per advisor: we have two strong system signals (`No metadata to load: <private>` during share-sheet prep; empty `types:()` list when Messages becomes the activity) but no direct read of `share.url` from our own code path. Shipping `CKModifyRecordsOperation` to pre-save the share — or rewriting around `ShareLink` / Universal Links — without that read would be guessing. Same anti-pattern that bit #162 (`store.reset()`) and #168 (URL scheme registration) where the wrong root cause shipped first.

## Test plan

- [ ] Merge to main, install via TestFlight (or local run)
- [ ] Open Settings → Share Household → tap Messages
- [ ] Capture trace from Console.app **and** `xcrun simctl spawn booted log stream` (the latter catches stderr `print()` output the unified log misses)
- [ ] Look for `[NP-PREP]` and `[NP-MAKEVC]` lines and read `url=…`
- [ ] Decision tree:
  - `url=nil` at handoff → fix is `CKModifyRecordsOperation` to persist before presenting
  - `url=nakedpantree…` valid → fix is in activity-item plumbing, not URL resolution
  - print lines also missing → code path is different than expected; investigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)